### PR TITLE
Improve instructions for randomizing MAC addresses

### DIFF
--- a/privacy/anonymizing-your-mac-address.md
+++ b/privacy/anonymizing-your-mac-address.md
@@ -34,10 +34,11 @@ wifi.scan-rand-mac-address=yes
 [connection]
 wifi.cloned-mac-address=stable
 ethernet.cloned-mac-address=stable
+connection.stable-id=${CONNECTION}/${BOOT}
 ~~~
 
-`stable` generates a random address that persists for each boot session.
-`random` generates a random address each time a link goes up.
+* `stable` in combination with `${CONNECTION}/${BOOT}` generates a random address that persists for each boot session.
+* `random` generates a random address each time a link goes up.
 
 To see all the available configuration options, refer to the man page: `man nm-settings`
 

--- a/privacy/anonymizing-your-mac-address.md
+++ b/privacy/anonymizing-your-mac-address.md
@@ -37,7 +37,7 @@ ethernet.cloned-mac-address=stable
 connection.stable-id=${CONNECTION}/${BOOT}
 ~~~
 
-* `stable` in combination with `${CONNECTION}/${BOOT}` generates a random address that persists for each boot session.
+* `stable` in combination with `${CONNECTION}/${BOOT}` generates a random address that persists until reboot.
 * `random` generates a random address each time a link goes up.
 
 To see all the available configuration options, refer to the man page: `man nm-settings`


### PR DESCRIPTION
NetworkManager, by default, uses a connection ID and a per-host random
and secret key to generate `stable` MAC addresses. The intention is to
keep a connection's MAC address stable indefinitely but for it to be
different on every host.

The current instruction mention that "`stable` generates a random
address that persists for each boot session". This is indeed true for
AppVMs using stock TemplateVMs. The reason is that the secret key doesn't
exist in the template and thus is only created when the AppVM starts.
This, however, may not be true for other VMs.

In order to ensure that MACs are always only `stable` during one boot
session, `stable-id`, which is used to generate MACs, can be adjusted.
[NetworkManager's documentation] suggests to use `${CONNECTION}/${BOOT}`
to ensure generated MACs are unique to a boot session and connection.

[NetworkManager's documentation]: https://developer.gnome.org/NetworkManager/stable/nm-settings.html