### PR TITLE
Reworked the page structure, added USBVM use case

### DIFF
--- a/managing-os/templates/fedora-minimal.md
+++ b/managing-os/templates/fedora-minimal.md
@@ -49,10 +49,10 @@ To access the journald log, use the `journalctl` command.
 
 ### as a NetVM
 
-If you want to use this template to for standard NetVMs with USB forwarding capabilities you should install some more packeges:
+If you want to use this template for standard NetVMs you should install some more packages:
 
 ~~~
-[user@F21-Minimal ~]$ sudo dnf install NetworkManager NetworkManager-wifi network-manager-applet  wireless-tools dbus-x11 dejavu-sans-fonts tinyproxy qubes-input-proxy-sender
+[user@F21-Minimal ~]$ sudo dnf install NetworkManager NetworkManager-wifi network-manager-applet  wireless-tools dbus-x11 dejavu-sans-fonts tinyproxy
 ~~~
 
 And maybe some more optional but useful packages as well:
@@ -62,6 +62,14 @@ And maybe some more optional but useful packages as well:
 ~~~
 
 If your network device needs some firmware then you should also install the corresponding packages as well. The `lspci` and `dnf search firmware` command will help to choose the right one :)
+
+### as a USBVM
+
+If you want this template to allow USB input forwarding, you will need to install one extra package.
+
+~~~
+[user@F21-Minimal ~]$ sudo dnf install qubes-input-proxy-sender
+~~~
 
 ### as a ProxyVM
 

--- a/managing-os/templates/fedora-minimal.md
+++ b/managing-os/templates/fedora-minimal.md
@@ -26,7 +26,7 @@ The Fedora minimal template can be installed with the following command:
 
 The download and installation process may take some time. 
 
-Cloning the template
+Duplication and first steps
 -----
 
 It is higly recommended to clone the original template, and make any changes in the clone instead of the original template. The following command clones the template. Replace "your-new-clone" with your desired name.
@@ -35,10 +35,7 @@ It is higly recommended to clone the original template, and make any changes in 
 [user@dom0 ~]$ qvm-clone fedora-23-minimal your-new-clone
 ~~~
 
-First steps
------
-
-You must start the template machine in order to customize it.
+You must start the template in order to customize it.
 A recommended first step is to install the `sudo` package, which is not installed by default in the minimal template:
 
 ~~~
@@ -46,40 +43,36 @@ A recommended first step is to install the `sudo` package, which is not installe
 [user@your-new-clone ~]$ dnf install sudo
 ~~~
 
-The rsyslog logging service is not installed by default. All logging is now being handled by the systemd journal. Users requiring the rsyslog service should install it manually.
+Customization
+-----
+
+Customizing the template for specific use cases normally only requires installing additional packages.
+The following table provides an overview of which packages are needed for which purpose.
+
+As expected, the required packages are to be installed in the running template with the following command. Replace "packages" with the list of packages to be installed, separated by space.
+
+~~~
+[user@your-new-clone ~]$ sudo dnf install packages
+~~~
+
+Use case | Description | Required steps
+--- | --- | ---
+**Standard utilities** | If you need the commonly used utilities | Install the following packages: `pciutils` `vim-minimal` `less` `psmisc` `gnome-keyring`
+**Firewall VM** | You can use the minimal template as a firewall VM, such as the basis template for `sys-firewall` | No extra packages are needed for the template to work as a firewall.
+**Network VM** | You can use this template as the basis for a NetVM such as `sys-net` | Install the following packages: `NetworkManager` `NetworkManager-wifi` `network-manager-applet` `wireless-tools` `dbus-x11 dejavu-sans-fonts` `tinyproxy`.
+**Network VM (extra firmware)** | If your network devices need extra packages for the template to work as a network VM | Use the `lspci` command to identify the devices, then run `dnf search firmware` (replace "firmware" with the appropriate device identifier) to find the needed packages and then install them.
+**Network utilities** | If you need utilities for debugging and analyzing network connections | Install the following packages: `tcpdump` `telnet` `nmap` `nmap-ncat`
+**USB VM** | If you want USB input forwarding to use this template as the basis for a USBVM such as `sys-usb` | Install `qubes-input-proxy-sender`
+**VPN VM** | You can use this template as basis for a VPN machine | Use the `dnf search "NetworkManager VPN plugin"` command to look up the VPN packages you need, based on the VPN technology you'll be using, and install them. Some GNOME related packages may be needed as well. After creation of a machine based on this template, follow the [VPN howto](/doc/vpn/#set-up-a-proxyvm-as-a-vpn-gateway-using-networkmanager) to configure it.
+**TOR** | If you want to provide torified networking to other clients | As described in [the TorVM page](/doc/torvm/), the recommendation is to use [the standard Whonix image](/doc/whonix/) for this use case.
+
+Common questions
+-----
+
+#### Logging
+
+The rsyslog logging service is not installed by default, as all logging is instead being handled by the systemd journal.
+Users requiring the rsyslog service should install it manually.
 
 To access the journald log, use the `journalctl` command.
 
-### as a NetVM
-
-If you want to use this template to for standard NetVMs you should install some more packeges:
-
-~~~
-[user@F21-Minimal ~]$ sudo dnf install NetworkManager NetworkManager-wifi network-manager-applet  wireless-tools dbus-x11 dejavu-sans-fonts tinyproxy
-~~~
-
-And maybe some more optional but useful packages as well:
-
-~~~
-[user@F21-Minimal ~]$ sudo dnf install pciutils vim-minimal less tcpdump telnet psmisc nmap nmap-ncat gnome-keyring
-~~~
-
-If your network device needs some firmware then you should also install the corresponding packages as well. The `lspci` and `dnf search firmware` command will help to choose the right one :)
-
-### as a ProxyVM
-
-If you want to use this template as a ProxyVM you may want to install even more packages
-
-#### Firewall
-
-This template is now ready to use for a standard firewall VM.
-
-#### VPN
-
-The needed packages depend on the VPN technology. The `dnf search "NetworkManager VPN plugin"` command may help you to choose the right one. You should also install the corresponding GNOME related packages as well.
-
-[More details about setting up a VPN Gateway](/doc/vpn/#proxyvm)
-
-#### TOR
-
-[UserDoc/TorVM](/wiki/UserDoc/TorVM)

--- a/managing-os/templates/fedora-minimal.md
+++ b/managing-os/templates/fedora-minimal.md
@@ -12,35 +12,38 @@ redirect_from:
 Fedora - minimal
 ================
 
-The template weighs only about 300MB and has most of the stuff cut off, except for minimal X and xterm. It is really just a barebone and not even usable in this form - but you can customize it to meet your needs. You can find some usage examples in the section below.  
+The template only weighs about 300 MB and has only the most vital packages installed, including a minimal X and xterm installation. It is not thought to be usable in its original form.
+The minimal template, however, can be easily extended to fit your requirements. The sections below contain the instructions on duplicating the template and provide some examples for commonly desired use cases.
 
-
-
-Install
+Installation
 -------
 
-It can be installed via the following command:
+The Fedora minimal template can be installed with the following command:
 
 ~~~
 [user@dom0 ~]$ sudo qubes-dom0-update qubes-template-fedora-23-minimal
 ~~~
 
-The download may take a while.
+The download and installation process may take some time. 
 
-Usage
+Cloning the template
 -----
 
-It is a good idea to clone the original template, and make any changes in the new clone instead:
+It is higly recommended to clone the original template, and make any changes in the clone instead of the original template. The following command clones the template. Replace "your-new-clone" with your desired name.
 
 ~~~
-[user@dom0 ~]$ qvm-clone fedora-23-minimal <your new template name>
+[user@dom0 ~]$ qvm-clone fedora-23-minimal your-new-clone
 ~~~
 
-The sudo package is not installed by default, so let's install it:
+First steps
+-----
+
+You must start the template machine in order to customize it.
+A recommended first step is to install the `sudo` package, which is not installed by default in the minimal template:
 
 ~~~
-[user@F23-Minimal ~]$ su -
-[user@F23-Minimal ~]$ dnf install sudo
+[user@your-new-clone ~]$ su -
+[user@your-new-clone ~]$ dnf install sudo
 ~~~
 
 The rsyslog logging service is not installed by default. All logging is now being handled by the systemd journal. Users requiring the rsyslog service should install it manually.
@@ -49,7 +52,7 @@ To access the journald log, use the `journalctl` command.
 
 ### as a NetVM
 
-If you want to use this template for standard NetVMs you should install some more packages:
+If you want to use this template to for standard NetVMs you should install some more packeges:
 
 ~~~
 [user@F21-Minimal ~]$ sudo dnf install NetworkManager NetworkManager-wifi network-manager-applet  wireless-tools dbus-x11 dejavu-sans-fonts tinyproxy
@@ -62,14 +65,6 @@ And maybe some more optional but useful packages as well:
 ~~~
 
 If your network device needs some firmware then you should also install the corresponding packages as well. The `lspci` and `dnf search firmware` command will help to choose the right one :)
-
-### as a USBVM
-
-If you want this template to allow USB input forwarding, you will need to install one extra package.
-
-~~~
-[user@F21-Minimal ~]$ sudo dnf install qubes-input-proxy-sender
-~~~
 
 ### as a ProxyVM
 

--- a/managing-os/templates/fedora-minimal.md
+++ b/managing-os/templates/fedora-minimal.md
@@ -49,10 +49,10 @@ To access the journald log, use the `journalctl` command.
 
 ### as a NetVM
 
-If you want to use this template to for standard NetVMs you should install some more packeges:
+If you want to use this template to for standard NetVMs with USB forwarding capabilities you should install some more packeges:
 
 ~~~
-[user@F21-Minimal ~]$ sudo dnf install NetworkManager NetworkManager-wifi network-manager-applet  wireless-tools dbus-x11 dejavu-sans-fonts tinyproxy
+[user@F21-Minimal ~]$ sudo dnf install NetworkManager NetworkManager-wifi network-manager-applet  wireless-tools dbus-x11 dejavu-sans-fonts tinyproxy qubes-input-proxy-sender
 ~~~
 
 And maybe some more optional but useful packages as well:


### PR DESCRIPTION
Expanded the description of a standard NetVM with qubes-input-proxy-sender, so that a 3.2 standard installation with NetVM=UsbVM does not leave USB broken when replacing the NetVM template with the fedora-minimal one.