### PR TITLE
debian-8-backports electrum has bug, use fedora-25?

### DIFF
--- a/security/split-bitcoin.md
+++ b/security/split-bitcoin.md
@@ -17,28 +17,24 @@ A "split" bitcoin wallet is a strategy of protecting your bitcoin by having your
 A "Watching" Wallet and a "Cold" Wallet
 ---------------------------------------
 
-1. Create a Debian 8 backports template using the Qubes VM Manager or running
-   `qvm-clone debian-8 debian-8-backports` in dom0.
+1. Create a fedora-25-electrum template using the Qubes VM Manager or running
+   `qvm-clone fedora-25 fedora-25-electrum` in dom0.
 
-2. Add backports to the sources for the new template by opening a terminal in
-   the new template, run `sudo vi /etc/apt/sources.list` and add
-   `deb http://http.debian.net/debian jessie-backports main`.
+2. Start the new template and install electrum:
+   `qvm-start fedora-25-electrum`
+   `qvm-run fedora-25-electrum xterm`
 
-   (If you are new to `vi` text editing, type `i` to be able to edit, and when
-   done editing press `ESC` then type `:x` and press `ENTER`.)
+3. Install `electrum`.  Inside fedora-25-electrum terminal enter:
+   `sudo dnf update`.
+   `sudo dnf install electrum`.
 
-3. Update source list: `sudo apt-get update`.
+5. shut down your `fedora-25-electrum` template
 
-4. Install `electrum` from backports:
-   `sudo apt-get -t jessie-backports install electrum`.
-
-5. shut down your `debian-8-backports` template
-
-6. create an `offline-bitcoin` qube based on `debian-8-backports` using the Qubes VM Manager or running `qvm-create -t debian-8-backports -l black offline-bitcoin` and `qvm-prefs -s offline-bitcoin netvm none` in dom0.
+6. create an `offline-bitcoin` qube based on `fedora-25-electrum` using the Qubes VM Manager or running `qvm-create -t fedora-25-electrum -l black offline-bitcoin` and `qvm-prefs -s offline-bitcoin netvm none` in dom0.
 
 7. follow the [electrum documentation in creating an offline wallet](http://docs.electrum.org/en/latest/coldstorage.html#create-an-offline-wallet)
 
-8. create a `watching-bitcoin` qubes based on `debian-8-backports` connecting to the internet how ever you prefer using the Qubes VM Manager or running for example `qvm-create -t debian-8-backports -l green watching-bitcoin` and `qvm-prefs -s watching-bitcoin netvm sys-whonix` in dom0.
+8. create a `watching-bitcoin` qubes based on `fedora-25-electrum` connecting to the internet how ever you prefer using the Qubes VM Manager or running for example `qvm-create -t fedora-25-electrum -l green watching-bitcoin` and `qvm-prefs -s watching-bitcoin netvm sys-whonix` in dom0.
 
 9. follow the [electrum documentation in creating an online watching-only wallet](http://docs.electrum.org/en/latest/coldstorage.html#create-a-watching-only-version-of-your-wallet)
 

--- a/security/split-bitcoin.md
+++ b/security/split-bitcoin.md
@@ -20,23 +20,23 @@ A "Watching" Wallet and a "Cold" Wallet
 1. Create a fedora-25-electrum template using the Qubes VM Manager or running
    `qvm-clone fedora-25 fedora-25-electrum` in dom0.
 
-2. Start the new template and install electrum:
+2. Start the new template:
    `qvm-start fedora-25-electrum`
    `qvm-run fedora-25-electrum xterm`
 
-3. Install `electrum`.  Inside fedora-25-electrum terminal enter:
+3. Install `electrum` to fedora-25-electrum template VM.  From fedora-25-electrum terminal enter:
    `sudo dnf update`.
    `sudo dnf install electrum`.
 
-5. shut down your `fedora-25-electrum` template
+4. Shut down your `fedora-25-electrum` template
 
-6. create an `offline-bitcoin` qube based on `fedora-25-electrum` using the Qubes VM Manager or running `qvm-create -t fedora-25-electrum -l black offline-bitcoin` and `qvm-prefs -s offline-bitcoin netvm none` in dom0.
+5. Create an `offline-bitcoin` qube based on `fedora-25-electrum` using the Qubes VM Manager or running `qvm-create -t fedora-25-electrum -l black offline-bitcoin` and `qvm-prefs -s offline-bitcoin netvm none` in dom0.
 
-7. follow the [electrum documentation in creating an offline wallet](http://docs.electrum.org/en/latest/coldstorage.html#create-an-offline-wallet)
+6. Follow the [electrum documentation in creating an offline wallet](http://docs.electrum.org/en/latest/coldstorage.html#create-an-offline-wallet)
 
-8. create a `watching-bitcoin` qubes based on `fedora-25-electrum` connecting to the internet how ever you prefer using the Qubes VM Manager or running for example `qvm-create -t fedora-25-electrum -l green watching-bitcoin` and `qvm-prefs -s watching-bitcoin netvm sys-whonix` in dom0.
+7. Create a `watching-bitcoin` qubes based on `fedora-25-electrum` connecting to the internet how ever you prefer using the Qubes VM Manager or running for example `qvm-create -t fedora-25-electrum -l green watching-bitcoin` and `qvm-prefs -s watching-bitcoin netvm sys-whonix` in dom0.
 
-9. follow the [electrum documentation in creating an online watching-only wallet](http://docs.electrum.org/en/latest/coldstorage.html#create-a-watching-only-version-of-your-wallet)
+8. Follow the [electrum documentation in creating an online watching-only wallet](http://docs.electrum.org/en/latest/coldstorage.html#create-a-watching-only-version-of-your-wallet)
 
 Important Notes
 ---------------


### PR DESCRIPTION
A bug in debian-8-backports electrum package makes network request when sending offline transaction.  When Qubes has no network vm the electrum hangs when making offline transactions.  It was suggested to use fedora-25 in issues.