### PR TITLE
Fix qubes-os.org formatting problems

### DIFF
--- a/configuration/vpn.md
+++ b/configuration/vpn.md
@@ -29,9 +29,6 @@ While the NetworkManager service is not started here (for a good reason), you ca
 
 ### ProxyVM
 
-
-**WARNING:** *You need to use Qubes 3.1-rc2 (or later)! In the previous releases the NetworkManager service was not working in ProxyVMs as expected.* ([#1052](https://github.com/QubesOS/qubes-issues/issues/1052))
-
 One of the best thing in Qubes is that you can use a special type of VM called a ProxyVM (or FirewallVM). The special thing is that your AppVMs see this as a NetVM, and your NetVMs see it as an AppVM. Because of this, you can place a ProxyVM between your AppVMs and your NetVM. This is how the default FirewallVM functions.
 
 Using a ProxyVM to set up a VPN client gives you the ability to:
@@ -40,9 +37,12 @@ Using a ProxyVM to set up a VPN client gives you the ability to:
 -   Separate your VPN credentials from Your AppVM data.
 -   Easily control which of your AppVMs are connected to your VPN by simply setting it as a NetVM of the desired AppVM.
 
-#### Setup a ProxyVM as a VPN gateway
+#### Setup a ProxyVM as a VPN gateway...
 
 #### Using NetworkManager
+
+**WARNING:** *You need to use Qubes 3.1-rc2 (or later)! In the previous releases the NetworkManager service was not working in ProxyVMs as expected.* ([#1052](https://github.com/QubesOS/qubes-issues/issues/1052))
+
 
 1.  Create a new VM and check the ProxyVM radio button.
 
@@ -78,6 +78,7 @@ Using a ProxyVM to set up a VPN client gives you the ability to:
     NOTE: If the connection breaks down all traffic will by default be routed through the upstream network device eth0 (we will stop this with iptables in step 3).
 
     Also add the following to accomodate a DNS script:
+    
     ```
     script-security 2
     up 'qubes-vpn-handler.sh up'
@@ -87,9 +88,9 @@ Using a ProxyVM to set up a VPN client gives you the ability to:
 3.  Setup iptables.
     Edit the firewall script with `sudo nano /rw/config/qubes-firewall-user-script` and add:
 
-	```
-	#!/bin/bash
-	#    First, block all outgoing traffic
+    ```
+    #!/bin/bash
+    #    First, block all outgoing traffic
 	iptables -P OUTPUT DROP
     iptables -F OUTPUT
 
@@ -105,68 +106,72 @@ Using a ProxyVM to set up a VPN client gives you the ability to:
     iptables -A OUTPUT -p all -o eth0 -m owner --gid-owner qvpn \
     -m state --state NEW,ESTABLISHED -j ACCEPT
 
-	#	Allow internal system connections:
+	#    Allow internal system connections:
     iptables -I OUTPUT -o lo -j ACCEPT
 
-	#	Block forwarding of connections through upstream network device
-	#	(in case the vpn tunnel breaks):
+	#    Block forwarding of connections through upstream network device
+	#    (in case the vpn tunnel breaks):
     iptables -I FORWARD -o eth0 -j DROP  
     iptables -I FORWARD -i eth0 -j DROP
     ```
+
     Now save `/rw/config/qubes-firewall-user-script` and make it executable:  
     `sudo chmod +x /rw/config/qubes-firewall-user-script`
 
 4.  Create the DNS-handling script.
     Use `sudo nano /rw/config/openvpn/qubes-vpn-handler.sh` to edit and add:
+
     ```
     #!/bin/bash
     set -e
     export PATH="$PATH:/usr/sbin:/sbin"
 
-case "$1" in
+    case "$1" in
 
-up)
-	# To override DHCP DNS, assign static DNS addresses with 'setenv vpn_dns' in openvpn config;
+    up)
+    # To override DHCP DNS, assign static DNS addresses with 'setenv vpn_dns' in openvpn config;
 	# Format is 'X.X.X.X  Y.Y.Y.Y [...]' with quotes.
-	if [[ -z "$vpn_dns" ]] ; then
-		# Parses DHCP options from openvpn to set DNS address translation:
-		for optionname in ${!foreign_option_*} ; do
-			option="${!optionname}"
-			unset fops; fops=($option)
-			if [ ${fops[1]} == "DNS" ] ; then vpn_dns="$vpn_dns ${fops[2]}" ; fi
-		done
-	fi
+	    if [[ -z "$vpn_dns" ]] ; then
+		    # Parses DHCP options from openvpn to set DNS address translation:
+    		for optionname in ${!foreign_option_*} ; do
+	    		option="${!optionname}"
+		    	unset fops; fops=($option)
+			    if [ ${fops[1]} == "DNS" ] ; then vpn_dns="$vpn_dns ${fops[2]}" ; fi
+    		done
+	    fi
 
-	iptables -t nat -F PR-QBS
-	if [[ -n "$vpn_dns" ]] ; then
-		# Set DNS address translation in firewall:
-		for addr in $vpn_dns; do
-			iptables -t nat -A PR-QBS -i vif+ -p udp --dport 53 -j DNAT --to $addr
-			iptables -t nat -A PR-QBS -i vif+ -p tcp --dport 53 -j DNAT --to $addr
-		done
-		su - -c 'notify-send "$(hostname): LINK IS UP." --icon=network-idle' user
-	else
-		su - -c 'notify-send "$(hostname): LINK UP, NO DNS!" --icon=dialog-error' user
-	fi
+    	iptables -t nat -F PR-QBS
+	    if [[ -n "$vpn_dns" ]] ; then
+    		# Set DNS address translation in firewall:
+	    	for addr in $vpn_dns; do
+		    	iptables -t nat -A PR-QBS -i vif+ -p udp --dport 53 -j DNAT --to $addr
+			    iptables -t nat -A PR-QBS -i vif+ -p tcp --dport 53 -j DNAT --to $addr
+    		done
+	    	su - -c 'notify-send "$(hostname): LINK IS UP." --icon=network-idle' user
+    	else
+	    	su - -c 'notify-send "$(hostname): LINK UP, NO DNS!" --icon=dialog-error' user
+    	fi
 
-	;;
-down)
-	su - -c 'notify-send "$(hostname): LINK IS DOWN !" --icon=dialog-error' user
-	;;
-esac
-```
+	    ;;
+    down)
+	    su - -c 'notify-send "$(hostname): LINK IS DOWN !" --icon=dialog-error' user
+    	;;
+    esac
+    ```
 
     Now save the script and make it executable:  
     `sudo chmod +x /rw/config/openvpn/qubes-vpn-handler.sh`
     
 5.  Setup the VPN's autostart:  
     Use `sudo nano /rw/config/rc.local` to edit and add:  
+
     ```
     #!/bin/bash
     groupadd -rf qvpn ; sleep 2s
     sg qvpn -c 'openvpn --cd /rw/config/openvpn/ --config openvpn-client.ovpn \
     --daemon --writepid /var/run/openvpn/openvpn-client.pid'
     ```
+
     Now save the script and make it executable:  
     `sudo chmod +x /rw/config/rc.local`
     


### PR DESCRIPTION
Some indentation and line spacing are mangling code blocks when displayed with the qubes-os.org stylesheet. Trying to correct...
In "Spaces" mode, I tried to get the editor to insert spaces instead of tabs, but it was converting my spaces into tabs :(
I also moved the warning about NM to the NM section.