### PR TITLE
Fix link to disposable VM customization

### DIFF
--- a/common-tasks/dispvm.md
+++ b/common-tasks/dispvm.md
@@ -74,7 +74,7 @@ Customizing Disposable VMs
 ---------------------------------------------------------
 
 You can change the template used to generate the Disposable VM, and change settings used in the Disposable VM savefile. These changes will be reflected in every new Disposable VM.
-Full instructions are [here](/doc/disp-vm-customization/) 
+Full instructions are [here](/doc/dispvm-customization/) 
 
 
 Disposable VMs and Local Forensics


### PR DESCRIPTION
Fix the link to the disposable customization page (excess dash sign)