### PR TITLE
explain how to publish the key

### DIFF
--- a/basics_dev/code-signing.md
+++ b/basics_dev/code-signing.md
@@ -78,6 +78,14 @@ uid                  Bilbo Baggins <bilbo@shire.org>
 sub   4096R/69B0EA85 2013-03-13
 ~~~
 
+Upload the Key
+--------------
+
+For others to find the public key, please upload it to a server.
+
+```
+gpg --send-keys 69B0EA85
+```
 
 Using PGP with Git
 ------------------

--- a/basics_dev/code-signing.md
+++ b/basics_dev/code-signing.md
@@ -84,7 +84,8 @@ Upload the Key
 For others to find the public key, please upload it to a server.
 
 ```
-gpg --send-keys 69B0EA85
+$ gpg --send-keys --keyserver pool.sks-keyservers.net 69B0EA85
+gpg: sending key 488BA441 to hkp server pool.sks-keyservers.net
 ```
 
 Using PGP with Git


### PR DESCRIPTION
Problem: The key needs to be published in order for the
  signature-checker to work. (my guess)
Solution: Add a section about uploading the key to a server.