### PR TITLE
recommend to check if Split GPG is installed

### DIFF
--- a/security/split-gpg.md
+++ b/security/split-gpg.md
@@ -78,6 +78,20 @@ between Split GPG and PGP/MIME.
 
 Configuring and using Split GPG
 -------------------------------
+
+In dom0, make sure the `qubes-gpg-split-dom0` package is installed.
+
+    sudo qubes-dom0-update qubes-gpg-split-dom0
+    
+If using templates based on Debian, make sure you have the `qubes-gpg-split`
+package installed.
+
+    sudo apt-get install qubes-gpg-split
+    
+For Fedora.
+
+    sudo yum install qubes-gpg-split
+
 Start with creating a dedicated AppVM for storing your keys (the GPG backend
 domain). It is recommended that this domain be network disconnected (set its
 netvm to `none`) and only used for this one purpose. In later examples this


### PR DESCRIPTION
Do you know if Split GPG does now get installed by default in dom0 and all templates (except the minimal ones)?

It wasn't installed on my Qubes installation (which was initially a Qubes R2). Not having it installed by default leads to strange issues that took me some time to debug. Missing Split GPG in dom0 will lead to "qrexec policy missing" (don't remember the exact wording, but you probably now what I mean). And not having it installed in the gpg backend VM will lead to `qubes-gpg-client` just outputting `EOF`.

Therefore please consider this pull request that recommend to check if Split GPG is actually installed.