### PR TITLE
Kali Linux TemplateVM

### DIFF
--- a/managing-os/pentesting/kali.md
+++ b/managing-os/pentesting/kali.md
@@ -6,7 +6,7 @@ redirect_from:
 - /doc/kali/
 ---
 
-**General Remainder:**
+**General reminder:**
 
 - The installation scripts and provided tools may have bugs, be vulnerable to Man in the Middle (MitM) attacks or other vulnerabilities.
 
@@ -27,15 +27,10 @@ There are multiple ways to create a Kali Linux VM:
  2. Clone the Qubes OS Debian image and turn it into a Kali Linux distribution using [katoolin]. Explained [here](#katoolin).
  3. Clone the Qubes OS 'jessie' Debian template, upgrade it to 'stretch'
     (Debian 9.0) and turn it into a Kali linux template. Explained
-    [here](#debian-upgrade).
+    [here](#templatevm-from-debian).
 
-## Alternative Options to Kali
-
-- [BlackArch][qubes-blackarch]
-- [PenTester Framework (PTF)][qubes-ptf]
-- [Pentesting][qubes-pentesting]
-
-## Kali Linux HVM <a name="hvm"/>
+Kali Linux HVM <a name="hvm"/>
+--------------
 
 1. Download the Kali installation DVD
 
@@ -45,11 +40,12 @@ There are multiple ways to create a Kali Linux VM:
 
         qvm-start <hvm-name> --cdrom <vm-name>:/home/user/Downloads/<iso-name>.iso
 
-## Create Debian Based Kali Template <a name="katoolin"/>
+Debian based Kali Template with Katoolin <a name="katoolin"/>
+----------------------------------------
 
 Katoolin is a script (written in Python) which helps you to install Kali tools.
 
-1. *(Optional)* Install `debian-8` template (if not already installed)
+1. (Optional) Install `debian-8` template (if not already installed)
 
 2. Update your `debian-8` template
 
@@ -74,7 +70,7 @@ Katoolin is a script (written in Python) which helps you to install Kali tools.
         sudo apt-get dist-upgrade
         sudo apt-get autoremove
 
-6. Install Katoolin and add Kali Linux repositories
+5. Install Katoolin and add Kali Linux repositories
 
     1. Install Katoolin
 
@@ -127,12 +123,12 @@ Katoolin is a script (written in Python) which helps you to install Kali tools.
 
                 What do you want to do ?> ^CShutdown requested...Goodbye...
 
-7. Clean up and update `kali` template
+6. Clean up and update `kali` template
 
        sudo apt-get dist-upgrade
        sudo apt-get autoremove
 
-8. Shutdown and trim `kali` template
+7. Shutdown and trim `kali` template
 
     - Shutdown `kali` template
 
@@ -142,9 +138,9 @@ Katoolin is a script (written in Python) which helps you to install Kali tools.
 
             qvm-trim-template kali
 
-9. Start image
+8. Start image
 
-11. Install tools
+9. Install tools
 
     1. View Categories
 
@@ -160,15 +156,17 @@ Katoolin is a script (written in Python) which helps you to install Kali tools.
 
         - **Note:** The `all` option does not work for `Information Gathering`, `Web Apps`, `Forensic Tools`, `Reverse Engineering` and `Extra`.
 
-12. Create a AppVMs based on the `kali` template
+10. Create a AppVMs based on the `kali` template
 
     - (Optional) Attach necessary devices
 
-## Installing Kali from a Debian template <a name="debian-upgrade"/>
+Kali Linux TemplateVM from a Debian template  <a name="debian-upgrade"/><a name="templatevm-from-debian"/>
+--------------------------------------------
 
-This section will explain how to create your own [Kali] Linux VM as a VM
-template. The basic idea is to personalize the template with the tools you need
-and then spin up isolated AppVMs based on the template.
+This section will explain how to create your own [Kali] Linux TemplateVM based
+on a Debian 9.0 (Stretch) TemplateVM. The basic idea is to personalize the
+template with all the tools needed, and then spin up isolated AppVMs based on
+the template.
 
 This has been tested on Qubes OS 3.2.
 
@@ -176,133 +174,152 @@ The steps can be summarised as:
 
 1. Install Qubes' Debian 8.0 (Jessie) template
 2. Upgrade the template to Debian 9.0 (Stretch)
-3. Install kali through the ``kali-linux-full`` package
-4. Use the template to build appVM so that you can maintain isolation between
+3. Install Kali Linux through the ``kali-linux-full`` package
+4. Use the template to build AppVM so that you can maintain isolation between
    e.g. pentesting jobs
 
+### Get Kali Linux GPG key ###
 
-Steps to build a Kali template
-------------------------------
+This step is required since by (security) default a TemplateVM do not have a
+direct Internet connectivity. Users understanding the risks of enabling such
+access can change this configuration in firewall settings for the TemplateVM.
 
-### Get the GPG key
+1. Retrive the Kali Linux GPG key using a DispVM.
 
-1. You'll need to fetch the Kali GPG key from a dispVM as the template you'll
-   build won't have direct internet connectivity unless you enable it from the
-   firewall:
+        [user@xxxx-dvm ~]$ gpg --keyserver hkp://keys.gnupg.net --recv-key 7D8D0BF6
+        [user@xxxx-dvm ~]$ gpg --list-keys --with-fingerprint 7D8D0BF6 
+        [user@xxxx-dvm ~]$ gpg --export --armor 7D8D0BF6 > kali-key.asc
 
-        # in a dispVM
-        gpg --keyserver hkp://keys.gnupg.net --recv-key 7D8D0BF6
-        gpg --list-keys --with-fingerprint 7D8D0BF6 
-        gpg --export --armor 7D8D0BF6 > kali.asc
-
-2. **DO NOT TURN OFF** the dispVM
+2. **DO NOT TURN OFF** the DispVM, the `kali-key.asc` file will be copied to
+   the Kali Linux template in a further step.
 
 3. Make sure the key ID is the valid one listed on the [Kali website]. Ideally,
    verify the fingerprint through other channels as recommended on that link.
 
-Once you have the key, keep the dispVM on as you'll need to copy the key over
-to the Kali template.
+### Create a Debian 9.0 (Stretch) template ###
 
-### Customize the template
+These instructions will show you how to upgrade a Debian 8 TemplateVM to Debian 9.
 
-1. Install [the debian-8 template] if not already installed
+**Note:** the prompt on each line indicates where each command should be entered
+(`@dom0` or `@debian-9`).
 
-2. Clone the debian template and start a terminal in it:
+1. (Optional) Install the [debian-8 Qube template][qubes-template-debian-install] if not already installed.
 
-        # in dom0:
-        qvm-clone debian-8 debian-9
-        qvm-run -a debian-9 gnome-terminal
+2. Ensure the base template is not running. 
 
-        # in the debian-9 template terminal:
-        # substitute jessie for stretch in
-        sudo -s
-        sensible-editor /etc/apt/sources.list
-        sensible-editor /etc/apt/sources.list.d/qubes-r3.list
-        apt-get update && apt-get dist-upgrade
-        # (hat tip: [the Debian wiki])
+        [user@dom0 ~]$ qvm-shutdown debian-8
 
-    Restart the template when done and make sure you can open a terminal.
+3. Clone the base template and start a terminal in the new template.
 
-3. Prepare the kali template:
+        [user@dom0 ~]$ qvm-clone debian-8 debian-9
+        [user@dom0 ~]$ qvm-run -a debian-9 gnome-terminal
 
-        # in dom0:
-        qvm-shutdown debian-9
-        qvm-clone debian-9 kali-tpl
-        qvm-run -a kali-tpl gnome-terminal
+4. Attempt the upgrade process in the new template.
 
-3. Add the sources to install Kali linux to the `kali-tpl` template:
+        [user@debian-9 ~]$ sudo sed -i 's/jessie/stretch/g' /etc/apt/sources.list
+        [user@debian-9 ~]$ sudo sed -i 's/jessie/stretch/g' /etc/apt/sources.list.d/qubes-r3.list
+        [user@debian-9 ~]$ sudo apt-get update
+        [user@debian-9 ~]$ sudo apt-get dist-upgrade
+        [user@debian-9 ~]$ sudo apt-get autoremove
+ 
+ 5. Shut down and trim the new template.
 
-        # in kali-tpl:
-        sudo -s
-        echo 'deb http://http.kali.org/kali kali-rolling main non-free contrib' >> /etc/apt/sources.list
+        [user@dom0 ~]$ qvm-shutdown debian-9
+        [user@dom0 ~]$ qvm-trim-template debian-9
 
-4. Copy the Kali key from the dispVM into the template:
+ 6. Ensure a terminal can be opened in the new template.
 
-        # in the dispVM:
-        qvm-copy-to-vm kali-tpl kali.asc
+        [user@dom0 ~]$ qvm-run -a debian-9 gnome-terminal
 
-        # in kali-tpl:
-        cat /home/user/QubesIncoming/dispXXX/kali-key.asc | sudo apt-key add -
+### Create a Kali Linux (rolling) template ###
 
-    The last command should return `OK` on a line by itself.
+These instructions will show you how to upgrade a Debian 9 TemplateVM to Kali Linux.
 
-5. Update the system:
+**Note:** The prompt on each line indicates where each command should be entered
+(`@dom0`, `@kali-rolling` or `@xxxx-dvm`).
 
-        # in kali-tpl:
-        sudo -s
-        apt-get update && apt-get dist-upgrade
+1. Ensure the base template is not running. 
 
-6. Shut down the `kali-tpl` template:
+        [user@dom0 ~]$ qvm-shutdown debian-9
 
-        # in dom0:
-        qvm-shutdown kali-tpl
+2. Clone the base template and start a terminal in the new template.
 
-### Install the Kali tools
+        [user@dom0 ~]$ qvm-clone debian-9 kali-rolling
+        [user@dom0 ~]$ qvm-run -a kali-rolling gnome-terminal
+
+3. Copy the Kali GPG key from the DispVM to the new template:
+
+        [user@xxxx-dvm ~]$ qvm-copy-to-vm kali-rolling kali-key.asc
+   
+   The DispVM can now be turned off.
+
+4. Add the Kali GPG key to the list of keys trusted to authenticate packages:
+
+        [user@kali-rolling ~]$ /home/user/QubesIncoming/dispXXX/kali-key.asc | sudo apt-key add -
+
+    This command should return `OK` on a line by itself.
+
+5. Attempt the upgrade process in the new template.
+
+        [user@kali-rolling ~]$ sudo cat <<EOF > /etc/apt/sources.list.d/kali.list
+        # Kali Linux repository
+        deb http://http.kali.org/kali kali-rolling main non-free contrib
+        EOF
+        [user@kali-rolling ~]$ sudo apt-get update
+        [user@kali-rolling ~]$ sudo apt-get dist-upgrade
+        [user@kali-rolling ~]$ sudo apt-get autoremove
+ 
+ 6. Shut down and trim the new template.
+
+        [user@dom0 ~]$ qvm-shutdown kali-rolling
+        [user@dom0 ~]$ qvm-trim-template kali-rolling
+
+ 7. Ensure a terminal can be opened in the new template.
+
+        [user@dom0 ~]$ qvm-run -a kali-rolling gnome-terminal
+
+### Install the Kali tools ###
 
 At this point you should have a working template and you can install the tools you need.
 
-1. [resize the template] if you plan on installing the full Kali distribution. For example to install `kali-linux-full` you must **grow** the size of the VM system from 10Gb to at least 20Gb.
+1. [resize the template disk image][qubes-resize-disk-image] if you plan on installing the full Kali distribution. For example to install `kali-linux-full` you must **grow** the size of the VM system from 10GB to at least 20GB.
 
-1. Install Kali linux:
+2. Install Kali Linux tools:
 
-        # in kali-tpl:
-        sudo apt-get install kali-linux-full
+        [user@kali-rolling ~]$ sudo apt-get install kali-linux-full
         
-2. [optional] Customise the template's home directory (e.g. install your licensed copy of Burp Suite Professional)
+3. (Optional) Customise the template's home directory (e.g. install your licensed copy of Burp Suite Professional)
         
-### Use the template
+### Use the template ###
 
-The template is ready to be used. You can now spin up AppVMs based on the `kali-tpl` template.
+The template is ready to be used. You can now spin up AppVMs based on the `kali-rolling` template.
 
 
 
-Alternative Options to Kali
-===========================
+Alternative Options to Kali Linux
+---------------------------------
 
- * PenTester Framework: [PTF] ([PTF Qubes OS guide])
- * Black Arch with [BA Qubes OS guide])
- * [KATOOLIN]
+ * [PenTester Framework][PTF], with [PTF Qubes OS guide][qubes-ptf]
+ * BlackArch Linux, with [BA Qubes OS guide][qubes-blackarch]
+ * [KATOOLIN][katoolin-howto]
+ * more on the [Penetration Testing page][qubes-pentesting]
 
 Notes
 -----
 
-Thanks to the people in [the discussion thread].
+Thanks to the people in [the discussion thread](https://github.com/QubesOS/qubes-issues/issues/1981).
 
+[qubes-pentesting]: /doc/pentesting/
 [qubes-blackarch]: /doc/pentesting/blackarch/
 [qubes-ptf]: /doc/pentesting/ptf/
-[qubes-pentesting]: /doc/pentesting/
+[qubes-template-debian-install]: /doc/templates/debian/#install
+[qubes-resize-disk-image]: /doc/resize-disk-image/
 
-[kali-vbox]: https://www.offensive-security.com/kali-linux-vmware-virtualbox-image-download/
 [kali]: https://www.kali.org/
+[kali-vbox]: https://www.offensive-security.com/kali-linux-vmware-virtualbox-image-download/
 [kali website]: https://docs.kali.org/introduction/download-official-kali-linux-images.
-[KATOOLIN]: http://www.tecmint.com/install-kali-linux-tools-using-katoolin-on-ubuntu-debian/ 
-[the debian-8 template]: https://www.qubes-os.org/doc/templates/debian/#install
+
 [PTF]: https://www.trustedsec.com/may-2015/new-tool-the-pentesters-framework-ptf-released/
-[audio CDs]: https://www.reddit.com/r/Nirvana/comments/3hmra1/the_main_character_in_the_tv_show_mr_robot_has_a/
-[resize the template]: https://www.qubes-os.org/doc/resize-disk-image/
-[the Debian wiki]: https://wiki.debian.org/Qubes#Install_Debian_Templates
-[the discussion thread]: https://github.com/QubesOS/qubes-issues/issues/1981
-[PTF Qubes OS guide]: https://www.qubes-os.org/doc/pentesting/ptf/
-[BA Qubes OS guide]: https://www.qubes-os.org/doc/pentesting/blackarch/
+
 [katoolin]: https://github.com/LionSec/katoolin
 [katoolin-howto]: http://www.tecmint.com/install-kali-linux-tools-using-katoolin-on-ubuntu-debian/


### PR DESCRIPTION
Partial rewrite of the page, mainly the last Kali TemplateVM section to:
- add missing steps in TemplateVM creation (ex: trimming to optimize disk space usage)
- correct inconsistent file names across subsections, which made the instruction nonfunctional "as-it"
- match shell commands with textual instructions
- remove unused, duplicate or wrongly formatted links /references
- enhance consistency in commands and style used within the same section
- enhance consistency in commands and style with other pages (ex: Qubes' Basics and Common Tasks, Fedora 23 to Fedora 24 upgrade, etc.)
- better follow Qubes Glossary and Documentation Guidelines
- have a hierarchical succession of headers / section titles