### PR TITLE
remove librem 15 section

### DIFF
--- a/hardware/certified-laptops.md
+++ b/hardware/certified-laptops.md
@@ -46,13 +46,6 @@ compatibility with Qubes:
 
        sudo qubes-dom0-update --enablerepo=qubes-dom0-unstable kernel
 
-Purism Librem 15
-----------------
-
-While it is also currently possible to order a Librem 15 with Qubes
-pre-installed, the Librem 15 is not yet officially certified. However, testing
-is underway, and we expect to be able to certify it soon.
-
 
 [System Requirements]: /doc/system-requirements/
 [Hardware Compatibility List]: /hcl/


### PR DESCRIPTION
we don't list laptops that aren't certified. 

anyone can sell a laptop with Qubes pre-installed on it. If we want to make a list of that then let's do that, maybe elsewhere.