### PR TITLE
Change CCleaner references to List of Software

### DIFF
--- a/customization/windows-template-customization.md
+++ b/customization/windows-template-customization.md
@@ -131,17 +131,14 @@ Manual tasks that can/should be started in the template
     1. Run Windows Disk Cleanup as Administrator.
     2. Enable all the task and run the cleaner
 
- * BleachBit
-    1. Install BleachBit (http://bleachbit.sourceforge.net/download)
-    2. Run BleachBit with 'Free disk space' checked.
- 
-        It will write zeros in all unused space. This will allow you to strip the root.img file later
+ * Secure Disk Erasure
+    List of Disk Erasing Software: https://en.wikipedia.org/wiki/List_of_data-erasing_software
 
  * TemplateVM stripping
 
     Ensure that you know what you are doing in this section as you may destroy by error your template root.img file.
 
-    * If you ran BleachBit with "Free disk space", follow the following procedure
+    * Use disk erasing software (list above) to fill free disk space with zeros. (Both CCleaner and BleachBit have been tested.)
 
         1. from dom0, go to /var/lib/templates-vm/yourtemplate
 

--- a/customization/windows-template-customization.md
+++ b/customization/windows-template-customization.md
@@ -132,6 +132,7 @@ Manual tasks that can/should be started in the template
     2. Enable all the task and run the cleaner
 
  * Secure Disk Erasure
+ 
     List of Disk Erasing Software: https://en.wikipedia.org/wiki/List_of_data-erasing_software
 
  * TemplateVM stripping

--- a/customization/windows-template-customization.md
+++ b/customization/windows-template-customization.md
@@ -127,23 +127,21 @@ Manual tasks that can/should be started in the template
 
  * Windows Update
 
- * Windows file cleaning
-    1. Run windows drive cleaner as Administrator.
+ * Windows Disk Cleanup
+    1. Run Windows Disk Cleanup as Administrator.
     2. Enable all the task and run the cleaner
 
- * CCleaner file cleaning
-    1. Install CCleaner free
-    2. Copy the attached ccleaner configuration file in CCleaner program file folder
-    3. Run ccleaner with all option set except "wipe free space" (it will also remove user history and preferences)
-    4. Run ccleaner only with the option "wipe free space".
-
+ * BleachBit
+    1. Install BleachBit (http://bleachbit.sourceforge.net/download)
+    2. Run BleachBit with 'Free disk space' checked.
+ 
         It will write zeros in all unused space. This will allow you to strip the root.img file later
 
  * TemplateVM stripping
 
     Ensure that you know what you are doing in this section as you may destroy by error your template root.img file.
 
-    * If you ran ccleaner with "wipe free space", follow the following procedure
+    * If you ran BleachBit with "Free disk space", follow the following procedure
 
         1. from dom0, go to /var/lib/templates-vm/yourtemplate
 


### PR DESCRIPTION
> The message should be: "Write zeros to the free space so that you can strip the .img later. Here's an example of a common tool that does that, but use whichever one you like.

Done. I couldn't care less about CCleaner, BleachBit, or the brand of my screwdriver. But it sets a bad precedent to have Qubes docs littered with references to software that is not in keeping with (my imagined) Qubes philosophy. :)

[Basic Github.com usage] Also, while I have you, could I have just re-opened my first pull request? I made changes to the original branch and resaved the changes to the same branch. But the Re-open option was not available.