### PR TITLE
Add fix for Linux HVM kernel error on bootup:   BUG: soft lockup - CPU#0 stuck for 23s! [systemd-udevd:244]

### DIFF
--- a/managing-os/linux-hvm-tips.md
+++ b/managing-os/linux-hvm-tips.md
@@ -11,6 +11,41 @@ redirect_from:
 Tips for Linux in HVM domain
 ============================
 
+Fixing bootup kernel error `BUG: soft lockup - CPU#0 stuck for 23s! [systemd-udevd:244]`
+----------------------------------------------------------------------------------------
+*Tested with Qubes R3.2-RC3*
+Issue may be related to "bochs_drm" video driver. 
+
+To fix:
+
+1.  Edit the file /etc/default/grub
+2.  Find the line which starts:
+
+    ~~~
+    GRUB_CMDLINE_LINUX=
+    ~~~
+
+3.  Remove this text from that line:
+
+    ~~~
+    rhgb
+    ~~~
+
+4.  Add this text to that line:
+  
+    ~~~
+    modprobe.blacklist=bochs_drm
+    ~~~
+
+5. Run this command:
+
+    ~~~
+    grub2-mkconfig --output=/boot/grub2/grub.cfg
+    ~~~
+
+The HVM should no longer display the error if it's related to the "bochs_drm" kernel driver.
+
+
 Screen resolution
 -----------------
 


### PR DESCRIPTION
@marmarek noted in https://github.com/QubesOS/qubes-issues/issues/1943#issuecomment-249306243 this was a possible place for this information.