### PR TITLE
Edit pentesting.md

### DIFF
--- a/managing-os/pentesting.md
+++ b/managing-os/pentesting.md
@@ -6,19 +6,19 @@ permalink: /doc/pentesting/
 
 **Legal notice:**
 
-The usage of penetration testing tools outside your own laboratory environment requires the permission of the organization you attack. Penetration testing without such a permission can have legal consequences.
+The usage of penetration testing tools outside your own laboratory environment requires the permission of the organization you attack. Penetration testing without permission can have legal consequences.
 
 To avoid such legal conflicts please refer to the [EC-Council: Code of Ethics](https://www.eccouncil.org/Support/code-of-ethics).
 
 Penetration Testing
 ===================
 
-"A penetration test, informally pen test, is an attack on a computer system that looks for security weaknesses, potentially gaining access to the computer's features and data." (source [Penetration test](https://en.wikipedia.org/wiki/Penetration_test)).
+"A penetration test, colloquially known as a pen test, is an authorised simulated attack on a computer system that looks for security weaknesses, potentially gaining access to the system's features and data." (Source: [Wikipedia](https://en.wikipedia.org/wiki/Penetration_test)).
 
 Penetration Testing Distributions
 ---------------------------------
 
-The following install instructions explain how to setup a penetration testing distribution within Qubes OS.  
+The following instructions explain how to install a penetration testing distribution within Qubes OS.  
 
 - [BlackArch](/doc/pentesting/blackarch/)
 - [Kali](/doc/pentesting/kali/)
@@ -27,4 +27,4 @@ The following install instructions explain how to setup a penetration testing di
 Using Qubes OS to host a "hacking" laboratory
 ---------------------------------------------
 
-Qubes OS is a hypervisor based operating system. Qubes OS can host various operating systems such as Linux, Unix or Windows and run them in parallel. Qubes OS can therefor be used to host your own "hacking" laboratory.
+Qubes OS is a hypervisor based operating system. Qubes OS can host various operating systems such as Linux, Unix or Windows and run them in parallel. Qubes OS can therefore be used to host your own "hacking" laboratory.


### PR DESCRIPTION
Updated the wikipedia definition to reflect what's on the page (which is a more accurate definition anyways). It's a little heavy, but since the sentence has quotation marks we should be basing it on a direct quote from the article and not a paraphrase. If you want to paraphrase it because it's dense someone else can come and remove those quotation marks and write their own defintion. 

While I did not modify the source, I also want to ask that we not source information from the wikipedia article itself, but rather the sources that it references in its footnotes. 

Also:
* Missing a lette
* Removed unnecessary word glyphs