### PR TITLE
qubes-mgmt-salt-admin-tools aint availble for 3.1

### DIFF
--- a/installing/upgrade/upgrade-to-r3.1.md
+++ b/installing/upgrade/upgrade-to-r3.1.md
@@ -90,10 +90,6 @@ complete.
     should be `3.1.4` or higher. If it's not, repeat the previous step with the
     `--clean` option.
 
-4.  Install new packages:
-
-        sudo qubes-dom0-update qubes-mgmt-salt-admin-tools
-
 4.  Reboot dom0.
     
     The system may hang during the reboot. If that happens, do not panic. All


### PR DESCRIPTION
I recently did an upgrade from 3.0 to 3.1 and noticed that qubes-mgmt-salt-admin-tools wasn't available in 3.1 & the upgrade still went smoothly…