### PR TITLE
Fix garbled text in sudoers file

### DIFF
--- a/user/security-in-qubes/vm-sudo.md
+++ b/user/security-in-qubes/vm-sudo.md
@@ -41,7 +41,6 @@ Background ([/etc/sudoers.d/qubes](https://github.com/QubesOS/qubes-core-agent-l
     # Because, really, if somebody could find and exploit a bug in the Xen
     # hypervisor -- as of 2016, there have been only three publicly disclosed
     # exploitable bugs in the Xen hypervisor from a VM -- then it would be
-    # incidentally by one of the Qubes developers (RW) -- then it would be
     # highly unlikely if that person couldn't also found a user-to-root
     # escalation in VM (which as we know from history of UNIX/Linux
     # happens all the time).


### PR DESCRIPTION
There's a stray line in the sudoers file in the docs which isn't in the actual file in the distro. The problem was introduced by commit 658e02cc5090cfc8b7d94d18871a224d8541d3e8 which should have removed the text "incidentally by one of the Qubes developers (RW)".