### PR TITLE
more useful link for USB keyboard

### DIFF
--- a/security/yubi-key.md
+++ b/security/yubi-key.md
@@ -11,7 +11,7 @@ Using YubiKey to Qubes authentication
 =====================================
 
 You can use YubiKey to enhance Qubes user authentication, for example to mitigate
-risk of snooping the password. This can also slightly improve security when you have [USB keyboard](https://github.com/marmarek/qubes-app-linux-input-proxy).
+risk of snooping the password. This can also slightly improve security when you have [USB keyboard](https://www.qubes-os.org/doc/usb/#security-warning-about-usb-input-devices).
 
 There (at least) two possible configurations: using OTP mode and using challenge-response mode.
 


### PR DESCRIPTION
The context is `also slightly improve security when you have USB keyboard`, so https://www.qubes-os.org/doc/usb/#security-warning-about-usb-input-devices fits better than https://github.com/marmarek/qubes-app-linux-input-proxy.

https://github.com/marmarek/qubes-app-linux-input-proxy isn't very explanatory on the referenced security aspect for users. Doesn't make clear what the security improvement will be. https://www.qubes-os.org/doc/usb/#security-warning-about-usb-input-devices does.