### PR TITLE
Update copying-files.md

### DIFF
--- a/common-tasks/copying-files.md
+++ b/common-tasks/copying-files.md
@@ -32,7 +32,12 @@ GUI
 CLI
 ---
 
+qvm-copy [--without-progress] dest_vmname file [file]+
+
 [qvm-copy-to-vm](/doc/vm-tools/qvm-copy-to-vm/)
+
+note: qvm-copy-to-vm/qvm-move-to-vm tools are deprecated, use qvm-copy/qvm-move to avoid typing target qube name twice
+
 
 On inter-qube file copy security
 ----------------------------------

--- a/common-tasks/copying-files.md
+++ b/common-tasks/copying-files.md
@@ -32,11 +32,17 @@ GUI
 CLI
 ---
 
-qvm-copy [--without-progress] dest_vmname file [file]+
+qvm-copy-to-vm [--without-progress] dest_vmname file [file]+
 
 [qvm-copy-to-vm](/doc/vm-tools/qvm-copy-to-vm/)
 
-note: qvm-copy-to-vm/qvm-move-to-vm tools are deprecated, use qvm-copy/qvm-move to avoid typing target qube name twice
+
+Qubes 4.0
+---------
+
+In Qubes 4.0, qvm-copy-to-vm and qvm-move-to-vm are deprecated (GUI behaviour is unchanged from Qubes 3.2).  In the command line, use qvm-copy or qvm-move to avoid typing target qube name twice.
+
+qvm-copy [--without-progress] file [file]+
 
 
 On inter-qube file copy security


### PR DESCRIPTION
adding command line notes indicating qvm-copy-to-vm/qvm-move-to-vm tools deprecated.