### PR TITLE
Arch linux template building

### DIFF
--- a/managing-os/templates/archlinux.md
+++ b/managing-os/templates/archlinux.md
@@ -119,11 +119,11 @@ Main maintainer of this template is [Olivier Médoc](mailto:o_medoc@yahoo.fr).
    
     *In the future this should not be needed once a change is made to the 'setup' script.*
 
-    *   Edit the '**qubes-os-master.conf**' which is found in **/home/user/qubes-builder/example-configs**  Use the text editor of your choice.
+    *   Edit the '**qubes-os-r3.1.conf**' which is found in **/home/user/qubes-builder/example-configs**  Use the text editor of your choice.
     
         *   **$ cd /home/user/qubes-builder/example-config/**
     
-        *   **$ nano -W qubes-os-master.conf** or **$ gedit qubes-os-master.conf** or etc….
+        *   **$ nano -W qubes-os-r3.1.conf** or **$ gedit qubes-os-r3.1.conf** or etc….
 <br>
 <br>
 ![arch-template-06](/attachment/wiki/ArchlinuxTemplate/arch-template-06.png)
@@ -181,8 +181,14 @@ Main maintainer of this template is [Olivier Médoc](mailto:o_medoc@yahoo.fr).
 
         *   Screen "**Choose Repos To Use To Build Packages**"
 
-            *   Select 'marmarek/qubes- Unstable-Bleeding Edge for Development'
+            *   Select 'QubesOS/qubes- Stable - Default Repo'
             *   Select '**OK**' Press '**Enter**' 
+<br>
+<br>
+
+        *   Screen "**Build Template Only?**"
+
+            *   Select '**Yes**' Press '**Enter**' 
 <br>
 <br>
 ![arch-template-12](/attachment/wiki/ArchlinuxTemplate/arch-template-12.png)
@@ -204,19 +210,12 @@ Main maintainer of this template is [Olivier Médoc](mailto:o_medoc@yahoo.fr).
 <br>
 <br>
 
-        *   Screen '**Get Resources**' wants to download additional packages needed for the choosen plugin/s.
+        *   Screen '**Get sources**' wants to download additional packages needed for the choosen plugin/s.
         
-            *   Select '**OK**' Prss '**Enter**'
-            
-        *   Upon completion you will get choose '**OK**' to proceed to the next screen
-        
-            *   Press '**Enter**'
+            *   Select '**No**' Press '**Enter**'
 <br>
 <br>
 ![arch-template-14](/attachment/wiki/ArchlinuxTemplate/arch-template-14.png)
-<br>
-![arch-template-15](/attachment/wiki/ArchlinuxTemplate/arch-template-15.png)
-<br>
 <br>
 
         *   Screen '**Template Distribution Selection**' allows you to choose the actual template/s you wish to build.
@@ -236,6 +235,18 @@ Main maintainer of this template is [Olivier Médoc](mailto:o_medoc@yahoo.fr).
 <br>
 <br>
 ![arch-template-17](/attachment/wiki/ArchlinuxTemplate/arch-template-17.png)
+<br>
+<br>
+	*	Archlinux builder is not(yet?) in official Qubes release branch, so it has to be downloaded from different repository.
+
+			* Open file builder.conf with your favourite text editor and find section **"O V E R R I D E   B R A N C H"** (single space
+between letters) and add:
+
+    			*   **GIT_URL_builder_archlinux = $(GIT_BASEURL)/marmarek/qubes-builder-archlinux.git**
+
+<br>
+<br>
+![arch-template-17](/attachment/wiki/ArchlinuxTemplate/arch-template-17a.png)
 <br>
 <br>
 <br>


### PR DESCRIPTION
	update instructions for Qubes 3.1

Fix for: qubes-core-vchan-xen - missing in marmarek repo and required to build Qubes for 3.1.

Also *qubes-attachments* updated.