### PR TITLE
Add page on installing and configuring i3wm

### DIFF
--- a/customization/i3.md
+++ b/customization/i3.md
@@ -1,0 +1,104 @@
+---
+layout: doc
+title: i3
+permalink: /doc/i3/
+redirect_from:
+- /en/doc/i3/
+- /doc/i3/
+- "/doc/UserDoc/i3/"
+- "/wiki/UserDoc/i3/"
+---
+
+i3 installation in dom0
+========================
+
+Note that all of the work in this document is done in a Fedora based domU (could
+be dispvm). The end result is always a .rpm that is copied to dom0 and then
+installed through the package manager.
+
+Getting the code
+----------------
+
+Clone the i3-qubes repository here:
+
+    $ git clone https://github.com/SietsevanderMolen/i3-qubes.git
+
+In this case, the most interesting file is probably
+`i3/0001-Show-qubes-domain-in-non-optional-colored-borders.patch` It's the patch
+with changes that are necessary to make i3 work nicely with Qubes OS. The code
+should not need much explanation, it just gets the vmname and label from Qubes
+OS and changes some defaults so the user can't override decisions.
+
+If you want to make any changes to the package, this is the time and place to do
+it.
+
+Building
+--------
+
+You'll need to install the build dependencies, which are listed in
+build-deps.list. You can verify them and then install them with
+
+    $ sudo dnf install -y $(cat build-deps.list)
+
+This used to be more complicated, but I finally redid this and use the same
+buildsystem that's used by Qubes OS for XFCE. It's just a Makefile that helps
+you get the sources and start off the build:
+
+    $ make rpms
+
+Installing
+----------
+
+You should now have your i3 rpm in `./rpm/x86_64/i3-4.8-3.fc20.x86_64.rpm`.
+Protip: copying this file to ~/i3.rpm now will save you some typing in the next
+step.
+
+Now in dom0, copy in the rpm:
+
+    $ qvm-run --pass-io <src_domain> 'cat </path/to/rpm_in_src_domain>' > i3.rpm
+
+Now that the rpm is in dom0 we can proceed with installing it. i3 has some
+dependencies that we can easily install with:
+
+    $ sudo qubes-dom0-update perl-AnyEvent-I3 xorg-x11-apps \\
+        rxvt-unicode xcb-util-wm perl-JSON-XS xcb-util-cursor \\
+        dzen2 dmenu xorg-x11-fonts-misc libev
+
+After that you can just install the generated rpm like any other local package
+
+    $ sudo yum localinstall i3.rpm
+
+Log out, select i3, then log in again.
+
+Configuration
+-------------
+
+Things needed/recommended to be done:
+
+  1. Create [a script][xdg_autostart_script] to start all entries in the xdg
+     autostart directory. This is necessary to bring transient vm's up and
+restore state.
+  2. Change dmenu to i3-dmenu-desktop in the i3 configuration file. This
+     respects xdg desktop files and gives you a good way of starting programs in
+specific domains.
+  3. Install i3status or use a [different kind of script][i3bar_script] to drive
+     i3bar.
+  4. You could install and bind tools to change backlight and volume levels in
+     i3's config. You could also run kmix and xfce4-power-manager, which are
+part of a normal Qubes installation, and bind the keys for you.
+  5. Qubes does automatic screen locking and so should you. Install `xautolock`
+     and `i3lock` in dom0 and then add
+
+        exec --no-startup-id "xautolock -detectsleep -time 3 -locker 'i3lock -d -c 000000' -notify 30 -notifier \"notify-send -t 2000 'Locking screen in 30 seconds'\""
+
+     to your i3 config to enable it.
+  6. By default `$mod+Return` in i3 will open a new terminal in dom0. If you
+     prefer to start a new terminal in the domain of the currently active
+     window, use [a script like this][terminal_start_script].
+
+[xdg_autostart_script]:
+https://gist.github.com/SietsevanderMolen/7b4cc32ce7b4884513b0a639540e454f
+[i3bar_script]:
+https://gist.github.com/SietsevanderMolen/e7f594f209dfaa3596907e427b657e30
+[terminal_start_script]:
+https://gist.github.com/SietsevanderMolen/7c6f2b5773dbc0c08e1509e49abd1e96

--- a/doc.md
+++ b/doc.md
@@ -136,6 +136,7 @@ Customization Guides
  * [Customizing Windows 7 templates](/doc/windows-template-customization)
  * [Using KDE in dom0](/doc/kde/)
  * [Installing XFCE in dom0](/doc/xfce/)
+ * [Installing i3 in dom0](/doc/i3/)
  * [Language Localization](/doc/language-localization/)
 
 


### PR DESCRIPTION
This will help users install and use the tiling window manager i3.

A special page is necessary for this as the window manager needs to be patched to work with Qubes window decorations.

Has been tested to work on Qubes R3.1.