### PR TITLE
Fixed misspelling in archlinux.md

### DIFF
--- a/managing-os/templates/archlinux.md
+++ b/managing-os/templates/archlinux.md
@@ -80,7 +80,7 @@ Main maintainer of this template is [Olivier Médoc](mailto:o_medoc@yahoo.fr).
 
     *   python-sh
 
-    *   dailog
+    *   dialog
 
     *   rpm-sign
     


### PR DESCRIPTION
Corrected spelling of package name from 'dailog' -> 'dialog'