### PR TITLE
Update emergency backup restore documentation

### DIFF
--- a/common-tasks/backup-emergency-restore-v2.md
+++ b/common-tasks/backup-emergency-restore-v2.md
@@ -1,14 +1,14 @@
 ---
 layout: doc
-title: Emergency Backup Recovery - format version 2
+title: Emergency Backup Recovery (v2)
 permalink: /doc/backup-emergency-restore-v2/
 redirect_from:
 - /en/doc/backup-emergency-restore-v2/
 - /doc/BackupEmergencyRestoreV2/
 ---
 
-Emergency Backup Recovery without Qubes - format version 2
-==========================================================
+Emergency Backup Recovery without Qubes (v2)
+============================================
 
 This page describes how to perform emergency restore of backup created on Qubes
 R2 Beta3 or earlier (which uses backup format 2).

--- a/common-tasks/backup-emergency-restore-v3.md
+++ b/common-tasks/backup-emergency-restore-v3.md
@@ -1,14 +1,14 @@
 ---
 layout: doc
-title: Emergency Backup Recovery - format version 3
+title: Emergency Backup Recovery (v3)
 permalink: /doc/backup-emergency-restore-v3/
 redirect_from:
 - /en/doc/backup-emergency-restore-v3/
 - /doc/BackupEmergencyRestoreV3/
 ---
 
-Emergency Backup Recovery without Qubes - format version 3
-==========================================================
+Emergency Backup Recovery without Qubes (v3)
+============================================
 
 This page describes how to perform an emergency restore of a backup created on
 Qubes R2 or later (which uses backup format version 3).


### PR DESCRIPTION
- Add instructions for obtaining scrypt binary
- Use shorter notation for backup format versions
- Use reference-style links
- Fix numbering
- Clarify backup_id step
- Make language more consistent

Closes QubesOS/qubes-issues#4047