### PR TITLE
Change deprecated `*.cloned-mac-address` to `*.assigned-mac-address`.

### DIFF
--- a/privacy/anonymizing-your-mac-address.md
+++ b/privacy/anonymizing-your-mac-address.md
@@ -32,8 +32,8 @@ Write the settings to a new file in the `/etc/NetworkManager/conf.d/` directory,
 wifi.scan-rand-mac-address=yes
 
 [connection]
-wifi.cloned-mac-address=stable
-ethernet.cloned-mac-address=stable
+wifi.assigned-mac-address=stable
+ethernet.assigned-mac-address=stable
 ~~~
 
 `stable` generates a random address that persists for each boot session.


### PR DESCRIPTION
From the [man pages of nm-settings](https://developer.gnome.org/NetworkManager/1.4/nm-settings.html) it seems that `{wifi,ethernet}.cloned-mac-address` is deprecated and replaced by `{wifi,ethernet}.assigned-mac-address`.

>Table 51. 802-3-ethernet setting & Table 52. 802-11-wireless setting
>
>assigned-mac-address | string | The new field for the cloned MAC address. It can be either a hardware address in ASCII representation, or one of the special values "preserve", "permanent", "random" or "stable". This field replaces the deprecated "cloned-mac-address" on D-Bus, which can only contain explict hardware addresses.
>
>cloned-mac-address | byte array | This D-Bus field is deprecated in favor of "assigned-mac-address" which is more flexible and allows specifying special variants like "random".