### PR TITLE
set Qubes policy to allow by default for USB Input

### DIFF
--- a/common-tasks/usb.md
+++ b/common-tasks/usb.md
@@ -165,7 +165,7 @@ Edit the `qubes.InputKeyboard` policy file in dom0, which is located here:
 
 Add a line like this one to the top of the file:
 
-    sys-usb dom0 ask,user=root
+    sys-usb dom0 allow,user=root
 
 (Change `sys-usb` to your desired USB qube.)
 
@@ -183,7 +183,7 @@ Edit the `qubes.InputMouse` policy file in dom0, which is located here:
 
 Add a line like this to the op of the file:
 
-    sys-usb dom0 ask,user=root
+    sys-usb dom0 allow,user=root
     
 (Change `sys-usb` to your desired USB qube.)
 


### PR DESCRIPTION
https://github.com/QubesOS/qubes-mgmt-salt-dom0-virtual-machines/blob/master/qvm/sys-usb.sls ets `/etc/qubes-rpc/policy/qubes.InputMouse` to `sys-usb dom0 allow,user=root`.

A user following `How to use a USB keyboard` / `How to use a USB mouse` probably wants this. Otherwise, if the user doesn't have a PS2 keyboard / mouse, the user locks itself out. I suggest to either change to `allow` by default (already done by sys-usb salt config) or to explain this in documentation.

Please carefully review this since it's not my area of expertise.