### PR TITLE
add link to qvm-expose-port issue

### DIFF
--- a/security/firewall.md
+++ b/security/firewall.md
@@ -194,6 +194,8 @@ network 192.168.x.0/24.
 
 > Note: To have all interfaces available and configured, make sure the 3 qubes are up and running
 
+> Note: [Issue #4028](https://github.com/QubesOS/qubes-issues/issues/4028) discusses adding a command to automate exposing the port.
+
 **1. Route packets from the outside world to the FirewallVM**
 
 From a Terminal window in sys-net VM, take note of the 'Interface name' and


### PR DESCRIPTION
https://github.com/QubesOS/qubes-issues/issues/4028

The purpose of adding this is to get more attention about
adding a command and possible contributors.