### PR TITLE
Fix link to Reflections on Trusting Trust paper

### DIFF
--- a/installing/install-security.md
+++ b/installing/install-security.md
@@ -77,7 +77,7 @@ Cons:
 
 
 [verify]: /security/verifying-signatures/
-[classic problem]: http://www.acm.org/classics/sep95/
+[classic problem]: https://www.ece.cmu.edu/~ganger/712.fall02/papers/p761-thompson.pdf
 [solutions]: http://www.dwheeler.com/trusting-trust/
 [USB qube]: /doc/usb/#creating-and-using-a-usb-qube
 [BadUSB]: https://srlabs.de/badusb/


### PR DESCRIPTION
Current link is gone (redirect to nowhere useful), the archive.org copy
is missing the figures, and dl.acm.org is not Tor-friendly.

This is the best copy there seems to be.