### PR TITLE
Building Non-Fedora Template Cleanup

### DIFF
--- a/building/building-non-fedora-template.md
+++ b/building/building-non-fedora-template.md
@@ -89,17 +89,12 @@ You will be able to test these script when making the first Qubes packages. Don'
 Qubes packages
 --------------
 
-### vmm-xen-vm
-
-### core-vchan-xen-vm
-
-### linux-utils-vm
-
-### core-agent-linux-vm
-
-### gui-common-vm
-
-### gui-agent-linux-vm
+* [vmm-xen](https://github.com/QubesOS/qubes-vmm-xen)
+* [core-vchan-xen](https://github.com/QubesOS/qubes-core-vchan-xen)
+* [linux-utils](https://github.com/QubesOS/qubes-linux-utils)
+* [core-agent-linux](https://github.com/QubesOS/qubes-core-agent-linux)
+* [gui-common](https://github.com/QubesOS/qubes-gui-common)
+* [gui-agent-linux](https://github.com/QubesOS/qubes-gui-agent-linux)
 
 Additional Installation scripts
 -------------------------------
@@ -137,15 +132,15 @@ As soon as you manage to make qrexec and qubes-gui-agent working, it should be s
 
 ### Xen libraries
 
-Several XEN libraries are required for Qubes to work correctly. In fact, you need to make xenstore commands working before anything else. For this, Qubes git can be used as several patches have been selected by Qubes developers that could impact the activity inside a VM. Start be retrieving a recent git and identify how you can build a package from it: `git clone git://git.qubes-os.org/marmarek/xen`
+Several XEN libraries are required for Qubes to work correctly. In fact, you need to make xenstore commands working before anything else. For this, Qubes git can be used as several patches have been selected by Qubes developers that could impact the activity inside a VM. Start be retrieving a recent git and identify how you can build a package from it: `git clone https://github.com/QubesOS/qubes-vmm-xen.git`
 
-Find the .spec file in the git repository (this is the file being used to build rpm packages), and try to adapt it to your OS in order to build a package similar to the target 'xen-vm'. For example, a PKGBUILD has been created for [ArchLinux](/doc/templates/archlinux/) and can be found on [http://aur.archlinux.org/packages/qu/qubes-vm-xen/PKGBUILD](http://aur.archlinux.org/packages/qu/qubes-vm-xen/PKGBUILD).
+Find the .spec file in the git repository (this is the file being used to build rpm packages), and try to adapt it to your OS in order to build a package similar to the target 'vmm-xen'. For example, a PKGBUILD has been created for [ArchLinux](/doc/templates/archlinux/) and can be found in the vmm-xen repository.
 
 Don't be afraid with the complexity of the PKGBUILD, most of the code is almost a copy/paste of required sources and patches found in the .spec file provided in the git repository.
 
 Note once the package has been successfully compiled and installed, you need to setup XEN filesystem. Add the following line to your fstab (you can create this line in your package install script): `xen                     /proc/xen               xenfs   defaults        0 0`
 
-Now install the package you built and mount /proc/xen. Verify that xenstore-read works by running: `xenstore-read qubes_vm_type` That should give you the current VM type such as HVM or AppVM.
+Now install the package you built and mount /proc/xen. Verify that xenstore-read works by running: `xenstore-read name` That should give you the current name.
 
 ### Qubes-OS core agents (qrexec...)
 


### PR DESCRIPTION
* Changed the package list to a proper list, dropped the "-vm" suffix,
  and added the links to their respective repositories.
* Replaced a link to a qubes-os.org repository with the new Github
  repository
* Updated a reference to "xen-vm" to "vmm-xen" and removed the outdated
  link to the Arch AUR.
* Updated the suggested xenstore-read command to one that currently works