### PR TITLE
Update fedora-minimal.md

### DIFF
--- a/managing-os/templates/fedora-minimal.md
+++ b/managing-os/templates/fedora-minimal.md
@@ -79,10 +79,10 @@ In Qubes 4.0, additional packages from the `qubes-core-agent` suite may be neede
 - `qubes-core-agent-passwordless-root`, `polkit`: By default the 'fedora-26-minimal' template doesn't have passwordless root. These two packages fix the situation.
 - `qubes-core-agent-nautilus`: This package provides integration with the Nautilus file manager (without it things like "copy to VM/open in disposable VM" will not be shown in Nautilus).
 - `qubes-core-agent-sysvinit`: Qubes unit files for SysV init style or upstart.
-- `qubes-core-agent-networking`: Networking support. Useful if the template has to be used for a `sys-net` VM.
-- `qubes-core-agent-network-manager`: Integration for NetworkManager. Useful if the template has to be used for a `sys-net` VM.
+- `qubes-core-agent-networking`: Networking support. Required if the template is to be used for a `sys-net` or `sys-firewall` VM.
+- `qubes-core-agent-network-manager`: Integration for NetworkManager. Useful if the template is to be used for a `sys-net` VM.
 - `qubes-core-agent-dom0-updates`: Script required to handle `dom0` updates. Any template which the VM responsible for 'dom0' updates (e.g. `sys-firewall`) is based on must contain this package.
-- `qubes-usb-proxy`: Required in minimal template for a USB qube (`sys-usb`) as well as in minimal template for any destination domains to which USB devices are to be attached (e.g `sys-net` if using USB network adapter).   
+- `qubes-usb-proxy`: Required if the template is to be used for a USB qube (`sys-usb`) or for any destination qube to which USB devices are to be attached (e.g `sys-net` if using USB network adapter).   
 - `pulseaudio-qubes`: Needed to have audio on the template VM.
 
 

--- a/managing-os/templates/fedora-minimal.md
+++ b/managing-os/templates/fedora-minimal.md
@@ -81,6 +81,7 @@ In Qubes 4.0, additional packages from the `qubes-core-agent` suite may be neede
 - `qubes-core-agent-sysvinit`: Qubes unit files for SysV init style or upstart.
 - `qubes-core-agent-networking`: Networking support. Required if the template is to be used for a `sys-net` or `sys-firewall` VM.
 - `qubes-core-agent-network-manager`: Integration for NetworkManager. Useful if the template is to be used for a `sys-net` VM.
+- `network-manager-applet`: Useful (together with `dejavu-sans-fonts` and `notification-daemon`) to have a system tray icon if the template is to be used for a `sys-net` VM.
 - `qubes-core-agent-dom0-updates`: Script required to handle `dom0` updates. Any template which the VM responsible for 'dom0' updates (e.g. `sys-firewall`) is based on must contain this package.
 - `qubes-usb-proxy`: Required if the template is to be used for a USB qube (`sys-usb`) or for any destination qube to which USB devices are to be attached (e.g `sys-net` if using USB network adapter).   
 - `pulseaudio-qubes`: Needed to have audio on the template VM.

--- a/managing-os/templates/fedora-minimal.md
+++ b/managing-os/templates/fedora-minimal.md
@@ -72,12 +72,6 @@ In Qubes R4.0, sudo is not installed by default in the minimal template.  To upd
 [user@dom0 ~]$ qvm-run -u root fedora-26-minimal xterm
 ~~~
 
-If you would like to skip this step in future, please install the `sudo` package:
-
-~~~
-[user@your-new-clone ~]$ dnf install sudo
-~~~
-
 In Qubes 4.0, additional packages from the `qubes-core-agent` suite may be needed to make the customized minimal template work properly. These packages are:
 
 - `qubes-core-agent-qrexec`: Qubes qrexec agent. Installed by default.
@@ -87,7 +81,8 @@ In Qubes 4.0, additional packages from the `qubes-core-agent` suite may be neede
 - `qubes-core-agent-sysvinit`: Qubes unit files for SysV init style or upstart.
 - `qubes-core-agent-networking`: Networking support. Useful if the template has to be used for a `sys-net` VM.
 - `qubes-core-agent-network-manager`: Integration for NetworkManager. Useful if the template has to be used for a `sys-net` VM.
-- `qubes-core-agent-dom0-updates`: Script required to handle `dom0` updates. Any template which the VM respondible for 'dom0' updates is based on must contain this package.
+- `qubes-core-agent-dom0-updates`: Script required to handle `dom0` updates. Any template which the VM responsible for 'dom0' updates (e.g. `sys-firewall`) is based on must contain this package.
+- `qubes-usb-proxy`: Required in minimal template for a USB qube (`sys-usb`) as well as in minimal template for any destination domains to which USB devices are to be attached (e.g `sys-net` if using USB network adapter).   
 - `pulseaudio-qubes`: Needed to have audio on the template VM.
 
 


### PR DESCRIPTION
for R4.0, removed incorrect `sudo` package install, added `qubes-usb-proxy` for usb qube source/sink to Qubes R4.0 (not sure if this should replace `qubes-input-proxy-sender` for all versions -- see [qubes-users thread here](https://groups.google.com/forum/#!topic/qubes-users/ltTbP7pFwdA)), and added `sys-firewall` to dom0 update domain for clarity.