### PR TITLE
Fix jekyll/salt templating conflict

### DIFF
--- a/configuration/salt.md
+++ b/configuration/salt.md
@@ -413,7 +413,7 @@ The solution is to shut down the updateVM between each install:
 
     install template and shutdown updateVM:
       cmd.run:
-      - name: sudo qubes-dom0-update -y fedora-24; qvm-shutdown {{salt.cmd.run(qubes-prefs updateVM) }}
+      - name: sudo qubes-dom0-update -y fedora-24; qvm-shutdown {% raw %}{{ salt.cmd.run(qubes-prefs updateVM) }}{% endraw %}
 
 ## Further Reading
 


### PR DESCRIPTION
This was preventing the correct command from being shown, and causing a warning in site generation.

See also: https://github.com/QubesOS/qubesos.github.io/pull/111