### PR TITLE
Update to add StandaloneVM Tutorial

### DIFF
--- a/privacy/signal.md
+++ b/privacy/signal.md
@@ -76,6 +76,32 @@ You can now launch the Signal messenger inside its own dedicated AppVM directly 
 
 The same steps should work for any Chrome app.
 
+Creating a shortcut in the applications menu for a StandaloneVM
+---------------------------------------------------------------
+
+If you want to add to the standalone VM rather than a template, then follow below.
+The following part will also assume that the .desktop file has been correctly made.
+This can also be used to add a application portable application/script from a tar archive, also this part of the guide is assuming that the StandaloneVM is called `Signal`.
+
+1. First you will need to copy/move the .desktop file: `/home/user/Desktop/chrome-bikioccmkafdpakkkcpdbhpfkkhcmohk-Default.desktop`to the applications folder on the StandaloneVM: `/usr/share/applications/`
+
+        [user@Signal ~]$ sudo mv /home/user/Desktop/chrome-bikioccmkafdpakkkcpdbhpfkkhcmohk-Default.desktop /usr/share/applications/
+
+2. Now copy/move over the icon file to make it look all nice and pretty.  
+
+        [user@Signal ~]$ sudo mv /home/user/Desktop/chrome-bikioccmkafdpakkkcpdbhpfkkhcmohk-Default.desktop /usr/share/icons/hicolor/48x48/apps/
+
+3. Now fire up the `dom0` Terminal Emulator from `Q` Menu -> `Terminal Emulator`. All you need to do now is run the command to sync the app menus `qvm-sync-appmenus` along with the Standalone VM name `Signal`.
+
+        [user@dom0 ~]$ qvm-sync-appmenus Signal
+
+4. Now stop the StandaloneVM: `Signal`.
+
+5. With your mouse select the `Q` menu -> `Domain: Signal` -> `Signal: Add more shortcuts`. Select `Signal Private Messenger` from the left `Available` column, move it to the right `Selected` column by clicking the `>` button and then `OK` to apply the changes and close the window.
+   
+6. (optional, only on KDE:) Follow the `Q` menu once more, right-click on the new `Signal: Signal Private Messenger` menu item and select `Add to Panel`.
+
+
 -----
 
 [Signal]: https://whispersystems.org/


### PR DESCRIPTION
After struggling to find a way to add an application to the menu of a standalone domain I cam across this guide and it worked with a few modifications, I have added them at the bottom in a clear guide.