### PR TITLE
Clarifying syntax for adding and removing USB devices

### DIFF
--- a/common-tasks/usb.md
+++ b/common-tasks/usb.md
@@ -90,7 +90,7 @@ follows:
 
  6.  In a dom0 console, detach the stick:
 
-        qvm-block -d &lt;device&gt; &lt;vmname&gt;
+        qvm-block -d < device > < vmname >
  
  7.  You may now remove the device.
 

--- a/common-tasks/usb.md
+++ b/common-tasks/usb.md
@@ -64,7 +64,7 @@ follows:
         sudo udevadm trigger --action=change
 
  3.  Assuming your USB drive is attached to dom0 and is `sdb`, we attach the
-     device to a qube like so:
+     device to a qube with the name `personal` like so:
 
         qvm-block -a personal dom0:sdb
 
@@ -90,8 +90,8 @@ follows:
 
  6.  In a dom0 console, detach the stick:
 
-        qvm-block -d <device> <vmname>
-
+        qvm-block -d &lt;device&gt; &lt;vmname&gt;
+ 
  7.  You may now remove the device.
 
 **Warning:** Do not remove the device before detaching it from the VM!

--- a/common-tasks/usb.md
+++ b/common-tasks/usb.md
@@ -90,7 +90,7 @@ follows:
 
  6.  In a dom0 console, detach the stick:
 
-        qvm-block -d < device > < vmname >
+        qvm-block -d device vmname
  
  7.  You may now remove the device.
 


### PR DESCRIPTION
the terms `device` and `vmname` which were in "<" and ">" were not rendered. I removed the characters. because it appears to be impossible to use the lesser and greater in markdown blocks.

If you however find a better method, please change it.