### PR TITLE
Update debian-minimal.md

### DIFF
--- a/managing-os/templates/debian-minimal.md
+++ b/managing-os/templates/debian-minimal.md
@@ -19,7 +19,7 @@ Installation
 The Debian minimal template can be installed with the following command:
 
 ~~~
-[user@dom0 ~]$ sudo qubes-dom0-update --enable-repo qubes-templates-itl-testing qubes-template-debian-9-minimal
+[user@dom0 ~]$ sudo qubes-dom0-update --enablerepo=qubes-templates-itl-testing qubes-template-debian-9-minimal
 ~~~
 
 The download may take a while depending on your connection speed.


### PR DESCRIPTION
Installation Command does not work, see: https://dnf.readthedocs.io/en/latest/command_ref.html

Please also check line 68: the (Fedora) "polkit" equivalent Debian package is called  "policykit-1". 
For reference: https://packages.debian.org/stretch/policykit-1 
But I´m not sure if policykit-1 is needed, since with qubes-template-debian-9-minimal-4.0.1-201901271906 it is enough to 
1) install the template,
2) `[user@dom0 ~]$ qvm-run -u root debian-9-minimal xterm`
3) `bash-4.4# apt install qubes-core-agent-passwordless-root`
4) update the template
5)-> passwordless root is enabled
