### PR TITLE
Format Ubuntu version numbers correctly.

### DIFF
--- a/managing-os/templates/ubuntu.md
+++ b/managing-os/templates/ubuntu.md
@@ -30,9 +30,9 @@ To quickly prepare the builder configuration, you can use the `setup` script
 available in the repository - it will interactively ask you which templates you
 want to build.
 
-The build for Ubuntu 14.4 LTS (Trusty) should be straightforward.
+The build for Ubuntu 14.04 LTS (Trusty) should be straightforward.
 
-The build for Ubuntu 16.4 LTS (Xenial) is straightforward.
+The build for Ubuntu 16.04 LTS (Xenial) is straightforward.
 
 ----------
 


### PR DESCRIPTION
This formats mentions of Ubuntu version numbers.

Reference: https://wiki.ubuntu.com/Releases