### PR TITLE
Remove ref to qubes-windows-tools in current repo

### DIFF
--- a/managing-os/windows-appvms.md
+++ b/managing-os/windows-appvms.md
@@ -38,13 +38,7 @@ Installing Qubes guest tools in Windows 7 VMs
 First, make sure that `qubes-windows-tools` is installed in your system:
 
 ~~~
-sudo qubes-dom0-update qubes-windows-tools
-~~~
-
-You can also install the package from testing repositories, where we usually publish new versions first:
-
-~~~
-qubes-dom0-update --enablerepo=qubes*testing qubes-windows-tools
+sudo qubes-dom0-update --enablerepo=qubes*testing qubes-windows-tools
 ~~~
 
 This package brings the ISO with Qubes Windows Tools that is passed to the VM when `--install-windows-tools` is specified for the `qvm-start` command. Please note that none of this software ever runs in Dom0 or any other part of the system except for the Windows AppVM in which it is to be installed.

--- a/managing-os/windows-appvms.md
+++ b/managing-os/windows-appvms.md
@@ -46,7 +46,6 @@ sudo qubes-dom0-update qubes-windows-tools
 You can also install the package from testing repositories, where we usually publish new versions first:
 
 ~~~
-qubes-dom0-update --enablerepo=qubes*testing qubes-windows-tools
 sudo qubes-dom0-update --enablerepo=qubes*testing qubes-windows-tools
 ~~~
 

--- a/managing-os/windows-appvms.md
+++ b/managing-os/windows-appvms.md
@@ -46,7 +46,7 @@ sudo qubes-dom0-update qubes-windows-tools
 You can also install the package from testing repositories, where we usually publish new versions first:
 
 ~~~
--qubes-dom0-update --enablerepo=qubes*testing qubes-windows-tools
+qubes-dom0-update --enablerepo=qubes*testing qubes-windows-tools
 sudo qubes-dom0-update --enablerepo=qubes*testing qubes-windows-tools
 ~~~
 

--- a/managing-os/windows-appvms.md
+++ b/managing-os/windows-appvms.md
@@ -38,6 +38,15 @@ Installing Qubes guest tools in Windows 7 VMs
 First, make sure that `qubes-windows-tools` is installed in your system:
 
 ~~~
+sudo qubes-dom0-update qubes-windows-tools
+~~~
+
+(If the above command does not work, it could be that the Qubes Tools are not in the stable repo yet. Try installing from the testing repo instead.)
+
+You can also install the package from testing repositories, where we usually publish new versions first:
+
+~~~
+-qubes-dom0-update --enablerepo=qubes*testing qubes-windows-tools
 sudo qubes-dom0-update --enablerepo=qubes*testing qubes-windows-tools
 ~~~
 


### PR DESCRIPTION
Hi,

qubes-windows-tools currently only exists in the dom0 current-testing repo.  According to the dom0 file /etc/yum.repos.d/qubes-dom0.repo, it seems this is by design.  If you would prefer to add the package to the current repo instead of this change, that is fine by me.  I just wanted to note this in the docs for the next person.

Best regards,
Ryan

`curl -s yum.qubes-os.org/r3.1/current/dom0/fc20/rpm | grep qubes-windows-tools`
returns nothing

However, current-testing does have it in there:
```
curl -s yum.qubes-os.org/r3.1/current-testing/dom0/fc20/rpm | grep qubes-windows-tools
<li><a href="qubes-windows-tools-3.0.3-1.x86_64.rpm"> qubes-windows-tools-3.0.3-1.x86_64.rpm</a></li>
<li><a href="qubes-windows-tools-3.0.4-1.x86_64.rpm"> qubes-windows-tools-3.0.4-1.x86_64.rpm</a></li>
```