### PR TITLE
StandaloneVM term with parentheses

### DIFF
--- a/reference/glossary.md
+++ b/reference/glossary.md
@@ -85,9 +85,9 @@ TemplateBasedVM
 Any [VM](#vm) which depends on a [TemplateVM](#templatevm) for its root
 filesystem.
 
-Standalone(VM)
+StandaloneVM
 --------------
-Standalone (Virtual Machine). In general terms, a [VM](#vm) is described as
+In general terms, a [VM](#vm) is described as
 **standalone** if and only if it does not depend on any other VM for its root
 filesystem. (In other words, a VM is standalone if and only if it is not a
 TemplateBasedVM.) More specifically, a **StandaloneVM** is a type of VM in Qubes


### PR DESCRIPTION
Not common and as far I understand not useful to write Standalone(VM) or just Standalone. The canonical way to write that probably is StandaloneVM.

Also removed superfluous `(Virtual Machine)` since the term VM is explained above and linked as `[VM](#vm)`already for better consistency. (Otherwise, also for AppVM we'd have to add `(Virtual Machine)` to the description.)