### PR TITLE
Replace pass-through with passthrough for documentation consistency

### DIFF
--- a/basics_dev/gsoc.md
+++ b/basics_dev/gsoc.md
@@ -343,8 +343,8 @@ immune to altering past entries. See
 
 **Mentor**: [Frédéric Pierret](/team/)
 
-### Xen GPU pass-through for Intel integrated GPUs
-**Project**: Xen GPU pass-through for Intel integrated GPUs (largely independent of Qubes)
+### Xen GPU passthrough for Intel integrated GPUs
+**Project**: Xen GPU passthrough for Intel integrated GPUs (largely independent of Qubes)
 
 **Brief explanation**: This project is prerequisite to full GUI domain support,
 where all desktop environment is running in dedicated VM, isolated from

--- a/configuration/assigning-devices.md
+++ b/configuration/assigning-devices.md
@@ -12,7 +12,7 @@ Assigning Devices to VMs
 ========================
 
 Sometimes you may need to assign an entire PCI or PCI Express device directly to a qube.
-This is also known as PCI pass-through.
+This is also known as PCI passthrough.
 The Qubes installer does this by default for `sys-net` (assigning all network class controllers), as well as `sys-usb` (assigning all USB controllers) if you chose to create the USB qube during install.
 While this covers most use cases, there are some occasions when you may want to manually assign one NIC to `sys-net` and another to a custom NetVM, or have some other type of PCI controller you want to manually assign.
 
@@ -84,7 +84,7 @@ This will show you a list of available devices, which you can select to be assig
 Finding the right USB controller
 --------------------------------
 
-Some USB devices are not compatible with the USB pass-through method Qubes employs.
+Some USB devices are not compatible with the USB passthrough method Qubes employs.
 In situations like this, you can still often get the USB device to work by passing through the entire USB controller to a qube.
 However, with this approach one cannot assign single USB devices, only the whole USB controller with whatever USB devices are connected to it. 
 More information on using and managing USB devices with qubes is available on the [USB] page. 

--- a/managing-os/windows/windows-tools.md
+++ b/managing-os/windows/windows-tools.md
@@ -24,7 +24,7 @@ Qubes Windows Tools are open source and are distributed under a GPL license.
 
 NOTES:
 - Qubes Windows Tools are currently unmaintained
-- Currently only 64-bit versions of Windows 7 are supported by Qubes Windows Tools. Only emulated SVGA GPU is supported (although [there has been reports](https://groups.google.com/forum/#!topic/qubes-users/cmPRMOkxkdA) on working GPU pass-through).
+- Currently only 64-bit versions of Windows 7 are supported by Qubes Windows Tools. Only emulated SVGA GPU is supported (although [there has been reports](https://groups.google.com/forum/#!topic/qubes-users/cmPRMOkxkdA) on working GPU passthrough).
 - There is currently no audio support for Windows HVMs.
 - There is currently no USB passsthrough support for Windows HVMs.
 - __This page documents the process of installing Qubes Windows Tools on versions up to R3.2.__. Installation on Qubes R4.0 is possible but is a work in progress and there are limitations/bugs (see [issue #3585](https://github.com/QubesOS/qubes-issues/issues/3585)).


### PR DESCRIPTION
Spelling "passthrough" is used in qubes-doc much more often, so to keep docs consistent it's needed to eliminate other spelling versions.
