### PR TITLE
[fix] configuration/salt.md:

### DIFF
--- a/configuration/salt.md
+++ b/configuration/salt.md
@@ -164,7 +164,7 @@ need to create state file (`/srv/salt/mc-everywhere.sls`):
 Then appropriate top file (`/srv/salt/mc-everywhere.top`):
 
     base:
-     - qubes:type:template:
+     qubes:type:template:
         - match: pillar
         - mc-everywhere
 


### PR DESCRIPTION
	Removes leading dash from qubes:type:template: example because it only works without