### PR TITLE
Add link to email archive

### DIFF
--- a/about/mailing-lists.md
+++ b/about/mailing-lists.md
@@ -134,8 +134,9 @@ Examples of topics or questions suitable for this list include:
 
 ### Read these first
 
-Please try searching both the Qubes website and the archives of the mailing
-lists before sending a question. In addition, please make sure that you have
+Please try searching both the Qubes website and the
+[archives of the mailing lists][qubes-users-archive]
+before sending a question. In addition, please make sure that you have
 read and understood the following basic documentation prior to posting to the
 list:
 
@@ -331,8 +332,8 @@ qubes-translation
 
 ### How to use this list
 
-This list is for discussion around the localization and translation of Qubes OS, 
-its documentation, and the website. 
+This list is for discussion around the localization and translation of Qubes OS,
+its documentation, and the website.
 
 Examples of topics or question suitable for this list include:
 
@@ -372,6 +373,7 @@ You must be subscribed in order to post to this list.
 [User FAQ]: /faq/#users
 [documentation]: /doc/
 [thunderbird-newsgroup]: https://support.mozilla.org/en-US/kb/creating-newsgroup-account
+[qubes-users-archive]: https://www.mail-archive.com/qubes-users@googlegroups.com/
 [qubes-users-web]: https://groups.google.com/group/qubes-users
 [qubes-devel-web]: https://groups.google.com/group/qubes-devel
 [qubes-translation-web]: https://groups.google.com/group/qubes-translation

--- a/about/mailing-lists.md
+++ b/about/mailing-lists.md
@@ -134,9 +134,8 @@ Examples of topics or questions suitable for this list include:
 
 ### Read these first
 
-Please try searching both the Qubes website and the
-[archives of the mailing lists][qubes-users-archive]
-before sending a question. In addition, please make sure that you have
+Please try searching both the Qubes website and the archives of the mailing
+lists before sending a question. In addition, please make sure that you have
 read and understood the following basic documentation prior to posting to the
 list:
 
@@ -167,6 +166,7 @@ were sent directly to the list.
      interface. This has the advantage that it allows you to search and reply to
      messages which were sent prior to your subscription to the list. However, a
      Google account is required in order to post through this interface.
+ * You can also search the [traditional mail archive][qubes-users-archive]
 
 #### Gmane
 
@@ -247,6 +247,7 @@ You must be subscribed in order to post to this list.
      interface. This has the advantage that it allows you to search and reply to
      messages which were sent prior to your subscription to the list. However, a
      Google account is required in order to post through this interface.
+ * You can also search the [traditional mail archive][qubes-devel-archive]
 
 #### Gmane
 
@@ -374,6 +375,7 @@ You must be subscribed in order to post to this list.
 [documentation]: /doc/
 [thunderbird-newsgroup]: https://support.mozilla.org/en-US/kb/creating-newsgroup-account
 [qubes-users-archive]: https://www.mail-archive.com/qubes-users@googlegroups.com/
+[qubes-devel-archive]: https://www.mail-archive.com/qubes-devel@googlegroups.com/
 [qubes-users-web]: https://groups.google.com/group/qubes-users
 [qubes-devel-web]: https://groups.google.com/group/qubes-devel
 [qubes-translation-web]: https://groups.google.com/group/qubes-translation


### PR DESCRIPTION
It's been challenging for me to find the email archive. I find it one day, then the next day I'm duckduckgoing again and can't find it. 

Let's put it on the website so we can just click the link!