### PR TITLE
Fix root shell PS1 in security/split-gpg

### DIFF
--- a/security/split-gpg.md
+++ b/security/split-gpg.md
@@ -161,7 +161,7 @@ the content of the file `/rw/config/gpg-split-domain`, which should be set to
 the name of the GPG backend VM. This file survives the AppVM reboot, of course.
 
     [user@work ~]$ sudo bash
-    [user@work ~]$ echo "work-gpg" > /rw/config/gpg-split-domain
+    [root@work ~]$ echo "work-gpg" > /rw/config/gpg-split-domain
 
 A note on passphrases:
 


### PR DESCRIPTION
The first command invokes a `bash` shell with elevated rights. The `echo` file redirection would not work as normal `user`.