### PR TITLE
Be consistent.

### DIFF
--- a/basics_dev/source-code.md
+++ b/basics_dev/source-code.md
@@ -26,7 +26,7 @@ All of our repositories are available under the [QubesOS GitHub account].
 To clone a repository:
 
 ~~~
-git clone https://github.com/QubesOS/<repo_name>.git <repo_name>
+git clone https://github.com/QubesOS/qubes-<repo_name>.git <repo_name>
 ~~~
 
 e.g.:


### PR DESCRIPTION
The repo names are given above, but they have to actually have the
'qubes-' prefix to match what actually exists on github