### PR TITLE
Replace kali key short id with fingerprint

### DIFF
--- a/managing-os/pentesting/kali.md
+++ b/managing-os/pentesting/kali.md
@@ -214,9 +214,9 @@ access can change this configuration in firewall settings for the TemplateVM.
 
 1. Retrive the Kali Linux GPG key using a DispVM.
 
-        [user@xxxx-dvm ~]$ gpg --keyserver hkp://keys.gnupg.net --recv-key 7D8D0BF6
-        [user@xxxx-dvm ~]$ gpg --list-keys --with-fingerprint 7D8D0BF6 
-        [user@xxxx-dvm ~]$ gpg --export --armor 7D8D0BF6 > kali-key.asc
+        [user@xxxx-dvm ~]$ gpg --keyserver hkp://keys.gnupg.net --recv-key 44C6513A8E4FB3D30875F758ED444FF07D8D0BF6
+        [user@xxxx-dvm ~]$ gpg --list-keys --with-fingerprint 44C6513A8E4FB3D30875F758ED444FF07D8D0BF6 
+        [user@xxxx-dvm ~]$ gpg --export --armor 44C6513A8E4FB3D30875F758ED444FF07D8D0BF6 > kali-key.asc
 
 2. **DO NOT TURN OFF** the DispVM, the `kali-key.asc` file will be copied to
    the Kali Linux template in a further step.
@@ -492,9 +492,9 @@ access can change this configuration in firewall settings for the TemplateVM.
 
 1. Retrive the Kali Linux GPG key using a DispVM.
 
-        [user@xxxx-dvm ~]$ gpg --keyserver hkp://keys.gnupg.net --recv-key 7D8D0BF6
-        [user@xxxx-dvm ~]$ gpg --list-keys --with-fingerprint 7D8D0BF6 
-        [user@xxxx-dvm ~]$ gpg --export --armor 7D8D0BF6 > kali-key.asc
+        [user@xxxx-dvm ~]$ gpg --keyserver hkp://keys.gnupg.net --recv-key 44C6513A8E4FB3D30875F758ED444FF07D8D0BF6
+        [user@xxxx-dvm ~]$ gpg --list-keys --with-fingerprint 44C6513A8E4FB3D30875F758ED444FF07D8D0BF6 
+        [user@xxxx-dvm ~]$ gpg --export --armor 44C6513A8E4FB3D30875F758ED444FF07D8D0BF6 > kali-key.asc
 
 2. **DO NOT TURN OFF** the DispVM, the `kali-key.asc` file will be copied to
    the Kali Linux template in a further step.


### PR DESCRIPTION
Currently the doc for installing Kali advises to use the short id in all places when referring to the Kali signing key. This PR changes the short id to the full fingerprint, which can be cross referenced on the Kali [site](https://docs.kali.org/introduction/download-official-kali-linux-images).

Use of short id is a potential security issue since there are known collisions [[1](https://security.stackexchange.com/questions/84280/short-openpgp-key-ids-are-insecure-how-to-configure-gnupg-to-use-long-key-ids-i)] [[2](https://security.stackexchange.com/questions/74009/what-is-an-openpgp-key-id-collision/74010)].

Even though the docs instruct the user to verify that they have received the correct key from a secondary source, there is no instructions on what to do if they have the wrong key. That would most likely be out of scope for this guide. Therefore, IMHO, we should attempt to avoid fostering the retrieval of an incorrect key and at the same time promote best security practices.