### PR TITLE
Add note to enable qubes-firewall when template is used as FirewallVM

### DIFF
--- a/managing-os/templates/fedora-minimal.md
+++ b/managing-os/templates/fedora-minimal.md
@@ -86,6 +86,11 @@ In Qubes 4.0, additional packages from the `qubes-core-agent` suite may be neede
 - `qubes-usb-proxy`: Required if the template is to be used for a USB qube (`sys-usb`) or for any destination qube to which USB devices are to be attached (e.g `sys-net` if using USB network adapter).   
 - `pulseaudio-qubes`: Needed to have audio on the template VM.
 
+Make sure the qubes-firewall feature is enabled if the template is used as a FirewallVM (eg. sys-firewall):
+
+~~~
+[user@dom0 ~]$ qvm-features fedora-26-minimal qubes-firewall 1
+~~~
 
 Logging
 -------


### PR DESCRIPTION
When a FirewallVM is based on a template that doesn't have the qubes-firewall feature enabled the qubes settings gui of VMs connected to this FirewallVM will show an error message:

"The 'work' qube is network connected to 'sys-firewall', which does not
support firewall!
You may edit the 'work' qube firewall rules, but these will not take any
effect until you connect it to a working Firewall qube." 

The system seems to be fully functional though.

fix: enable the template's qubes-firewall feature.

ref:  https://groups.google.com/forum/#!topic/qubes-users/i08ZSoQLPUQ