### PR TITLE
Apply <lower> filter to <color.hex>.

### DIFF
--- a/basics_dev/style-guide.md
+++ b/basics_dev/style-guide.md
@@ -36,7 +36,7 @@ The following **grayscale** colors are currently used on the Qubes website and d
   <div class="swatch more-bottom more-right">
     <div class="color add-bottom bg-{{color.class}}"></div>
     <strong class="add-bottom">{{color.name}}</strong>
-    <code>#{{color.hex | lower}}</code>
+    <code>#{{color.hex | downcase}}</code>
   </div>
   {% endif %}
 {% endfor %}
@@ -50,7 +50,7 @@ The following **colors** are currently being used on the Qubes website and docum
   <div class="swatch more-bottom more-right">
     <div class="color add-bottom bg-{{color.class}}"></div>
     <strong class="add-bottom">{{color.name}}</strong>
-    <code>#{{color.hex | lower}}</code>
+    <code>#{{color.hex | downcase}}</code>
   </div>
   {% endif %}
 {% endfor %}

--- a/basics_dev/style-guide.md
+++ b/basics_dev/style-guide.md
@@ -36,7 +36,7 @@ The following **grayscale** colors are currently used on the Qubes website and d
   <div class="swatch more-bottom more-right">
     <div class="color add-bottom bg-{{color.class}}"></div>
     <strong class="add-bottom">{{color.name}}</strong>
-    <code>#{{color.hex}}</code>
+    <code>#{{color.hex | lower}}</code>
   </div>
   {% endif %}
 {% endfor %}
@@ -50,7 +50,7 @@ The following **colors** are currently being used on the Qubes website and docum
   <div class="swatch more-bottom more-right">
     <div class="color add-bottom bg-{{color.class}}"></div>
     <strong class="add-bottom">{{color.name}}</strong>
-    <code>#{{color.hex}}</code>
+    <code>#{{color.hex | lower}}</code>
   </div>
   {% endif %}
 {% endfor %}


### PR DESCRIPTION
As now, some hex values are in uppercase. To unify the page, and prevent this from happening, we can apply lower filter.
Pros:
> Easy of copy-paste