### PR TITLE
Fixed link-rot to Virtcs paper

### DIFF
--- a/QubesResearch.md
+++ b/QubesResearch.md
@@ -23,7 +23,7 @@ Here are some links to various papers/research projects that somehow relate to Q
 
 ### Application-level security
 
--   [Virtics: A System for Privilege Separation of Legacy Desktop Applications](http://radlab.cs.berkeley.edu/wiki/Virtics) by Matt Piotrowski
+-   [Virtics: A System for Privilege Separation of Legacy Desktop Applications](http://bnrg.cs.berkeley.edu/~adj/publications/paper-files/EECS-2010-70.pdf) by Matt Piotrowski
     (We plan to implement some ideas from Matt's thesis in Qubes very soon -- stay tuned for details)
 
 ### VMM/Xen disagregation


### PR DESCRIPTION
The old link pointed to some home page for the project that is now blank.