### PR TITLE
vpn.md: disconnect-resistant fail closed configuration

### DIFF
--- a/configuration/vpn.md
+++ b/configuration/vpn.md
@@ -102,6 +102,11 @@ It has been tested with Fedora 23 and Debian 8 templates.
    Make sure it already includes or add:
 
        redirect-gateway def1
+   
+   Since we will be routing DNS queries to go through the VPN, the client will not be able to look up the server's IP if it disconnects, preventing it from reconnecting again.
+   To fix this, add the following to remember the initially resolved IP address:
+   
+       persist-remote-ip
 
    The VPN client may not be able to prompt you for credentials when connecting to the server.
    Create a file in the `/rw/config/vpn` folder with your credentials and using a directive.


### PR DESCRIPTION
If the connection to the VPN server drops long enough for it to be reinitiated (60s by default), the DNS lookup for the server will fail and prevent reestablishing the connection. `persist-remote-ip` reuses the IP from the previous connection.