### PR TITLE
clearer explanation of qubes-service

### DIFF
--- a/reference/qubes-service.md
+++ b/reference/qubes-service.md
@@ -12,7 +12,7 @@ Usage documentation is on [qvm-service manual page](/doc/dom0-tools/qvm-service/
 
 Under the hood enabled service in VM is signaled by file in /var/run/qubes-service. This can be used to implement almost enable/disable **per-VM** switch controlled by dom0. Adding support for systemd services is pretty simple:
 
-Create `/etc/systemd/system/<service name>.service.d/30_qubes.conf` file
+In the VM, create `/etc/systemd/system/<service name>.service.d/30_qubes.conf` file
 containing (you may need to create a directory for this file first):
 
 ~~~
@@ -20,4 +20,4 @@ containing (you may need to create a directory for this file first):
 ConditionPathExists=/var/run/qubes-service/<service name>
 ~~~
 
-This will cause service to be started only when you enable it with qvm-service for given VM.
+This will cause service to be started only when you enable it with qvm-service for this VM.


### PR DESCRIPTION
It's wasn't perfectly clear that the 30_qubes.conf file should be created in the targeted VM, not in dom0