### PR TITLE
Make dd bs flag work for BSD/MacOS

### DIFF
--- a/installing/installation-guide.md
+++ b/installing/installation-guide.md
@@ -94,7 +94,7 @@ an installation medium.)
 If you prefer to use a USB drive, then you just need to copy the ISO onto the
 USB device, e.g. using `dd`:
 
-    dd if=Qubes-R3-x86_64.iso of=/dev/sdX bs=1M && sync
+    dd if=Qubes-R3-x86_64.iso of=/dev/sdX bs=1024 && sync
 
 Change `Qubes-R3-x86_64.iso` to the filename of the version you're installing,
 and change `/dev/sdX` to the correct target device (e.g., `/dev/sdc`).


### PR DESCRIPTION
BSD `dd` uses lowercase letters for the bs argument. https://www.unix.com/man-page/FreeBSD/1/dd/

This way of noting seemed most concise, but if you prefer having it more descriptive or as a full second command/section let me know. Thanks!