### PR TITLE
Add "sync" to the USB installation guide

### DIFF
--- a/installing/installation-guide.md
+++ b/installing/installation-guide.md
@@ -65,7 +65,7 @@ an installation medium.)
 If you prefer to use a USB drive, then you just need to copy the ISO onto the
 USB device, e.g. using `dd`:
 
-    dd if=Qubes-R3-x86_64.iso of=/dev/sdX bs=1M
+    dd if=Qubes-R3-x86_64.iso of=/dev/sdX bs=1M && sync
 
 Change `Qubes-R3-x86_64.iso` to the filename of the version you're installing,
 and change `/dev/sdX` to the correct target device (e.g., `/dev/sda`).


### PR DESCRIPTION
Pulling out the USB drive after dd completes leads to corrupted/incomplete installation media if one forgets to flush the cached writes with "sync". Explicitly mentioning the command will possibly avoid some future annoyances/confusion.