### PR TITLE
Automatic; No manual coding of IP addresses.

### DIFF
--- a/configuration/vpn.md
+++ b/configuration/vpn.md
@@ -121,7 +121,7 @@ Using a ProxyVM to set up a VPN client gives you the ability to:
     ```
     #!/bin/bash
     set -e
-    export PATH=$PATH:/usr/sbin:/sbin
+    export PATH="$PATH:/usr/sbin:/sbin"
 
 case "$1" in
 

--- a/configuration/vpn.md
+++ b/configuration/vpn.md
@@ -121,6 +121,7 @@ Using a ProxyVM to set up a VPN client gives you the ability to:
     ```
     #!/bin/bash
     set -e
+    export PATH=$PATH:/usr/sbin:/sbin
 
 case "$1" in
 


### PR DESCRIPTION
This requires the user only to add a few lines to their ovpn config file, and copy a few scripts (verbatim). They do not have to figure out which IP addresses are appropriate and hard-code them--unless their VPN service is bereft of domain names. Even in that case, they can do it easily within the ovpn config file. This is much less error-prone and should work with a greater variety of services (large commercial services tend to change their IPs so using domain names and DHCP is preferable in that case).

Also converted firewall section (3) to one code block for much less cutting/pasting. Comments are still there as shell comments.

The only required template changes are adding openvpn itself and possibly disabling the default systemd service for it. Everything else should be there in /rw/config.

This doesn't include extra firewall protections against inadvertent net access from within the VPN VM. I'm thinking of proposing those additions in a separate edit.