### PR TITLE
--hvm not an option, use --property virt_mode=mvh

### DIFF
--- a/external/os-guides/windows/windows-tools.md
+++ b/external/os-guides/windows/windows-tools.md
@@ -153,6 +153,6 @@ Then, periodically check for updates in the Template VM and the changes will be 
 Once the template has been created and installed it is easy to create AppVMs based on it:
 
 ~~~
-qvm-create --hvm <new windows appvm name> --template <name of template vm> --label <label color>
+qvm-create --property virt_mode=hvm <new windows appvm name> --template <name of template vm> --label <label color>
 ~~~
 

--- a/user/managing-os/standalone-and-hvm.md
+++ b/user/managing-os/standalone-and-hvm.md
@@ -302,7 +302,7 @@ qvm-run --pass-io untrusted 'cat "/media/user/externalhd/win10.raw"' > /home/use
 Create a new HVM in Dom0 with the root image we just copied to Dom0 (change the amount of RAM in GB as you wish):
 
 ~~~
-qvm-create --hvm win10 --label red --mem=4096 --root-move-from /home/user/win10-root.img
+qvm-create --property virt_mode=hvm win10 --label red --mem=4096 --root-move-from /home/user/win10-root.img
 ~~~
 
 Start win10 VM:


### PR DESCRIPTION
I may be mistaken, but I do not have an `--hvm` option on my `qvm-create`.

OT: I suggest we use qubes versions in he doc's url, most of the docs I follow have bugs just like this