### PR TITLE
Added note on memory for Tails

### DIFF
--- a/privacy/tails.md
+++ b/privacy/tails.md
@@ -25,6 +25,7 @@ To run Tails under Qubes:
     - In Manager, click "VM menu" and select "Create VM"
     - Name the new qube - "Tails"
     - Select "HVM"
+    - Set "initial memory" and "max memory" as the same ([official documentation](https://tails.boum.org/doc/about/requirements/index.en.html) recommends at least 2048 MB)
     - Configure networking
     - Click "OK" to create new HVM.
 


### PR DESCRIPTION
As mentioned [here](https://github.com/QubesOS/qubes-issues/issues/3339#issuecomment-419736808) it is important that initial memory and max memory of a Tails qube to be the same. This PR proposes adding a line mentioning such requirement at the [Tails page](https://www.qubes-os.org/doc/tails/).