### PR TITLE
Edit grammar/flow of gui.md

### DIFF
--- a/system/gui.md
+++ b/system/gui.md
@@ -15,43 +15,50 @@ Qubes GUI protocol
 qubes_gui and qubes_guid processes
 ------------------------------------
 
-All AppVM X applications connect to local (running in AppVM) Xorg server, that uses the following "hardware" drivers:
+All AppVM X applications connect to local (running in AppVM) Xorg servers that use the following "hardware" drivers:
 
 -   *dummyqsb_drv* - video driver, that paints onto a framebuffer located in RAM, not connected to real hardware
 -   *qubes_drv* - it provides a virtual keyboard and mouse (in fact, more, see below)
 
-For each AppVM, there is a pair of *qubes_gui* (running in AppVM) and *qubes_guid* (running in dom0) processes, connected over vchan. Main responsibilities of *qubes_gui* are:
+For each AppVM, there is a pair of *qubes_gui* (running in AppVM) and *qubes_guid* (running in dom0) processes connected over vchan. 
+The main responsibilities of *qubes_gui* are:
 
 -   call XCompositeRedirectSubwindows on the root window, so that each window has its own composition buffer
 -   instruct the local Xorg server to notify it about window creation, configuration and damage events; pass information on these events to dom0
 -   receive information about keyboard and mouse events from dom0, tell *qubes_drv* to fake appropriate events
 -   receive information about window size/position change, apply them to the local window
 
-Main responsibilities of *qubes_guid* are:
+The main responsibilities of *qubes_guid* are:
 
 -   create a window in dom0 whenever an information on window creation in AppVM is received from *qubes_gui*
 -   whenever the local window receives XEvent, pass information on it to AppVM (particularly, mouse and keyboard data)
 -   whenever AppVM signals damage event, tell local Xorg server to repaint a given window fragment
 -   receive information about window size/position change, apply them to the local window
 
-Note that keyboard and mouse events are passed to AppVM only if a window belonging to this AppVM has focus. AppVM has no way to get information on keystrokes fed to other AppVMs (e.g. XTEST extension will report the status of local AppVM keyboard only), nor synthesize and pass events to other AppVMs.
+Note that keyboard and mouse events are passed to AppVM only if a window belonging to this AppVM has focus.
+AppVM has no way to get information on keystrokes fed to other AppVMs (e.g. XTEST extension will report the status of local AppVM keyboard only) or synthesize and pass events to other AppVMs.
 
 Window content updates implementation
 -------------------------------------
 
-Typical remote desktop applications, like *vnc*, pass the information on all changed window content in-band (say, over tcp). As the channel has limited throughput, this impacts video performance. In case of Qubes, *qubes_gui* does not transfer all changed pixels via vchan. Instead, for each window, upon its creation or size change, *qubes_gui*
+Typical remote desktop applications, like *vnc*, pass information on all changed window content in-band (say, over tcp). 
+As that channel has limited throughput, this impacts video performance. 
+In case of Qubes, *qubes_gui* does not transfer all changed pixels via vchan. Instead, for each window, upon its creation or size change, *qubes_gui*
 
 -   asks *qubes_drv* driver for the list of physical memory frames that hold the composition buffer of a window
--   pass this information via `MFNDUMP` message to *qubes_guid* in dom0
+-   passes this information via `MFNDUMP` message to *qubes_guid* in dom0
 
-Now, *qubes_guid* has to tell dom0 Xorg server about the location of the buffer. There is no supported way (e.g. Xorg extension) to do this zero-copy style. The following method is used in Qubes:
+Now, *qubes_guid* has to tell the dom0 Xorg server about the location of the buffer. 
+There is no supported way (e.g. Xorg extension) to do this zero-copy style. 
+The following method is used in Qubes:
 
 -   in dom0, the Xorg server is started with *LD_PRELOAD*-ed library named *shmoverride.so*. This library hooks all function calls related to shared memory.
 -   *qubes_guid* creates a shared memory segment, and then tells Xorg to attach it via *MIT-SHM* extension
 -   when Xorg tries to attach the segment (via glibc *shmat*) *shmoverride.so* intercepts this call and instead maps AppVM memory via *xc_map_foreign_pages*
 -   since then, we can use MIT-SHM functions, e.g. *XShmPutImage* to draw onto a dom0 window. *XShmPutImage* will paint with DRAM speed; actually, many drivers use DMA for this.
 
-The important detail is that *xc_map_foreign_pages* verifies that a given mfn range actually belongs to a given domain id (and the latter is provided by trusted *qubes_guid*). Therefore, rogue AppVM cannot gain anything by passing crafted mnfs in the `MFNDUMP` message.
+The important detail is that *xc_map_foreign_pages* verifies that a given mfn range actually belongs to a given domain id (and the latter is provided by trusted *qubes_guid*). 
+Therefore, rogue AppVM cannot gain anything by passing crafted mnfs in the `MFNDUMP` message.
 
 To sum up, this solution has the following benefits:
 
@@ -64,45 +71,49 @@ To sum up, this solution has the following benefits:
 Security markers on dom0 windows
 --------------------------------
 
-It is important that user knows which AppVM a given window belongs to. This prevents an attack when a rogue AppVM paints a window pretending to belong to other AppVM or dom0, and tries to steal e.g. passwords.
+It is important that user knows which AppVM a given window belongs to. This prevents a rogue AppVM from painting a window pretending to belong to other AppVM or dom0 and trying to steal, for example, passwords.
 
-In Qubes, the custom window decorator is used, that paints a colourful frame (the colour is determined during AppVM creation) around decorated windows. Additionally, window title always starts with **[name of the AppVM]**. If a window has a *override_redirect* attribute, meaning that it should not be treated by a window manager (typical case is menu windows), *qubes_guid* draws a two-pixel colourful frame around it manually.
+In Qubes, a custom window decorator is used that paints a colourful frame (the colour is determined during AppVM creation) around decorated windows. Additionally, the window title always starts with **[name of the AppVM]**. If a window has a *override_redirect* attribute, meaning that it should not be treated by a window manager (typical case is menu windows), *qubes_guid* draws a two-pixel colourful frame around it manually.
 
 Clipboard sharing implementation
 --------------------------------
 
-Certainly, it would be insecure to allow AppVM to read/write clipboard of other AppVMs unconditionally. Therefore, the following mechanism is used:
+Certainly, it would be insecure to allow AppVM to read/write the clipboards of other AppVMs unconditionally. 
+Therefore, the following mechanism is used:
 
 -   there is a "qubes clipboard" in dom0 - its contents is stored in a regular file in dom0.
 -   if user wants to copy local AppVM clipboard to qubes clipboard, she must focus on any window belonging to this AppVM, and press **Ctrl-Shift-C**. This combination is trapped by *qubes-guid*, and `CLIPBOARD_REQ` message is sent to AppVM. *qubes-gui* responds with *CLIPBOARD_DATA* message followed by clipboard contents.
 -   user focuses on other AppVM window, presses **Ctrl-Shift-V**. This combination is trapped by *qubes-guid*, and `CLIPBOARD_DATA` message followed by qubes clipboard contents is sent to AppVM; *qubes_gui* copies data to the local clipboard, and then user can paste its contents to local applications normally.
 
-This way, user can quickly copy clipboards between AppVMs. This action is fully controlled by the user, it cannot be triggered/forced by any AppVM.
+This way, user can quickly copy clipboards between AppVMs. 
+This action is fully controlled by the user, it cannot be triggered/forced by any AppVM.
 
 *qubes_gui* and *qubes_guid* code notes
 -----------------------------------------
 
-Both applications are structures similarly. They use *select* function to wait for any of the two event sources
+Both applications are structured similarly. They use *select* function to wait for any of these two event sources:
 
 -   messages from the local X server
 -   messages from the vchan connecting to the remote party
 
-The XEvents are handled by *handle_xevent_eventname* function, messages are handled by *handle_messagename* function. One should be very careful when altering the actual *select* loop - e.g. both XEvents and vchan messages are buffered, meaning that *select* will not wake for each message.
+The XEvents are handled by the *handle_xevent_eventname* function, and messages are handled by *handle_messagename* function. One should be very careful when altering the actual *select* loop, because both XEvents and vchan messages are buffered, and  *select* will not wake for each message.
 
 If one changes the number/order/signature of messages, one should increase the *QUBES_GUID_PROTOCOL_VERSION* constant in *messages.h* include file.
 
-*qubes_guid* writes debugging information to */var/log/qubes/qubes.domain_id.log* file; *qubes_gui* writes debugging information to */var/log/qubes/gui_agent.log*. Include these files when reporting a bug.
+*qubes_guid* writes debugging information to */var/log/qubes/qubes.domain_id.log* file; *qubes_gui* writes debugging information to */var/log/qubes/gui_agent.log*. 
+Include these files when reporting a bug.
 
 AppVM -> dom0 messages
 -----------------------
 
-Proper handling of the below messages is security-critical. Observe that beside two messages (`CLIPBOARD` and `MFNDUMP`) the rest have fixed size, so the parsing code can be small.
+Proper handling of the below messages is security-critical. 
+Observe that beside two messages (`CLIPBOARD` and `MFNDUMP`) the rest have fixed size, so the parsing code can be small.
 
 The *override_redirect* window attribute is explained at [Override Redirect Flag](http://tronche.com/gui/x/xlib/window/attributes/override-redirect.html). The *transient_for* attribute is explained at [Transient_for attribute](http://tronche.com/gui/x/icccm/sec-4.html#WM_TRANSIENT_FOR).
 
-Window manager hints and flags are described at [http://standards.freedesktop.org/wm-spec/latest/](http://standards.freedesktop.org/wm-spec/latest/), especially part about `_NET_WM_STATE`.
+Window manager hints and flags are described in the [Extended Window Manager Hints (EWMH) spec](http://standards.freedesktop.org/wm-spec/latest/), especially under the `_NET_WM_STATE` section.
 
-Each message starts with the following header
+Each message starts with the following header:
 
 ~~~
 struct msghdr {   
@@ -117,7 +128,7 @@ struct msghdr {
 };
 ~~~
 
-The header is followed by message-specific data.
+This header is followed by message-specific data:
 
 <table class="table">
   <tr>
@@ -266,8 +277,7 @@ struct msghdr {
 };
 ~~~
 
-The header is followed by message-specific data.
- `KEYPRESS`, `BUTTON`, `MOTION`, `FOCUS` messages pass information extracted from dom0 XEvent; see appropriate event documentation.
+The header is followed by message-specific data:
 
 <table class="table">
   <tr>
@@ -398,3 +408,5 @@ struct msg_window_flags {
  <td>Window state change confirmation</td>
 </tr>
 </table>
+
+ `KEYPRESS`, `BUTTON`, `MOTION`, `FOCUS` messages pass information extracted from dom0 XEvent; see appropriate event documentation.


### PR DESCRIPTION
Fixed problems related to:
* Unnecessary wordiness
* Subject-Verb Agreement
* Typos
* Not creating newline at end of sentence as per documentation guidelines.
* Putting sentences where they logically needed to be
* Adding articles where necessary
* Added descriptions of links that just used the URL as the display text

I don't understand some of the information here, so tell me if any of the fixes I made inadvertently created inaccuracies.