### PR TITLE
changed link to release notes

### DIFF
--- a/customization/kde.md
+++ b/customization/kde.md
@@ -12,7 +12,7 @@ Installation
 ------------
 
 Prior to R3.2, KDE was the default desktop environment in Qubes. Beginning with
-R3.2, however, [XFCE is the new default desktop environment](https://github.com/QubesOS/qubes-issues/issues/2119). Nonetheless, it is
+R3.2, however, [XFCE is the new default desktop environment](https://www.qubes-os.org/doc/releases/3.2/release-notes/). Nonetheless, it is
 still possible to install KDE by issuing this command in dom0:
 
     $ sudo qubes-dom0-update @kde-desktop-qubes


### PR DESCRIPTION
changed link to R3.2 release notes rather than github issue. the vitrol of the github ticket I don't think is appropriate to link to from a doc, linking to official release notes makes more sense.