### PR TITLE
formatting fixes

### DIFF
--- a/configuration/vpn.md
+++ b/configuration/vpn.md
@@ -65,23 +65,23 @@ This method is more involved than the one above, but has anti-leak features that
 1. Create a new VM, name it, click the ProxyVM radio button, and choose a color and template.
 
     ![Create\_New\_VM.png](/attachment/wiki/VPN/Create_New_VM.png)
-    
+
     Note: Do not enable NetworkManager in the ProxyVM, as it can interfere with the scripts' DNS features. If you enabled NetworkManager or used other methods in a previous attempt, do not re-use the old ProxyVM... Create a new one according to this step.
-    
+
     If your choice of TemplateVM doesn't already have the VPN client software, you'll need to install the software in the template before proceeding. Disable any auto-starting service that comes with the software package. For example for OpenVPN.
-    
-       sudo systemctl disable openvpn.service
-    
+
+    sudo systemctl disable openvpn.service
+
 You may also wish to install `nano` or another simple text editor for entering the scripts below.
 
 2.  Set up and test the VPN client.
 
 Make sure the VPN VM and its TemplateVM is not running.
-    
+
 Run a terminal (CLI) in the VPN VM -- this will start the VM. Then create a new `/rw/config/vpn` folder with.
-    
-        sudo mkdir /rw/config/vpn
-    
+
+    sudo mkdir /rw/config/vpn
+
 Copy your VPN config files to `/rw/config/vpn`. Your VPN config file should be named `openvpn-client.ovpn`) so you can use the scripts below as is without modification. Otherwise you would have to replace the file name. `openvpn-client.ovpn` contents:
 
 Files accompanying the main config such as `*.crt` and `*.pem` should also go to `/rw/config/vpn` folder.
@@ -92,50 +92,49 @@ The VPN scripts here are intended to work with commonly used `tun` interfaces, w
 
 Also, the config should route all traffic through your VPN's interface after a connection is created; For OpenVPN the directive for this is `redirect-gateway def1`.
 
-       sudo nano /rw/config/vpn/openvpn-client.ovpn
-       
+    sudo nano /rw/config/vpn/openvpn-client.ovpn
+
 Make sure it already includes or add:
 
-       redirect-gateway def1
+    redirect-gateway def1
 
 The VPN client may not be able to prompt you for credentials when connecting to the server. Create a file in the `/rw/config/vpn` folder with your credentials and using a directive. For example for OpenVPN, add:
 
-      auth-user-pass pass.txt
-      
- Save file `/rw/config/vpn/openvpn-client.ovpn`.
- 
- Make sure a `/rw/config/vpn/pass.txt` file actually exists.
- 
-      sudo nano /rw/config/vpn/pass.txt
- 
- Add:
- 
-        username
-        password
- 
- Replace `username` and `password` with your actual username and password.
- 
+    auth-user-pass pass.txt
+
+Save file `/rw/config/vpn/openvpn-client.ovpn`.
+
+Make sure a `/rw/config/vpn/pass.txt` file actually exists.
+
+    sudo nano /rw/config/vpn/pass.txt
+
+Add:
+
+    username
+    password
+
+Replace `username` and `password` with your actual username and password.
+
  __Test your client configuration:__ Run the client from a CLI prompt in the 'vpn' folder, preferably as root. For example:
-    
-       sudo openvpn --cd /rw/config/vpn --config openvpn-client.ovpn
-    
+
+    sudo openvpn --cd /rw/config/vpn --config openvpn-client.ovpn
+
 Watch for status messages that indicate whether the connection is successful and test from another VPN VM terminal window with `ping`.
 
-       ping 8.8.8.8
-       
+    ping 8.8.8.8
+
 `ping` can be aborted by pressing the two keys `ctrl` + `c` at the same time.
 
 DNS may be tested at this point by replacing addresses in `/etc/resolv.conf` with ones appropriate for your VPN (although this file will not be used when setup is complete). Diagnose any connection problems using resources such as client documentation and help from your VPN service provider.
-    
+
 Proceed to the next step when you're sure the basic VPN connection is working.
 
 3.  Create the DNS-handling script.
 
-        sudo nano /rw/config/vpn/qubes-vpn-handler.sh
-       
- Edit and add:
+    sudo nano /rw/config/vpn/qubes-vpn-handler.sh
 
-    ~~~
+Edit and add:
+
     #!/bin/bash
     set -e
     export PATH="$PATH:/usr/sbin:/sbin"
@@ -171,26 +170,23 @@ Proceed to the next step when you're sure the basic VPN connection is working.
 	su - -c 'notify-send "$(hostname): LINK IS DOWN !" --icon=dialog-error' user
 	;;
     esac
-    ~~~
 
 Save the script.
 
 Make it executable.
 
-       sudo chmod +x /rw/config/vpn/qubes-vpn-handler.sh
-    
+    sudo chmod +x /rw/config/vpn/qubes-vpn-handler.sh
+
 4.  Configure client to use the DNS handling script. Using openvpn as an example, edit the config.
 
-       sudo nano /rw/config/vpn/openvpn-client.ovpn
-       
- Add the following.
+    sudo nano /rw/config/vpn/openvpn-client.ovpn
 
-    ~~~
+Add the following.
+
     script-security 2
     up 'qubes-vpn-handler.sh up'
     down 'qubes-vpn-handler.sh down'
-    ~~~
-    
+
 Remove other instances of lines starting with `script-security`, `up` or `down` should there be any others.
 
 Save the script.
@@ -199,19 +195,18 @@ Save the script.
 
 5.  Set up iptables anti-leak rules.
 
-    Edit the firewall script.
-    
-       sudo nano /rw/config/qubes-firewall-user-script
-       
+Edit the firewall script.
+
+    sudo nano /rw/config/qubes-firewall-user-script
+
 Clear out the existing lines and add:
 
-	~~~
 	#!/bin/bash
 	#    Block forwarding of connections through upstream network device
 	#    (in case the vpn tunnel breaks):
 	iptables -I FORWARD -o eth0 -j DROP
 	iptables -I FORWARD -i eth0 -j DROP
-	
+
 	#    Block all outgoing traffic
 	iptables -P OUTPUT DROP
 	iptables -F OUTPUT
@@ -227,38 +222,35 @@ Clear out the existing lines and add:
 	#    Allow traffic from the `qvpn` group to the uplink interface (eth0);
 	#    Our VPN client will run with group `qvpn`.
     iptables -I OUTPUT -p all -o eth0 -m owner --gid-owner qvpn -j ACCEPT
-    ~~~
 
 Save the script.
 
 Make it executable.
 
-       sudo chmod +x /rw/config/qubes-firewall-user-script
+    sudo chmod +x /rw/config/qubes-firewall-user-script
 
 5.  Set up the VPN's autostart.
 
-       sudo nano /rw/config/rc.local
+    sudo nano /rw/config/rc.local
 
 Clear out the existing lines and add:
 
-    ~~~
     #!/bin/bash
     VPN_CLIENT='openvpn'
     VPN_OPTIONS='--cd /rw/config/vpn/ --config openvpn-client.ovpn --daemon'
-    
+
     su - -c 'notify-send "$(hostname): Starting $VPN_CLIENT..." --icon=network-idle' user
     groupadd -rf qvpn ; sleep 2s
     sg qvpn -c "$VPN_CLIENT $VPN_OPTIONS"
-    ~~~
-    
+
 If you are using anything other than OpenVPN, change the `VPN_CLIENT` and `VPN_OPTIONS` variables to match your VPN software.
 
 Save the script.
 
 Make it executable.
 
-       sudo chmod +x /rw/config/rc.local`
-    
+    sudo chmod +x /rw/config/rc.local`
+
 6. Restart the new VM! The link should then be established automatically with a popup notification to that effect.
 
 Usage
@@ -275,7 +267,7 @@ Then, configure AppVMs to use your new FirewallVM as their NetVM.
 If you want to update your TemplateVMs through the VPN, enable the `qubes-updates-proxy` service in your new FirewallVM.
 You can do this in the Services tab in Qubes VM Manager or on the command-line:
 
-    $ qvm-service -e <name> qubes-updates-proxy
+    qvm-service -e <name> qubes-updates-proxy
 
 Then, configure your templates to use your new FirewallVM as their NetVM.
 


### PR DESCRIPTION
Please merge https://github.com/QubesOS/qubes-doc/pull/540/files first.

https://www.qubes-os.org/doc/vpn/

* Is now showing `~~~` to be copied. Since all code after the `~~~` is properly intended, I assume the `~~~` can just be removed.

* Currently using `       ` (tabs included). Therefore three spaces are prepended in front of each command. Looks like this.

```
   sudo chmod +x /rw/config/vpn/qubes-vpn-handler.sh
```

I changed it to four spaces. (Figured out that markup from another documentation page that does not have this issue.)

* Replaced `$ qvm-service -e <name> qubes-updates-proxy` with `qvm-service -e <name> qubes-updates-proxy` for better consistency since all other commands on that page not referencing `$` either. Also, users get confused by `$` since nowhere an explanation that this means "run as user" is to be found. Since `$` is a special character, not even google will find an explanation easily.