### PR TITLE
Add instructions for newer UEFI systems

### DIFF
--- a/troubleshooting/thinkpad-troubleshooting.md
+++ b/troubleshooting/thinkpad-troubleshooting.md
@@ -15,6 +15,33 @@ redirect_from:
 
 # Lenovo ThinkPad Troubleshooting #
 
+## Instructions to create USB installation medium for newer (UEFI-only) ThinkPads ##
+Newer ThinkPads (e.g. T470, T470p, ThinkPad 25) are likely to fail installation attempts made from a USB stick that was created with dd or Rufus, and even from a DVD burned using official ISO images - if the ThinkPad is configured for UEFI boot. If you don't want to use Legacy Mode as a workaround, the following instructions should help you create a Qubes Installation USB stick that works in UEFI-only mode.
+
+In a nutshell, you need to use the Fedora livecd-tools to make a Qubes Installation USB Stick from the Qubes ISO image, then update the label on the partition of that USB stick to "BOOT", and then update the BOOT/EFI/xen.cfg file on the USB stick so that all labels point to BOOT. In more detail:
+
+1. On your ThinkPad, enter the UEFI setup (press F1 at startup) and make sure to set at least the following options:
+   - *USB UEFI BIOS Support: Enabled*
+   - *UEFI/Legacy Boot: UEFI Only*
+   - *Secure Boot: Disabled*
+2. On a different computer, create a "Fedora Live USB Stick": Download a current Fedora Live CD image, and put it onto a USB stick (e.g. using dd or Rufus). Start your ThinkPad from the Fedora Live USB Stick on your ThinkPad (Press F12 at startup to select boot device). Of course, you can alternatively start a different machine from the Fedora Live USB Stick, or use an existing Fedora installation. The next steps all occur within Fedora:
+3. Install livecd-tools: `# dnf install livecd-tools`
+4. Download the desired Qubes ISO image (or attach a storage device containing it), and verify the signatures as described in the Qubes installation guide. For these instructions, I assume the ISO image is at */run/media/liveuser/qsrc/Qubes-R4.0-rc3-x86_64.iso* (so whenever you see that path going forward in these instructions, replace it with whatever your own path is)
+5. Within Fedora, attach the USB stick that you would like to turn into your Qubes Installation USB Stick. Use `dmesg` to figure out what the device name of that stick is. For these instructions, I assume it's */dev/sdd* (so whenever you see */dev/sdd* going forward in these instructions, replace it with whatever your actual device name is)
+6. Make sure your target USB stick (presumed to be /dev/sdd) has no mounted partitions: ``# umount /dev/sdd*`` (the asterisk at the end makes sure to unmount all partitions if more than one exists). If none are mounted you'll get an error that you can ignore.
+7. Use livecd-tools to copy the image: ``# livecd-iso-to-disk --format --efi /run/media/liveuser/qsrc/Qubes-R4.0-rc3-x86_64.iso /dev/sdd``. **This will erase everythig on the drive. Make sure you specify the correct destination.** Then press ENTER when prompted to proceed. This process will take quite a while, be patient.
+8. When imaging is complete, change the partition label to BOOT: ``# dosfslabel /dev/sdd1 BOOT``
+9. Now create a mount point and mount the partition:
+
+   ``# mkdir /mnt/qinst``
+
+   ``# mount /dev/sdd1 /mnt/qinst/``
+
+10. Use your favorite editor to edit the file */mnt/qinst/EFI/BOOT/xen.cfg*: Replace all instances of ``LABEL=Qubes-R4.0-rc3-x86_64`` with ``LABEL=BOOT``. There is typically no space in front of ``LABEL``, but there is a space at the end of the portion you replace.
+11. Unmount the Qubes Installation USB stick: ``# umount /dev/sdd*`` and disconnect it.
+
+That's it! You can now reboot the machine with the Qubes USB Installation stick attached, and press F12 to select it as the boot device at startup. Proceed to install Qubes OS normally. Enjoy!
+
 ## ThinkPads with Intel HD 3000 graphics ##
 
 Several ThinkPad models have Intel HD 3000 graphics, including the T420s and the


### PR DESCRIPTION
Add instructions on how to create a USB installation medium that works on newer ThinkPad systems in UEFI-only mode. This is necessary because existing troubleshooting steps for ThinkPad and UEFI are no longer sufficient. The content was created based on the thread at https://groups.google.com/forum/#!topic/qubes-users/TEmVIozLJh0