### PR TITLE
Removed typesetting artifacts

### DIFF
--- a/SoftwareUpdateDom0.md
+++ b/SoftwareUpdateDom0.md
@@ -35,15 +35,11 @@ Of course, command line tools are still available for accomplishing various upda
 
 1.  To check and install updates for dom0 software:
 
-    {% highlight trac-wiki %}
     $ sudo qubes-dom0-update
-    {% endhighlight %}
 
 1.  To install additional packages in dom0 (usually not recommended):
 
-    {% highlight trac-wiki %}
     $ sudo qubes-dom0-update anti-evil-maid
-    {% endhighlight %}
 
     You may also pass the `--enablerepo=` option in order to enable optional repositories (see yum configuration in dom0). However, this is only for advanced users who really understand what they are doing.
 
@@ -51,16 +47,10 @@ Of course, command line tools are still available for accomplishing various upda
 
 1.  Download an older version of the package:
 
-    {% highlight trac-wiki %}
     sudo qubes-dom0-update package-version
-    {% endhighlight %}
 
     Yum will say that there is no update, but the package will nonetheless be downloaded to dom0.
 
 1.  Downgrade the packge:
 
-    {% highlight trac-wiki %}
     sudo yum downgrade package-version
-    {% endhighlight %}
-
-


### PR DESCRIPTION
Probably from the old wiki, these shell command typesetting statements are no longer needed (as they have been replaced by simple indentation) and are registered as plaintext by markdown.