### PR TITLE
Add example for DVM creation

### DIFF
--- a/customization/dispvm-customization.md
+++ b/customization/dispvm-customization.md
@@ -21,8 +21,9 @@ In order to regenerate the Disposable VM "snapshot" (called 'savefile' on Qubes)
 
     [user@dom0 ~]$ qvm-create-default-dvm <custom-template-name>
 
-
-This would create a new Disposable VM savefile based on the custom template. Now, whenever one opens a file (from any AppVM) in a Disposable VM, a Disposable VM based on this template will be used.
+This would create a new Disposable VM savefile based on the custom template.
+For example `<custom-template-name>` could be the name of the existing `debian-8` vm, which creates the disposable vm `debain-8-dvm`.
+Now, whenever one opens a file (from any AppVM) in a Disposable VM, a Disposable VM based on this template will be used.
 
 One can easily verify if the new Disposable VM template is indeed based on a custom template (in the example below the template called "f17-yellow" was used as a basis for the Disposable VM):
 


### PR DESCRIPTION
Problem: I was not sure if the dvm, which is a template should be named after an existing template. I feared it replaces the vm if I use the same name

Solution: clarify that using the name of an existing vm template is indeed intended.

PS: creating this from the newly installed qubes