### PR TITLE
Custom "kernel" key in xen.cfg on USB install media

### DIFF
--- a/troubleshooting/uefi-troubleshooting.md
+++ b/troubleshooting/uefi-troubleshooting.md
@@ -10,15 +10,19 @@ Troubleshooting UEFI related problems
 Change installer kernel parameters in UEFI
 ---------------------
 
-If you've installed successfully in legacy mode but had to change some kernel parameters for it to work, you should try installing in UEFI with the same kernel parameters.
+If you've installed successfully in legacy mode but had to change some kernel parameters for it to work, you should try installing in UEFI mode with the same parameters.
 
-Change the `xen.cfg` on a USB media
-
-01. Attach the usb disk, find the EFI partition and mount it
-02. Edit your xen.cfg changing the `kernel` key to add your kernel parameters on the boot entry of your choice
+**Change the xen configuration on a USB media**
+01. Attach the usb disk, mount the EFI partition (second partition available on the disk) 
+02. Edit your xen config (`xen.cfg/BOOTX64.cfg`) changing the `kernel` key to add your kernel parameters on the boot entry of your choice
 03. Install using your modified boot entry
 
-You can also update an iso image, use `losetup` to isolate the EFI partition and mount it.
+**Change xen configuration directly in an iso image**
+01. Get EFI partition boundaries `parted Qubes-R4.0-rc4-x86_64.iso unit B print`
+02. Using the start address and the size of the EFI partition, setup a loop device for it `sudo losetup -o 524288 --sizelimit 30562304 /dev/loop0 Qubes-R4.0-rc4-x86_64.iso`
+03. Mount the loop device `sudo mount /dev/loop0 /mnt`
+04. Edit `EFI/BOOT/BOOTX64.cfg` to add your params to the `kernel` configuration key
+05. Save your changes, unmount and dd to usb device
 
 
 Cannot start installation, installation completes successfully but then BIOS loops at boot device selection, hangs at four penguins after choosing "Test media and install Qubes OS" in GRUB menu

--- a/troubleshooting/uefi-troubleshooting.md
+++ b/troubleshooting/uefi-troubleshooting.md
@@ -7,6 +7,19 @@ permalink: /doc/uefi-troubleshooting/
 Troubleshooting UEFI related problems
 ========================================
 
+Change installer kernel parameters in UEFI
+---------------------
+
+If you've installed successfully in legacy mode but had to change some kernel parameters for it to work, you should try installing in UEFI with the same kernel parameters.
+
+Change the `xen.cfg` on a USB media
+
+01. Attach the usb disk, find the EFI partition and mount it
+02. Edit your xen.cfg changing the `kernel` key to add your kernel parameters on the boot entry of your choice
+03. Install using your modified boot entry
+
+You can also update an iso image, use `losetup` to isolate the EFI partition and mount it.
+
 
 Cannot start installation, installation completes successfully but then BIOS loops at boot device selection, hangs at four penguins after choosing "Test media and install Qubes OS" in GRUB menu
 ---------------------


### PR DESCRIPTION
Reviewing the HCL a lot of reporters had to install in legacy mode because UEFI mode would fail. For various reports, they used custom kernel parameters by changing the grub entry. This is frequent for recent hardware or some configurations (dual gpu,...).

With this procedure a user can perform UEFI install with custom kernel parameters