### PR TITLE
Update uefi-troubleshooting.md

### DIFF
--- a/troubleshooting/uefi-troubleshooting.md
+++ b/troubleshooting/uefi-troubleshooting.md
@@ -68,6 +68,10 @@ Some Dell systems and probably others have [another bug in UEFI firmware](http:/
 5. Execute:
 
         sed -i -e 's/^options=.*/\0 efi=attr=uc/' /mnt/sysimage/boot/efi/qubes/xen.cfg
+        
+   or if you're installing 3.2 execute:
+   
+        sed -i -e 's/^options=.*/\0 efi=attr=uc/' /mnt/sysimage/boot/efi/EFI/qubes/xen.cfg
 
 6. Now you can reboot the system by issuing `reboot` command.
 


### PR DESCRIPTION
When installing 3.2 from usb I found that the xen.cfg file was located in a different place, mnt/sysimage/boot/efi/EFI/qubes/xen.cfg.
