### PR TITLE
Add IPv6 failsafe

### DIFF
--- a/configuration/vpn.md
+++ b/configuration/vpn.md
@@ -212,6 +212,8 @@ It has been tested with Fedora 23 and Debian 8 templates.
    #    (in case the vpn tunnel breaks):
    iptables -I FORWARD -o eth0 -j DROP
    iptables -I FORWARD -i eth0 -j DROP
+   ip6tables -I FORWARD -o eth0 -j DROP
+   ip6tables -I FORWARD -i eth0 -j DROP
    
    #    Block all outgoing traffic
    iptables -P OUTPUT DROP


### PR DESCRIPTION
While we're waiting for qubes-tunnel and new instructions to be approved, it would be a good idea to extend failsafe to IPv6. This is not an issue for R3.2, but R4.0 does allow IPv6 traffic.