### PR TITLE
Add link to qubes-usb-proxy

### DIFF
--- a/common-tasks/usb.md
+++ b/common-tasks/usb.md
@@ -333,7 +333,8 @@ templates used for the USB qube and qubes you want to connect USB devices to. No
 you cannot pass through devices from dom0 (in other words: USB VM is required).
 `qubes-usb-proxy` should be installed by default in the template VM.
 However, if you receive this error: `ERROR: qubes-usb-proxy not installed in the VM`,
-you can install the `qubes-usb-proxy` with the package manager.
+you can install the `qubes-usb-proxy` with the package manager in the VM
+you want to attach the USB device to.
 
 - Fedora: `sudo dnf install qubes-usb-proxy`
 - Debian/Ubuntu: `sudo apt-get install qubes-usb-proxy`

--- a/common-tasks/usb.md
+++ b/common-tasks/usb.md
@@ -325,7 +325,7 @@ passthrough will **expose your target qube** for most of them. If possible, use
 method specific for particular device type (for example block devices described
 above), instead of this generic one.
 
-To use this feature, you need to install `qubes-usb-proxy` package in the
+To use this feature, you need to install [`qubes-usb-proxy`][qubes-usb-proxy] package in the
 templates used for USB qube and qubes you want to connect USB devices to. Note
 you cannot pass through devices from dom0 (in other words: USB VM is required).
 
@@ -375,3 +375,4 @@ This feature is not yet available in Qubes Manager however, if you would like to
 [gsoc-page]: https://summerofcode.withgoogle.com/organizations/6239659689508864/
 [YubiKey]: /doc/YubiKey/
 [Security Warning about USB Input Devices]: #security-warning-about-usb-input-devices
+[qubes-usb-proxy]: https://github.com/QubesOS/qubes-app-linux-usb-proxy

--- a/common-tasks/usb.md
+++ b/common-tasks/usb.md
@@ -325,9 +325,20 @@ passthrough will **expose your target qube** for most of them. If possible, use
 method specific for particular device type (for example block devices described
 above), instead of this generic one.
 
+### Installation of qubes-usb-proxy ###
+[installation]: #installation-of-qubes-usb-proxy
+
 To use this feature, you need to install [`qubes-usb-proxy`][qubes-usb-proxy] package in the
-templates used for USB qube and qubes you want to connect USB devices to. Note
+templates used for the USB qube and qubes you want to connect USB devices to. Note
 you cannot pass through devices from dom0 (in other words: USB VM is required).
+`qubes-usb-proxy` should be installed by default in the template VM.
+However, if you receive this error: `ERROR: qubes-usb-proxy not installed in the VM`,
+you can install the `qubes-usb-proxy` with the package manager.
+
+- Fedora: `sudo dnf install qubes-usb-proxy`
+- Debian/Ubuntu: `sudo apt-get install qubes-usb-proxy`
+
+### Usage of qubes-usb-proxy ###
 
 Listing available USB devices:
 
@@ -345,7 +356,9 @@ Attaching selected USB device:
     sys-usb:2-5     058f:3822 058f_USB_2.0_Camera (attached to conferences)
     sys-usb:2-1     03f0:0641 PixArt_HP_X1200_USB_Optical_Mouse
 
-Now, you can use your USB device (camera in this case) in `conferences` qube.
+Now, you can use your USB device (camera in this case) in the `conferences` qube.
+If you see the error `ERROR: qubes-usb-proxy not installed in the VM` instead,
+please refer to the [Installation Section][installation].
 
 When you finish, detach the device:
 


### PR DESCRIPTION
Issue: https://github.com/QubesOS/qubes-issues/issues/3171
Related installation information: https://github.com/QubesOS/qubes-issues/pull/3170

This adds a link to get the information for how to install the proxy.
