### PR TITLE
NM: start VPN automatically, fail-close

### DIFF
--- a/configuration/vpn.md
+++ b/configuration/vpn.md
@@ -68,6 +68,8 @@ Set up a ProxyVM as a VPN gateway using NetworkManager
    And substitute "XXXXXXXXXXXXXX" for the actual password.
    The contents of `passwd-file.txt` may differ depending on your VPN settings.  See the [documentation for `nmcli up`](https://www.mankier.com/1/nmcli#up).
    
+   Troubleshooting:  If you notice that the VPN doesn't autostart on hardware bootup but it does when restaring the VPN VM, try adding a slight delay in seconds in `/rw/config/rc.local` before the `nmcli` command, e.g. `sleep 2`.
+   
 5. (Optional) Make the network fail-close for the AppVMs if the connection to the VPN breaks.
 
    Edit `/rw/config/qubes-firewall-user-script` and add these lines:

--- a/configuration/vpn.md
+++ b/configuration/vpn.md
@@ -50,11 +50,39 @@ Set up a ProxyVM as a VPN gateway using NetworkManager
 
 3. Set up your VPN as described in the NetworkManager documentation linked above.
 
-4. Configure your AppVMs to use the new VM as a NetVM.
+4. Make your VPN start automatically.
+
+   Edit `/rw/config/rc.local` and add these lines:
+   
+   ```bash
+   # Automatically connect to the VPN
+   nmcli connection up file-vpn-conn passwd-file /rw/config/NM-system-connections/secrets/passwd-file.txt
+   ```
+   You can find the actual "file-vpn-conn" in `/rw/config/NM-system-connections/`.
+   
+   Create directory `/rw/config/NM-system-connections/secrets/` (You can put your `*.crt` and `*.pem` files here too).
+   Create a new file `/rw/config/NM-system-connections/secrets/passwd-file.txt`:
+   ```
+   vpn.secrets.password:XXXXXXXXXXXXXX
+   ```
+   And substitute "XXXXXXXXXXXXXX" for the actual password.
+   The contents of `passwd-file.txt` may differ depending on your VPN settings.  See the [documentation for `nmcli up`](https://www.mankier.com/1/nmcli#up).
+   
+5. Make the network fail-close for the AppVMs if the connection to the VPN breaks.
+
+   Edit `/rw/config/qubes-firewall-user-script` and add these lines:
+   ```bash
+   #    Block forwarding of connections through upstream network device
+   #    (in case the vpn tunnel breaks):
+   iptables -I FORWARD -o eth0 -j DROP
+   iptables -I FORWARD -i eth0 -j DROP
+   ```
+
+6. Configure your AppVMs to use the new VM as a NetVM.
 
    ![Settings-NetVM.png](/attachment/wiki/VPN/Settings-NetVM.png)
 
-5. Optionally, you can install some [custom icons](https://github.com/Zrubi/qubes-artwork-proxy-vpn) for your VPN
+7. Optionally, you can install some [custom icons](https://github.com/Zrubi/qubes-artwork-proxy-vpn) for your VPN
 
 
 Set up a ProxyVM as a VPN gateway using iptables and CLI scripts

--- a/configuration/vpn.md
+++ b/configuration/vpn.md
@@ -50,7 +50,7 @@ Set up a ProxyVM as a VPN gateway using NetworkManager
 
 3. Set up your VPN as described in the NetworkManager documentation linked above.
 
-4. Make your VPN start automatically.
+4. (Optional) Make your VPN start automatically.
 
    Edit `/rw/config/rc.local` and add these lines:
    
@@ -68,7 +68,7 @@ Set up a ProxyVM as a VPN gateway using NetworkManager
    And substitute "XXXXXXXXXXXXXX" for the actual password.
    The contents of `passwd-file.txt` may differ depending on your VPN settings.  See the [documentation for `nmcli up`](https://www.mankier.com/1/nmcli#up).
    
-5. Make the network fail-close for the AppVMs if the connection to the VPN breaks.
+5. (Optional) Make the network fail-close for the AppVMs if the connection to the VPN breaks.
 
    Edit `/rw/config/qubes-firewall-user-script` and add these lines:
    ```bash

--- a/configuration/vpn.md
+++ b/configuration/vpn.md
@@ -55,7 +55,8 @@ Set up a ProxyVM as a VPN gateway using NetworkManager
    Edit `/rw/config/rc.local` and add these lines:
    
    ```bash
-   # Automatically connect to the VPN
+   # Automatically connect to the VPN once Internet is up
+   for i in {1..50}; do ping -c1 1.1.1.1 &> /dev/null && break; done
    nmcli connection up file-vpn-conn passwd-file /rw/config/NM-system-connections/secrets/passwd-file.txt
    ```
    You can find the actual "file-vpn-conn" in `/rw/config/NM-system-connections/`.
@@ -67,8 +68,6 @@ Set up a ProxyVM as a VPN gateway using NetworkManager
    ```
    And substitute "XXXXXXXXXXXXXX" for the actual password.
    The contents of `passwd-file.txt` may differ depending on your VPN settings.  See the [documentation for `nmcli up`](https://www.mankier.com/1/nmcli#up).
-   
-   Troubleshooting:  If you notice that the VPN doesn't autostart on hardware bootup but it does when restaring the VPN VM, try adding a slight delay in seconds in `/rw/config/rc.local` before the `nmcli` command, e.g. `sleep 2`.
    
 5. (Optional) Make the network fail-close for the AppVMs if the connection to the VPN breaks.
 

--- a/configuration/vpn.md
+++ b/configuration/vpn.md
@@ -56,7 +56,7 @@ Set up a ProxyVM as a VPN gateway using NetworkManager
    
    ```bash
    # Automatically connect to the VPN once Internet is up
-   for i in {1..50}; do ping -c1 1.1.1.1 &> /dev/null && break; done
+   nm-online --quiet --wait-for-startup
    nmcli connection up file-vpn-conn passwd-file /rw/config/NM-system-connections/secrets/passwd-file.txt
    ```
    You can find the actual "file-vpn-conn" in `/rw/config/NM-system-connections/`.


### PR DESCRIPTION
When configuring with NetworkManager, make VPN start automatically and fail-close the connection.

Editing the connection `VM uplink eth0` won't persist between VM reboots.