### PR TITLE
Contributing document link fix

### DIFF
--- a/basics_dev/contributing.md
+++ b/basics_dev/contributing.md
@@ -41,7 +41,7 @@ look at our [GitHub issues] to see which tasks are the most urgent. You can
 filter issues depending on your interest and experience. For example, here are
 some common issue labels:
 
-* [Help wanted](https://github.com/QubesOS/qubes-issues/issues?page=3&q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22&utf8=%E2%9C%93)
+* [Help wanted](https://github.com/QubesOS/qubes-issues/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22&utf8=%E2%9C%93)
 * [UX and usability](https://github.com/QubesOS/qubes-issues/issues?q=is%3Aissue+is%3Aopen+label%3AUX)
 * [Windows tools](https://github.com/QubesOS/qubes-issues/issues?q=is%3Aissue+is%3Aopen+label%3A%22C%3A+windows+tools%22)
 * [Documentation](https://github.com/QubesOS/qubes-issues/issues?q=is%3Aissue+is%3Aopen+label%3A%22C%3A+doc%22)


### PR DESCRIPTION
The link to the current github issues with the help wanted tag was pointing to page 3 of the results.