### PR TITLE
Update usb.md

### DIFF
--- a/common-tasks/usb.md
+++ b/common-tasks/usb.md
@@ -266,6 +266,9 @@ To use this feature, you need to install `qubes-usb-proxy` package in the
 templates used for USB qube and qubes you want to connect USB devices to. Note
 you cannot pass through devices from dom0 (in other words: USB VM is required).
 
+Set USB proxying rules: 
+* Default configuration in `/etc/qubes-rpc/policy/qubes.USB` does not allow USB proxying between VMs
+
 Listing available USB devices:
 
     [user@dom0 ~]$ qvm-usb


### PR DESCRIPTION
USB input devices are handled as input devices in a specific qubes-rpc configuration file.

If a user wants to enable USB proxy for other USB devices type, he must update /etc/qubes-rpc/policy/qubes.USB

