### PR TITLE
Update DispVM Customization

### DIFF
--- a/customization/dispvm-customization.md
+++ b/customization/dispvm-customization.md
@@ -40,10 +40,10 @@ Customization of Disposable VM
 
 It is possible to change the settings of each new Disposable VM (DispVM). This can be done by customizing the DispVM template:
 
-1.  Start a terminal in the `fedora-20-x64-dvm` TemplateVM by running the following command in a dom0 terminal. (By default, this TemplateVM is not shown in Qubes VM Manager. However, it can be shown by selecting "Show/Hide internal VMs.")
+1.  Start a terminal in the `fedora-23-dvm` TemplateVM by running the following command in a dom0 terminal. (By default, this TemplateVM is not shown in Qubes VM Manager. However, it can be shown by selecting "Show/Hide internal VMs.")
 
 
-        [user@dom0 ~]$ qvm-run -a fedora-20-x64-dvm gnome-terminal
+        [user@dom0 ~]$ qvm-run -a fedora-23-dvm gnome-terminal
 
 2.  Change the VM's settings and/or applications, as desired. Note that currently Qubes supports exactly one DispVM template, so any changes you make here will affect all DispVMs. Some examples of changes you may want to make include:
     -   Changing Firefox's default startup settings and homepage.
@@ -53,7 +53,7 @@ It is possible to change the settings of each new Disposable VM (DispVM). This c
 3.  Create an empty `/home/user/.qubes-dispvm-customized` file in the VM (not in dom0):
 
 
-        [user@fedora-20-x64-dvm ~]$ touch /home/user/.qubes-dispvm-customized
+        [user@fedora-23-dvm ~]$ touch /home/user/.qubes-dispvm-customized
 
 4.  Shutdown the VM (either by `poweroff` from VM terminal, or `qvm-shutdown` from dom0 terminal).
 5.  Regenerate the DispVM template using the default template:


### PR DESCRIPTION
This update adjusts to the current default DispVM template name, "fedora-23-dvm."