### PR TITLE
Remove dates from dom0 tools reference pages

### DIFF
--- a/reference/dom0-tools/qubes-dom0-update.md
+++ b/reference/dom0-tools/qubes-dom0-update.md
@@ -16,9 +16,6 @@ NAME
 
 qubes-dom0-update - update software in dom0
 
-Date  
-2012-04-13
-
 SYNOPSIS
 --------
 

--- a/reference/dom0-tools/qubes-prefs.md
+++ b/reference/dom0-tools/qubes-prefs.md
@@ -23,9 +23,6 @@ qubes-prefs - display system-wide Qubes settings, such as:
 -   default kernel
 -   default netVM
 
-Date  
-2012-04-13
-
 SYNOPSIS
 --------
 

--- a/reference/dom0-tools/qvm-add-appvm.md
+++ b/reference/dom0-tools/qvm-add-appvm.md
@@ -18,9 +18,6 @@ qvm-add-appvm - add an already installed appvm to the Qubes DB
 
 WARNING: Normally you should not need this command, and you should use qvm-create instead!
 
-Date  
-2012-04-10
-
 SYNOPSIS
 --------
 

--- a/reference/dom0-tools/qvm-add-template.md
+++ b/reference/dom0-tools/qvm-add-template.md
@@ -16,9 +16,6 @@ NAME
 
 qvm-add-template - adds an already installed template to the Qubes DB
 
-Date  
-2012-04-10
-
 SYNOPSIS
 --------
 

--- a/reference/dom0-tools/qvm-backup-restore.md
+++ b/reference/dom0-tools/qvm-backup-restore.md
@@ -16,9 +16,6 @@ NAME
 
 qvm-backup-restore - restores Qubes VMs from backup
 
-Date  
-2012-04-10
-
 SYNOPSIS
 --------
 

--- a/reference/dom0-tools/qvm-backup.md
+++ b/reference/dom0-tools/qvm-backup.md
@@ -16,9 +16,6 @@ NAME
 
 qvm-backup
 
-Date  
-2012-04-10
-
 SYNOPSIS
 --------
 

--- a/reference/dom0-tools/qvm-block.md
+++ b/reference/dom0-tools/qvm-block.md
@@ -16,9 +16,6 @@ NAME
 
 qvm-block - list/set VM PCI devices.
 
-Date  
-2012-04-10
-
 SYNOPSIS
 --------
 

--- a/reference/dom0-tools/qvm-clone.md
+++ b/reference/dom0-tools/qvm-clone.md
@@ -16,9 +16,6 @@ NAME
 
 qvm-clone - clones an existing VM by copying all its disk files
 
-Date  
-2012-04-10
-
 SYNOPSIS
 --------
 

--- a/reference/dom0-tools/qvm-create-default-dvm.md
+++ b/reference/dom0-tools/qvm-create-default-dvm.md
@@ -16,9 +16,6 @@ NAME
 
 qvm-create-default-dvm - creates a default disposable VM
 
-Date  
-2012-04-10
-
 SYNOPSIS
 --------
 

--- a/reference/dom0-tools/qvm-create.md
+++ b/reference/dom0-tools/qvm-create.md
@@ -16,9 +16,6 @@ NAME
 
 qvm-create - creates a new VM
 
-Date  
-2012-04-10
-
 SYNOPSIS
 --------
 

--- a/reference/dom0-tools/qvm-firewall.md
+++ b/reference/dom0-tools/qvm-firewall.md
@@ -16,9 +16,6 @@ NAME
 
 qvm-firewall
 
-Date  
-2012-04-10
-
 SYNOPSIS
 --------
 

--- a/reference/dom0-tools/qvm-grow-private.md
+++ b/reference/dom0-tools/qvm-grow-private.md
@@ -16,9 +16,6 @@ NAME
 
 qvm-grow-private - increase private storage capacity of a specified VM
 
-Date  
-2012-04-10
-
 SYNOPSIS
 --------
 

--- a/reference/dom0-tools/qvm-kill.md
+++ b/reference/dom0-tools/qvm-kill.md
@@ -16,9 +16,6 @@ NAME
 
 qvm-kill - kills the specified VM
 
-Date  
-2012-04-10
-
 SYNOPSIS
 --------
 

--- a/reference/dom0-tools/qvm-ls.md
+++ b/reference/dom0-tools/qvm-ls.md
@@ -16,9 +16,6 @@ NAME
 
 qvm-ls - list VMs and various information about their state
 
-Date  
-2012-04-03
-
 SYNOPSIS
 --------
 

--- a/reference/dom0-tools/qvm-pci.md
+++ b/reference/dom0-tools/qvm-pci.md
@@ -16,9 +16,6 @@ NAME
 
 qvm-pci - list/set VM PCI devices
 
-Date  
-2012-04-11
-
 SYNOPSIS
 --------
 

--- a/reference/dom0-tools/qvm-prefs.md
+++ b/reference/dom0-tools/qvm-prefs.md
@@ -16,9 +16,6 @@ NAME
 
 qvm-prefs - list/set various per-VM properties
 
-Date  
-2012-04-11
-
 SYNOPSIS
 --------
 

--- a/reference/dom0-tools/qvm-remove.md
+++ b/reference/dom0-tools/qvm-remove.md
@@ -16,9 +16,6 @@ NAME
 
 qvm-remove - remove a VM
 
-Date  
-2012-04-11
-
 SYNOPSIS
 --------
 

--- a/reference/dom0-tools/qvm-revert-template-changes.md
+++ b/reference/dom0-tools/qvm-revert-template-changes.md
@@ -16,9 +16,6 @@ NAME
 
 qvm-revert-template-changes
 
-Date  
-2012-04-11
-
 SYNOPSIS
 --------
 

--- a/reference/dom0-tools/qvm-run.md
+++ b/reference/dom0-tools/qvm-run.md
@@ -16,9 +16,6 @@ NAME
 
 qvm-run - run a command on a specified VM
 
-Date  
-2012-04-11
-
 SYNOPSIS
 --------
 

--- a/reference/dom0-tools/qvm-service.md
+++ b/reference/dom0-tools/qvm-service.md
@@ -16,9 +16,6 @@ NAME
 
 qvm-service - manage (Qubes-specific) services started in VM
 
-Date  
-2012-05-30
-
 SYNOPSIS
 --------
 

--- a/reference/dom0-tools/qvm-shutdown.md
+++ b/reference/dom0-tools/qvm-shutdown.md
@@ -16,9 +16,6 @@ NAME
 
 qvm-shutdown
 
-Date  
-2012-04-11
-
 SYNOPSIS
 --------
 

--- a/reference/dom0-tools/qvm-start.md
+++ b/reference/dom0-tools/qvm-start.md
@@ -16,9 +16,6 @@ NAME
 
 qvm-start - start a specified VM
 
-Date  
-2012-04-11
-
 SYNOPSIS
 --------
 

--- a/reference/dom0-tools/qvm-sync-appmenus.md
+++ b/reference/dom0-tools/qvm-sync-appmenus.md
@@ -16,9 +16,6 @@ NAME
 
 qvm-sync-appmenus - updates desktop file templates for given StandaloneVM or TemplateVM
 
-Date  
-2012-04-11
-
 SYNOPSIS
 --------
 

--- a/reference/dom0-tools/qvm-template-commit.md
+++ b/reference/dom0-tools/qvm-template-commit.md
@@ -16,9 +16,6 @@ NAME
 
 qvm-template-commit
 
-Date  
-2012-04-11
-
 SYNOPSIS
 --------
 


### PR DESCRIPTION
This commit removes the stale dates from the dom0 tools' reference pages, as per the discussion at [1].

[1] https://github.com/QubesOS/qubes-core-admin/pull/93
