### PR TITLE
Fix misformating in Split GPG doc

### DIFF
--- a/security/split-gpg.md
+++ b/security/split-gpg.md
@@ -78,10 +78,10 @@ there? To Be Determined.
 GnuPG backend is protected by a passphrase, it will give a *"Inappropriate ioctl
 for device"* error. Avoid setting passphrases for the private keys in the GPG
 backend domain, it won't provide extra security anyway, as explained before. If
-you have a private key that already has a passphrase set use `gpg2 --edit-key
-<key_id>`, then `passwd` to set an empty passphrase. Be aware that
-`pinentry-ncurses` doesn't allow setting empty passphrases, so you would need to
-install `pinentry-gtk` for it to work.
+you have a private key that already has a passphrase set use
+`gpg2 --edit-key {key_id}`, then `passwd` to set an empty passphrase. Be aware
+that `pinentry-ncurses` doesn't allow setting empty passphrases, so you would need
+to install `pinentry-gtk` for it to work.
 
 ## Configuring Split GPG ##
 


### PR DESCRIPTION
An error was introduced in pull request #717.

![qubes doc split gpg misformat](https://user-images.githubusercontent.com/71658/47448948-e4f0c380-d7b0-11e8-98da-21cc8eb4a69b.png)