### PR TITLE
uefi-troubleshooting add section about removing noexitboot and mapbs

### DIFF
--- a/troubleshooting/uefi-troubleshooting.md
+++ b/troubleshooting/uefi-troubleshooting.md
@@ -143,8 +143,40 @@ Ctrl-Alt-F2), or booting from installation media in "Rescue a Qubes system" mode
 
        efibootmgr -v -c -u -L Qubes -l /EFI/qubes/xen.efi -d /dev/sda -p 1 "placeholder /mapbs /noexitboot"
 
+
 Installation freezes before getting to Anaconda
 -----------------------------------------------
+
+Some systems can freeze with the default UEFI install options.
+You can try the following to remove `noexitboot` and `mapbs`.
+If you have an Nvidia card, see also [Nvidia Troubleshooting](/doc/nvidia-troubleshooting/#disabling-nouveau).
+
+1. Follow the [steps above](/doc/uefi-troubleshooting/#change-installer-kernel-parameters-in-uefi) to edit the `[qubes-verbose]` section of your installer's `xen.cfg`.
+   You want to comment out the `mapbs` and `noexitboot` lines.
+   The end result should look like this:
+   ~~~
+   [qubes-verbose]
+   options=console=vga efi=attr=uc
+   # noexitboot=1
+   # mapbs=1
+   kernel=vmlinuz inst.stage2=hd:LABEL=Qubes-R4.0-x86_64 i915.alpha_support=1
+   ramdisk=initrd.img
+   ~~~
+2. Boot the installer and continue to install as normal, but don't reboot the system at the end when prompted.
+3. Go to `tty2` (Ctrl-Alt-F2).
+4. Use your preferred text editor (`nano` works) to edit `/mnt/sysimage/boot/efi/EFI/qubes/xen.cfg`, verifying the `noexitboot` and `mapbs` lines are not present.
+This is also a good time to make permanent any other changes needed to get the installer to work, such as `nouveau.modeset=0`.
+   For example:
+   ~~~
+   [4.14.18-1.pvops.qubes.x86_64]
+   options=loglvl=all dom0_mem=min:1024M dom0_mem=max:4096M iommu=no-igfx ucode=scan efi=attr=uc
+   ~~~
+5. Go back to `tty6` (Ctrl-Alt-F6) and click `Reboot`.
+6. Continue with setting up default templates and logging in to Qubes.
+
+
+Installation freezes before getting to Anaconda / disable EFI runtime services
+------------------------------------------------------------------------------
 
 On some early, buggy UEFI implementations, you may need to disable EFI under Qubes completely.
 This can sometimes be done by switching to legacy mode in your BIOS/UEFI configuration.


### PR DESCRIPTION
a bit redundant with the immediately following section but less drastic