### PR TITLE
Mention Fedora 21 update proxy problem on upgrade instructions

### DIFF
--- a/FedoraTemplateUpgrade20.md
+++ b/FedoraTemplateUpgrade20.md
@@ -214,3 +214,8 @@ list which also apply to TemplateVM management and migration in general:
 
  * [Marek](https://groups.google.com/d/msg/qubes-users/mCXkxlACILQ/dS1jbLRP9n8J)
  * [Jason M](https://groups.google.com/d/msg/qubes-users/mCXkxlACILQ/5PxDfI-RKAsJ)
+
+Known issues with Fedora 21
+===========================
+
+* [The "Update VM" command in Qubes Manager does not work](https://github.com/QubesOS/qubes-issues/issues/982).


### PR DESCRIPTION
This isn't the ideal place for known issues with Fedora 21 that aren't specific to upgrading from Fedora 20, but it's one place I would have seen the information.