### PR TITLE
Fix bash history expansion and scrypt args order

### DIFF
--- a/common-tasks/backup-emergency-restore-v4.md
+++ b/common-tasks/backup-emergency-restore-v4.md
@@ -45,8 +45,9 @@ The Qubes backup system has been designed with emergency disaster recovery in mi
 
  4. Verify integrity of `backup-header`. For compatibility reasons `backup-header.hmac` is in fact is an encrypted *and integrity protected* version of `backup-header`.
 
+        [user@restore ~]$ set +H
         [user@restore ~]$ echo "backup-header!$backup_pass" |\
-            scrypt -P dec backup-header.hmac backup-header.verified && \
+            scrypt dec -P backup-header.hmac backup-header.verified && \
             diff -qs backup-header backup-header.verified
         Files backup-header and backup-header.verified are identical
 
@@ -71,7 +72,7 @@ Recovery - format version 3](/doc/backup-emergency-restore-v3/)
         [user@restore ~]$ backup_id=20161020T123455-1234 # see backup-header above
         [user@restore ~]$ for f_enc in vm1/private.img.???.enc; do \
             f_dec=${f_enc%.enc}; \
-            echo "$backup_id!$f_dec!$backup_pass" | scrypt -P dec $f_enc $f_dec || break; \
+            echo "$backup_id!$f_dec!$backup_pass" | scrypt dec -P $f_enc $f_dec || break; \
             done
 
     **Note:** If the above fail, most likely your backup is corrupted, or been tampered with.


### PR DESCRIPTION
On a freshly installed and update 4.0 GA, I tried to follow this procedure and ran into 2 issues:
- Command `echo "backup-header!$backup_pass"` was broken because `!` and the following `$` were interpreted as bash history expansion
- `scrypt` command was complaining about the first parameter being restricted to `dec` or `enc`, moved `-P` switch to 2nd position

References:
- https://www.gnu.org/software/bash/manual/html_node/History-Interaction.html
- https://www.gnu.org/software/bash/manual/html_node/Event-Designators.html#Event-Designators
- https://sanctum.geek.nz/arabesque/bash-history-expansion/