### PR TITLE
GSoC Idea: Porting Qubes to ARM/aarch64

### DIFF
--- a/basics_dev/gsoc.md
+++ b/basics_dev/gsoc.md
@@ -455,22 +455,22 @@ details in [#2618](https://github.com/QubesOS/qubes-issues/issues/2618).
 
 **Project**: Qubes Converters
 
-**Brief explanation**: One of the pioneering ideas of Qubes is to use disposable virtual machines to convert untrustworthy files (such as documents given to journalists by unknown and potentially malicious whistleblowers) into trusthworhty files.  See [Joanna's blog on the Qubes PDF Convert](http://theinvisiblethings.blogspot.co.uk/2013/02/converting-untrusted-pdfs-into-trusted.html) for details of the idea.  Joanna has implemented a prototype for PDF documents.  The goal of this project would be to generalize beyond the simple prototype to accommodate a wide variety of file formats, including Word documents, audio files, video files, spreadsheets, and so on.  The converters should prioritise safety over faithful conversion.  For example the Qubes PDF converter typically leads to lower quality PDFs (e.g. cut and paste is no longer possible), because this makes the conversion process safer.
+**Brief explanation**: One of the pioneering ideas of Qubes is to use disposable virtual machines to convert untrustworthy files (such as documents given to journalists by unknown and potentially malicious whistleblowers) into trustworthy files.  See [Joanna's blog on the Qubes PDF Convert](http://theinvisiblethings.blogspot.co.uk/2013/02/converting-untrusted-pdfs-into-trusted.html) for details of the idea.  Joanna has implemented a prototype for PDF documents.  The goal of this project would be to generalize beyond the simple prototype to accommodate a wide variety of file formats, including Word documents, audio files, video files, spreadsheets, and so on.  The converters should prioritise safety over faithful conversion.  For example the Qubes PDF converter typically leads to lower quality PDFs (e.g. cut and paste is no longer possible), because this makes the conversion process safer.
 
 **Expected results**: We expect that in the timeframe, it will be possible to implement many converters for many file formats.  However, if any unexpected difficulties arise, we would prioritise a small number of safe and high quality converters over a large number of unsafe or unuseful converters.
 
-**Knowledge prerequisite**: Most of the coding will probably be implemented as shell scripts to interface with pre-existing converts (such as ImageMagick in the Qubes PDF converter).  However, shell scripts are not safe for processing untrusted data, so any extra processing will need to be implemented in another language -- probably Python.
+**Knowledge prerequisite**: Most of the coding will probably be implemented as shell scripts to interface with pre-existing converters (such as ImageMagick in the Qubes PDF converter).  However, shell scripts are not safe for processing untrusted data, so any extra processing will need to be implemented in another language -- probably Python.
 
 **Mentors**: Andrew Clausen and Jean-Philippe Ouellet
 
 ### Mitigate focus-stealing attacks
 **Project**: Mitigate focus-stealing attacks
 
-**Brief explanation**: [Focus stealing attacks](https://en.wikipedia.org/wiki/Focus_stealing) have long been an issue in Qubes OS. The Qubes community has long punted the issue due to having higher priority things to work on, and it being viewed as the responsability of the window manager, but nevertheless it remains a serious issue, and an *effective* mitigation would be most welcome. Any student wishing to work on this would need to engage the community in a discussion about the effectiveness of their proposed earlier rather than later. [#1166](https://github.com/QubesOS/qubes-issues/issues/1166)
+**Brief explanation**: [Focus stealing attacks](https://en.wikipedia.org/wiki/Focus_stealing) have long been an issue in Qubes OS. The Qubes community has long punted the issue due to having higher priority things to work on, and it being viewed as the responsibility of the window manager, but nevertheless it remains a serious issue, and an *effective* mitigation would be most welcome. Any student wishing to work on this would need to engage the community in a discussion about the effectiveness of their proposed solution earlier rather than later. [#1166](https://github.com/QubesOS/qubes-issues/issues/1166)
 
 **Expected results**: Working robust focus stealing prevention for Xfce (currently the default Qubes desktop environment) or Gnome (the targeted future Qubes desktop environment).
 
-**Knoledge prerequisite**: X APIs, Qubes GUI protocol, familiarity with the targeted window manager.
+**Knowledge prerequisite**: X APIs, Qubes GUI protocol, familiarity with the targeted window manager.
 
 **Mentor**: Inquire on [qubes-devel][ml-devel].
 
@@ -487,7 +487,7 @@ for more information and qubes-specific background.
 
 **Expected results**: Significant progress towards making the Qubes build process deterministic. This would likely involve cooperation with and hacking on several upstream build tools to eliminate sources of variability.
 
-**Knoledge prerequisite**: qubes-builder [[1]](/doc/qubes-builder/) [[2]](/doc/qubes-builder-details/) [[3]](https://github.com/QubesOS/qubes-builder/tree/master/doc), and efficient at introspecting complex systems: comfortable with tracing and debugging tools, ability to quickly identify and locate issues within a large codebase (upstream build tools), etc.
+**Knowledge prerequisite**: qubes-builder [[1]](/doc/qubes-builder/) [[2]](/doc/qubes-builder-details/) [[3]](https://github.com/QubesOS/qubes-builder/tree/master/doc), and efficient at introspecting complex systems: comfortable with tracing and debugging tools, ability to quickly identify and locate issues within a large codebase (upstream build tools), etc.
 
 **Mentor**: [Marek Marczykowski-Górecki](/team/)
 

--- a/basics_dev/gsoc.md
+++ b/basics_dev/gsoc.md
@@ -491,6 +491,28 @@ for more information and qubes-specific background.
 
 **Mentor**: [Marek Marczykowski-Górecki](/team/)
 
+### Porting Qubes to ARM/aarch64
+
+**Project**: Porting Qubes to ARM/aarch64
+
+**Brief explanation**: Qubes currently only supports the x86_64 CPU architecture. Xen currently has additional support for ARM32/ARM64 processors, however work needs to be done to integrate this into the Qubes build process, as well as work in integrating this with the Qubes toolstack and security model. This may also be beneficial in simplifying the process of porting to other architectures. Some related discussion (porting to ppc64):
+[#4318](https://github.com/QubesOS/qubes-issues/issues/4318).
+
+**Expected results**:
+
+ - Add cross-compilation support to qubes-builder and related components.
+ - Make aarch64 specific adjustments to Qubes toolstacks/manager (including passthrough of devices from device tree to guest domains).
+ - Aarch64 specific integration and unit tests.
+ - Production of generic u-boot or uefi capable image/iso for target hardware.
+
+**Knowledge prerequisite**:
+
+ - Libvirt and Qubes toolstacks (C and python languages).
+ - Xen debugging.
+ - General ARM architecture knowledge.
+ 
+**Mentor**: Inquire on [qubes-devel][ml-devel].
+
 ### Android development in Qubes
 
 **Project**: Research running Android in Qubes VM (probably HVM) and connecting it to Android Studio


### PR DESCRIPTION
I've added an idea for GSoC (Porting Qubes to ARM/aarch64), that I may consider applying for as a student if Qubes is accepted for the 2019 GSoC program.
I've left the mentor part as "Inquire on qubes-devel", although I'd assume Marek would be the person to mentor on this type of project.
Any feedback welcome.