### PR TITLE
doc.md add links to R4 content

### DIFF
--- a/doc.md
+++ b/doc.md
@@ -233,6 +233,8 @@ System
  * [Security-critical elements of Qubes OS](/doc/security-critical-code/)
  * [Qubes Core Admin](https://dev.qubes-os.org/projects/core-admin/en/latest/)
  * [Qubes Core Admin Client](https://dev.qubes-os.org/projects/core-admin-client/en/latest/)
+ * [Qubes Admin API](https://www.qubes-os.org/news/2017/06/27/qubes-admin-api/)
+ * [Qubes Core Stack](https://www.qubes-os.org/news/2017/10/03/core3/)
  * [Qrexec: command execution in VMs](/doc/qrexec3/)
  * [Qubes GUI virtualization protocol](/doc/gui/)
  * [Networking in Qubes](/doc/networking/)


### PR DESCRIPTION
Not sure if this is the best approach, or if the content should be pulled out into new /doc files.