### PR TITLE
s/python-sh/python2-sh/

### DIFF
--- a/building/building-archlinux-template.md
+++ b/building/building-archlinux-template.md
@@ -59,7 +59,7 @@ redirect_from:
 
     *   rpmdevtools
 
-    *   python-sh
+    *   python2-sh
 
     *   dialog
 
@@ -70,7 +70,7 @@ redirect_from:
 
 *   The tools can usually be installed all together with the following terminal command string:
 
-    *   **$ sudo dnf install git createrepo rpm-build make wget rpmdevtools python-sh dialog rpm-sign gnupg**
+    *   **$ sudo dnf install git createrepo rpm-build make wget rpmdevtools python2-sh dialog rpm-sign gnupg**
 <br>
 <br>
 ![arch-template-04](/attachment/wiki/ArchlinuxTemplate/arch-template-04.png)

--- a/building/qubes-builder.md
+++ b/building/qubes-builder.md
@@ -27,7 +27,7 @@ In order to use it, one should use an rpm-based distro, like Fedora :), and shou
 -   make
 -   wget
 -   rpmdevtools
--   python-sh
+-   python2-sh
 -   dialog
 -   rpm-sign
 -   dpkg-dev
@@ -36,7 +36,7 @@ In order to use it, one should use an rpm-based distro, like Fedora :), and shou
 
 Usually one can install those packages by just issuing:
 
-    sudo dnf install gpg git createrepo rpm-build make wget rpmdevtools python-sh dialog rpm-sign dpkg-dev debootstrap PyYAML
+    sudo dnf install gpg git createrepo rpm-build make wget rpmdevtools python2-sh dialog rpm-sign dpkg-dev debootstrap PyYAML
 
 The build system creates build environments in chroots and so no other packages are needed on the host. All files created by the build system are contained within the qubes-builder directory. The full build requires some 25GB of free space, so keep that in mind when deciding where to place this directory.
 


### PR DESCRIPTION
Was replaced in qubes-builder in commits:
- f25bf99f63d908ebfc40af0c506ed508eb35ff21
- 436636d08d0aa4e63f12f1e0413d4bbb76d125e9
- fe67e382e7f2b3cb92bc83977b00810bbe11685e

This just updates docs to match.