### PR TITLE
Added documentation for qvm-device and derived commands

### DIFF
--- a/reference/tools/4.0/dom0.md
+++ b/reference/tools/4.0/dom0.md
@@ -12,3 +12,8 @@ Reference pages for these tools are available here:
  * <https://dev.qubes-os.org/projects/core-admin/en/latest/manpages/>
  * <https://dev.qubes-os.org/projects/core-admin-client/en/latest/manpages/>
 
+ * [qvm-device](/doc/tools/4.0/dom0/qvm-device/)
+ * [qvm-pci](/doc/tools/4.0/dom0/qvm-pci/)
+ * [qvm-usb](/doc/tools/4.0/dom0/qvm-usb/)
+ * [qvm-block](/doc/tools/4.0/dom0/qvm-block/)
+

--- a/reference/tools/4.0/dom0/qvm-block.md
+++ b/reference/tools/4.0/dom0/qvm-block.md
@@ -1,0 +1,74 @@
+---
+layout: doc
+title: qvm-block
+permalink: /doc/tools/4.0/dom0/qvm-block/
+redirect_from:
+- /doc/dom0-tools/qvm-block/
+- /doc/dom0-tools/qvm-block/
+- /en/doc/dom0-tools/qvm-block/
+- /doc/Dom0Tools/QvmBlock/
+- /wiki/Dom0Tools/QvmBlock/
+---
+
+#qvm-block
+
+##Synopsis
+
+    qvm-block [COMMAND] [OPTIONS] <target-vm-name> <block-vm-name>:<device>
+
+`qvm-block` is an alias for `qvm-device block`. [`qvm-device`](/doc/tools/4.0/dom0/qvm-device/) offers a generalised interface for attachment and detachment of devices (in the case of `qvm-block` block devices), only the options specific to `qvm-block` will be discussed here.
+
+##Usage
+
+Please follow the [`qvm-device`](/doc/tools/4.0/dom0/qvm-device/) documentation for general usage.
+
+See also [handling USB-devices](/doc/usb/#r40) for a quick guide of the most common use-case.
+
+##Options Specific to Block-Devices
+
+These options can be specified using the `-o` or `--option` handle. The general syntax is
+
+    qvm-block a -o <option=value>[ -o <option=value>[...]] <target-vm> <source-vm>:<device-id>
+
+###frontend-dev
+Specify device node in target domain.
+
+Possible values are non-space strings.
+
+Default is first available, starting from `xvdi`.
+
+###read-only
+Attach block-device in read-only mode. If device itself is read-only, only read-only attach is allowed.
+
+Possible values are `True` and `False`.
+
+Default is `False`, if read-write attachment is possible.
+
+###devtype
+Type of device
+
+Possible Values are `disk` adn `cdrom`.
+
+Default: `disk`
+
+##Deprecated --attach-file option
+Up until Qubes 3.2, `qvm-block` exposed an option to attach a [file as block-device](/doc/tools/3.2/dom0/qvm-block/) to another VM. Qubes 4.0 does _not_ support this behavior. As a workaround, `losetup` can be used in linux VMs.
+
+In the linux-source VM run
+
+    sudo losetup /dev/loop0 /path/to/file
+
+(Where `loop0` is just a generic device-id.)
+Afterwards, run `qvm-block` in dom0 to list known block devices. The newly created loopdevice should show up:
+
+    ~]$ qvm-block
+    BACKEND:DEVID  DESCRIPTION  USED BY
+    <source-vm>:loop0 /path/to/file
+
+You can now attach the `loop0`-device to any other vm using `qvm-block` as usual
+
+    qvm-block a <target-vm> <source-vm>:loop0
+
+After detaching the the device again, detach the loopdevice within the source-vm:
+
+    sudo losetup -d /dev/loop0

--- a/reference/tools/4.0/dom0/qvm-block.md
+++ b/reference/tools/4.0/dom0/qvm-block.md
@@ -47,7 +47,7 @@ Default is `False`, if read-write attachment is possible.
 ###devtype
 Type of device
 
-Possible Values are `disk` adn `cdrom`.
+Possible Values are `disk` and `cdrom`.
 
 Default: `disk`
 
@@ -59,7 +59,7 @@ In the linux-source VM run
     sudo losetup /dev/loop0 /path/to/file
 
 (Where `loop0` is just a generic device-id.)
-Afterwards, run `qvm-block` in dom0 to list known block devices. The newly created loopdevice should show up:
+Afterwards, run `qvm-block` in dom0 to list known block devices. The newly created loop-device should show up:
 
     ~]$ qvm-block
     BACKEND:DEVID  DESCRIPTION  USED BY
@@ -69,6 +69,6 @@ You can now attach the `loop0`-device to any other vm using `qvm-block` as usual
 
     qvm-block a <target-vm> <source-vm>:loop0
 
-After detaching the the device again, detach the loopdevice within the source-vm:
+After detaching the the device again, detach the loop-device within the source-vm:
 
     sudo losetup -d /dev/loop0

--- a/reference/tools/4.0/dom0/qvm-device.md
+++ b/reference/tools/4.0/dom0/qvm-device.md
@@ -15,8 +15,7 @@ Possible device classes are:
  - [pci](/doc/tools/4.0/dom0/qvm-pci/) (Alias for `qvm-device pci` is `qvm-pci`.)
  - [usb](/doc/tools/4.0/dom0/qvm-usb/) (Alias for `qvm-device usb` is `qvm-usb`.)
  - [block](/doc/tools/4.0/dom0/qvm-block/) (Alias for `qvm-device block` is `qvm-block`.)
- - mic
- - **?**
+ - mic (No alias)
 
 ##Commands
 
@@ -32,7 +31,7 @@ Optionally accepts a list of source-vms. Lists devices found in all vms if omitt
 ####Command Specific Options:
 
 #####`--all`
-Used instead of source-vm list. **[Does this take precedence over a given list?]**
+Equivalent to listing all existing source-vms. Currently, supplying a list of VMs will also list attached devices even if not present in the system. This might be a [bug](https://github.com/QubesOS/qubes-doc/pull/746#issuecomment-445350618).
 
 #####`--exclude`
 Exclude list of following VMs from listing. Only valid in conjunction with `--all`. **[WHY?]**
@@ -46,13 +45,16 @@ Syntax:
 
 Requires target-vm, source-vm and device-id. The attached device will be available in target-vm. **[Will it stay available in source-vm? To what degree]**
 
+####General Note on Attaching Devices
+Attaching devices to a qube increases attack-surface. It is advised to use the smallest unit to attach. If possible, attach a single block device. If the whole usb-stack is required, attach a single usb device. Please read up on the [security implications of using USB passthrough](https://blog.invisiblethings.org/2011/05/31/usb-security-challenges.html).
+
 ####Command Specific Options:
 
 #####`--option`, `-o`
 Specify device-specific options (see [qvm-pci](/doc/tools/4.0/dom0/qvm-pci/) and [qvm-block](/doc/tools/4.0/dom0/qvm-block/)) using `name=value` format. Specify this option multiple times to set multiple device-specific options.
 
 ####`--persistent`, `-p`
-Attach device automatically to the qube, **not tested/may be wrong** once both the source-vm and target-vm are started, even after reboot.**[What happens when source-vm doesn't expose device?]**
+Attach device automatically to the qube when it starts. If the device isn't available, startup will fail.
 
 ###`detach`, `dt`, `d`
 Detach device of given device-id found in source-vm from target-vm.

--- a/reference/tools/4.0/dom0/qvm-device.md
+++ b/reference/tools/4.0/dom0/qvm-device.md
@@ -1,0 +1,76 @@
+---
+layout: doc
+title: qvm-device
+permalink: /doc/tools/4.0/dom0/qvm-device/
+---
+
+#qvm-device
+
+##Synopsis
+
+    qvm-device [DEVICE_CLASS] [COMMAND] <target-vm> <source-vm>:<device-id> [OPTIONS]
+
+##Device Classes
+Possible device classes are:
+ - [pci](/doc/tools/4.0/dom0/qvm-pci/) (Alias for `qvm-device pci` is `qvm-pci`.)
+ - [usb](/doc/tools/4.0/dom0/qvm-usb/) (Alias for `qvm-device usb` is `qvm-usb`.)
+ - [block](/doc/tools/4.0/dom0/qvm-block/) (Alias for `qvm-device block` is `qvm-block`.)
+ - mic
+ - **?**
+
+##Commands
+
+###`list`, `ls`, `l`
+List available devices of specified class. Output will show 
+
+Syntax:
+
+    qvm-device [DEVICE_CLASS] list [<source-vm>[ <source-vm>[...]]] [OPTIONS]
+
+Optionally accepts a list of source-vms. Lists devices found in all vms if omitted.
+
+####Command Specific Options:
+
+#####`--all`
+Used instead of source-vm list. **[Does this take precedence over a given list?]**
+
+#####`--exclude`
+Exclude list of following VMs from listing. Only valid in conjunction with `--all`. **[WHY?]**
+
+###`attach`, `at`, `a`
+Attach device of given device-id found in source-vm to target-vm.
+
+Syntax:
+
+    qvm-device [DEVICE_CLASS] attach <target-vm> <source-vm>:<device-id> [OPTIONS]
+
+Requires target-vm, source-vm and device-id. The attached device will be available in target-vm. **[Will it stay available in source-vm? To what degree]**
+
+####Command Specific Options:
+
+#####`--option`, `-o`
+Specify device-specific options (see [qvm-pci](/doc/tools/4.0/dom0/qvm-pci/) and [qvm-block](/doc/tools/4.0/dom0/qvm-block/)) using `name=value` format. Specify this option multiple times to set multiple device-specific options.
+
+####`--persistent`, `-p`
+Attach device automatically to the qube, **not tested/may be wrong** once both the source-vm and target-vm are started, even after reboot.**[What happens when source-vm doesn't expose device?]**
+
+###`detach`, `dt`, `d`
+Detach device of given device-id found in source-vm from target-vm.
+
+Syntax:
+
+    qvm-device [DEVICE_CLASS] detach <target-vm> <source-vm>:<device-id> [OPTIONS]
+
+Requires target-vm, source-vm and device-id. The detached device will no longer be available in the target-vm.
+
+##General Options
+These options apply to all devices and commands.
+
+###`--verbose`, `-v`
+increase verbosity during command-completion.
+
+###`--quiet`, `-q`
+decrease verbosity during command-completion.
+
+###`--help`, `-h`
+Show help-message

--- a/reference/tools/4.0/dom0/qvm-pci.md
+++ b/reference/tools/4.0/dom0/qvm-pci.md
@@ -1,0 +1,45 @@
+---
+layout: doc
+title: qvm-pci
+permalink: /doc/tools/4.0/dom0/qvm-pci/
+redirect_from:
+- /doc/dom0-tools/qvm-pci/
+- /en/doc/dom0-tools/qvm-pci/
+- /doc/Dom0Tools/QvmPci/
+- /wiki/Dom0Tools/QvmPci/
+---
+
+#qvm-pci
+
+##Synopsis
+
+    qvm-pci [COMMAND] [OPTIONS] <target-vm-name> <block-vm-name>:<device>
+
+`qvm-pci` is an alias for `qvm-device usb`. [`qvm-device`](/doc/tools/4.0/dom0/qvm-device/) offers a generalised interface for attachment and detachment of devices (in the case of `qvm-pci` usb devices).
+
+##Usage
+
+**BEWARE:** Only dom0 exposes PCI-devices and some, like host bridge, are strictly required to stay in dom0.
+Move ahead if you know what your doing and/or this documentation specifically called for it.
+
+Please follow the [`qvm-device`](/doc/tools/4.0/dom0/qvm-device/) documentation for general usage.
+
+See also [assigning PCI-devices](/doc/assigning-devices/#r40) for a quick guide of the most common use-case.
+
+
+##Options Specific to PCI-Devices
+
+These options can be specified using the `-o` or `--option` handle. The general syntax is
+
+    qvm-pci a -o <option=value>[ -o <option=value>[...]] <target-vm> dom0:<device-id>
+
+###no-strict-reset
+Allow attaching device even if no reliable reset-method is supported.
+Switching non-resetable devices poses a security risk, as VM-isolation is weakened.
+
+Possible values are `True` and `False`.
+
+Default value is `False`.
+
+###permissive
+#TODO: What's the difference to no-strict-reset?

--- a/reference/tools/4.0/dom0/qvm-pci.md
+++ b/reference/tools/4.0/dom0/qvm-pci.md
@@ -35,7 +35,7 @@ These options can be specified using the `-o` or `--option` handle. The general 
 
 ###no-strict-reset
 Allow attaching device even if no reliable reset-method is supported.
-Switching non-resetable devices poses a security risk, as VM-isolation is weakened.
+Switching non-resettable devices poses a security risk, as VM-isolation is weakened.
 
 Possible values are `True` and `False`.
 

--- a/reference/tools/4.0/dom0/qvm-pci.md
+++ b/reference/tools/4.0/dom0/qvm-pci.md
@@ -42,4 +42,10 @@ Possible values are `True` and `False`.
 Default value is `False`.
 
 ###permissive
-#TODO: What's the difference to no-strict-reset?
+Allow write access to most of PCI config space, instead of only selected whitelisted registers.
+A workaround for some PCI passthrough problems, potentially unsafe though!
+
+
+Possible values are `True` and `False`.
+
+Default value is `False`.

--- a/reference/tools/4.0/dom0/qvm-usb.md
+++ b/reference/tools/4.0/dom0/qvm-usb.md
@@ -17,7 +17,7 @@ redirect_from:
 
 ##Usage
 
-Please follow the [`qvm-device`](/doc/tools/4.0/dom0/qvm-device/) documentation for general usage.
+Please follow the [`qvm-device`](/doc/tools/4.0/dom0/qvm-device/) documentation for general usage. Additional information and examples can be found in the [usb handling in qubes documentation](/doc/usb/#attaching-a-single-usb-device-to-a-qube-usb-passthrough).
 
 Attaching a USB-device instead of just block-devices to a VM enables non-storage applications of USB-devices, e.g. webcams, microcontroller-programming, wifi- and bluetooth dongles, etc.
 

--- a/reference/tools/4.0/dom0/qvm-usb.md
+++ b/reference/tools/4.0/dom0/qvm-usb.md
@@ -1,0 +1,25 @@
+---
+layout: doc
+title: qvm-usb
+permalink: /doc/tools/4.0/dom0/qvm-usb/
+redirect_from:
+- /doc/dom0-tools/qvm-usb/
+- /en/doc/dom0-tools/qvm-usb/
+---
+
+#qvm-usb
+
+##Synopsis
+
+    qvm-usb [COMMAND] [OPTIONS] <target-vm-name> <block-vm-name>:<device>
+
+`qvm-usb` is an alias for `qvm-device usb`. [`qvm-device`](/doc/tools/4.0/dom0/qvm-device/) offers a generalised interface for attachment and detachment of devices (in the case of `qvm-usb` usb devices).
+
+##Usage
+
+Please follow the [`qvm-device`](/doc/tools/4.0/dom0/qvm-device/) documentation for general usage.
+
+Attaching a USB-device instead of just block-devices to a VM enables non-storage applications of USB-devices, e.g. webcams, microcontroller-programming, wifi- and bluetooth dongles, etc.
+
+##Options Specific to USB-Devices
+There are no USB-specific options.


### PR DESCRIPTION
After raising the [issue of missing documentation](https://github.com/QubesOS/qubes-issues/issues/4530#issuecomment-441106070) for qvm-device, qvm-pci, qvm-usb and qvm-block, I decided to write down what the manpage told me plus some information from the mailinglist (mainly the losetup-trick documented in qvm-block).

However, there is a lot I don't know which would need someone more knowledgeable than myself to fill in:
 - What are the possible device-classes? I know of at least `mic` which isn't documented in the manpage. (in qvm-device.md)
 - What's the idea behind the `--all` option? Isn't this default-behavior? Why is it required when using `--exclude`? (in qvm-device.md)
 - How does `persistent` behave? Especially, when does Qubes try to attach a device again? Only when both VMs and device are available? When both VMs are available? What do the fail-states look like? (in qvm-device.md)
 - What's the difference between `no-strict-reset` and `permissive`? (in qvm-pci.md)
 - I'm unsure as to what's the threat-model / security considerations behind using qvm-block over qvm-usb over qvm-pci. Using qvm-usb compared to qvm-pci is convenient, but is there a disadvantage of using qvm-usb over qvm-block?
 - I created the files by copying existing 3.2 documentation. I'm not sure weather the "redirect_from" headers are version-specific, so maybe they need to be removed.

This does NOT close the mentioned issue, since the qvm-device interface still should be reworked to be more intuitive.

P.S.: Someone should probably check spelling.