### PR TITLE
Additional step for Whonix

### DIFF
--- a/security/vm-sudo.md
+++ b/security/vm-sudo.md
@@ -141,11 +141,14 @@ this for extra security.**
 
           auth sufficient pam_permit.so
 
-    - For Whonix, if prompts appear during boot, create /etc/sudoers.d/zz99 and add two lines:
+    - For Whonix, if prompts appear during boot, create /etc/sudoers.d/zz99 and add these lines:
 
     ```
           ALL ALL=NOPASSWD: /usr/sbin/virt-what
-          ALL ALL=NOPASSWD: /usr/sbin/service whonixcheck *
+          ALL ALL=NOPASSWD: /usr/sbin/service whonixcheck restart
+          ALL ALL=NOPASSWD: /usr/sbin/service whonixcheck start
+          ALL ALL=NOPASSWD: /usr/sbin/service whonixcheck stop
+          ALL ALL=NOPASSWD: /usr/sbin/service whonixcheck status
     ```
 
 Dom0 password-less root access

--- a/security/vm-sudo.md
+++ b/security/vm-sudo.md
@@ -141,6 +141,12 @@ this for extra security.**
 
           auth sufficient pam_permit.so
 
+    - For Whonix, if prompts appear during boot, create /etc/sudoers.d/zz99 and add two lines:
+
+    ```
+          ALL ALL=NOPASSWD: /usr/sbin/virt-what
+          ALL ALL=NOPASSWD: /usr/sbin/service whonixcheck *
+    ```
 
 Dom0 password-less root access
 ------------------------------


### PR DESCRIPTION
Per this discussion, https://forums.whonix.org/t/fixing-whonix-boot-issue-after-securing-qubes-root-auth/3155/8

Whonix executes sudo commands in non-root startup scripts which causes pop-up auth prompts to appear while Whonix VMs are starting. The problem is partly due to sudo parsing sudoers.d entries in alphabetical order, and some later configs cause earlier ones to get overridden. Adding the right permissions to a lexically 'last' filename resolves the issue.