### PR TITLE
Correction in faq about reassigning PCI device to dom0

### DIFF
--- a/basics/user-faq.md
+++ b/basics/user-faq.md
@@ -236,4 +236,4 @@ or
         echo 0000:<BDF> > /sys/bus/pci/drivers/pciback/unbind
         MODALIAS=`cat /sys/bus/pci/devices/0000:<BDF>/modalias`
         MOD=`modprobe -R $MODALIAS | head -n 1`
-        echo <BDF> > /sys/bus/pci/drivers/$MOD/bind
+        echo 0000:<BDF> > /sys/bus/pci/drivers/$MOD/bind


### PR DESCRIPTION
This command need the full device ID to work

This fix is proposed about the issue:
https://groups.google.com/forum/#!searchin/qubes-users/readlink/qubes-users/LqhHWJ6GZZU/r0Jf27WIDQAJ