### PR TITLE
signal.md: fix destination directory for app icon

### DIFF
--- a/privacy/signal.md
+++ b/privacy/signal.md
@@ -56,7 +56,7 @@ you use Signal in an AppVM named `Signal`, and this AppVM uses `fedora-23` as it
    Move these files to the following locations:
    
         [user@fedora-23 Signal]$ sudo mv chrome-bikioccmkafdpakkkcpdbhpfkkhcmohk-Default.desktop /usr/share/applications/
-        [user@fedora-23 Signal]$ sudo mv chrome-bikioccmkafdpakkkcpdbhpfkkhcmohk-Default.png /usr/share/icons/hicolor/48x48/
+        [user@fedora-23 Signal]$ sudo mv chrome-bikioccmkafdpakkkcpdbhpfkkhcmohk-Default.png /usr/share/icons/hicolor/48x48/apps/
 
 5. From a Dom0 terminal, instruct Qubes to synchronize the application menus of this TemplateVM:
 


### PR DESCRIPTION
Moving application-specific icons under the `.../hicolor/48x48/` directory does not work: running `qvm-sync-appmenus` for a fedora-23 template displays:
```
----> Failed to get icon for XXX: No icon received
```
A solution is to move icons under `.../hicolor/48x48/apps/` instead (as suggested by [FreeDesktop's Icon Theme Specification](https://specifications.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html)). Indeed, there is no icon file directly under `48x48/` in my (very standard) fedora-23 template VM; they are all under `48x48/apps/`.