### PR TITLE
Make reference to using bind-dirs with cron

### DIFF
--- a/reference/dom0-tools/qvm-service.md
+++ b/reference/dom0-tools/qvm-service.md
@@ -88,7 +88,7 @@ Enable CUPS service. The user can disable cups in VM which do not need printing 
 crond  
 Default: disabled
 
-Enable CRON service.
+Enable CRON service.  To have cron jobs persist across reboots, put /var/spool/cron in /rw/config/qubes-bind-dirs/50_user.conf. (See [Instructions](/doc/bind-dirs/) )
 
 network-manager  
 Default: enabled in NetVM

--- a/reference/dom0-tools/qvm-service.md
+++ b/reference/dom0-tools/qvm-service.md
@@ -88,7 +88,7 @@ Enable CUPS service. The user can disable cups in VM which do not need printing 
 crond  
 Default: disabled
 
-Enable CRON service.  To have cron jobs persist across reboots, put /var/spool/cron in /rw/config/qubes-bind-dirs/50_user.conf. (See [Instructions](/doc/bind-dirs/) )
+Enable CRON service.  To have cron jobs persist across reboots, /var/spool/cron is bind-mounted from /rw/bind-dirs. To override this see [Bind-Dir Instructions](/doc/bind-dirs/) )
 
 network-manager  
 Default: enabled in NetVM


### PR DESCRIPTION
Make it clear that for persistent crontabs bind-dirs should be used. QubesOS/qubes-issues#2326 and QubesOS/qubes-issues#2327 refer