### PR TITLE
Refactoring the intro page

### DIFF
--- a/doc.md
+++ b/doc.md
@@ -79,7 +79,7 @@ Core documentation for Qubes users.
 
  * [TemplateVMs](/doc/templates/)
  * [Fedora](/doc/templates/fedora/)
- * [Debian](/doc/templates/fedora/)
+ * [Debian](/doc/templates/debian/)
  * [Minimal TemplateVMs](/doc/templates/minimal/)
  * [Windows](/doc/windows/)
  * [StandaloneVMs and HVMs](/doc/standalone-and-hvm/)

--- a/introduction/intro.md
+++ b/introduction/intro.md
@@ -13,30 +13,123 @@ redirect_from:
 What is Qubes OS?
 -----------------
 
-Qubes OS is a free and open-source security-oriented operating system meant for single-user desktop computing. 
+  <div class="row">
+      <div class="col-lg-3 col-md-3 text-left">
+          <p>Qubes OS is a free and open-source security-oriented operating system meant for single-user desktop computing.</p> 
+          <p>Qubes OS leverages <a href="https://wiki.xen.org/wiki/Xen_Project_Software_Overview/">xen-based virtualization</a> to allow for the creation and management of isolated virtual machines called <a href="/doc/glossary#qube">qubes</a>. Qubes, which are also referred to as <a href="/doc/glossary#qube/">domains</a> or compartments, have specific :</p>
+          <ul>
+            <li><b>Purposes</b> : with a predefined set of one or many isolated applications, for personal or professional projects, to manage the <a href="/doc/networking/">network stack</a>, <a href="/doc/firewall/">the firewall</a>, or to fulfill other user-defined purposes.</li>
+            <li><b>Natures</b> : <a href="/doc/standalone-and-hvm/">full-fledged</a> or <a href="/getting-started/#appvms-qubes-and-templatevms">stripped-down</a> virtual machines which are based on popular operating systems such as <a href="/doc/templates/fedora">Fedora</a>, <a href="/doc/templates/debian">Debian</a> or <a href="/doc/windows/">Windows</a>.</li>
+            <li><b>Levels of trust</b> : from complete to non-existent. All windows are displayed in a unified desktop environment with <a href="https://www.qubes-os.org/getting-started/">unforgeable colored window borders</a> so different security levels are easily identifiable.</li>
+          </ul>
+      </div>
+      <div class="col-lg-9 col-md-9">
+        <h3 class="text-center add-bottom">Qubes OS Overview Example</h3>
+        <img src="/attachment/site/qubesosdiagram.png" height="600" class="center-block">
+      </div>
+  </div>
 
-Qubes OS allows you to compartmentalize various parts of your digital life into isolated domains. If one of those compartments get compromised by a malicious email attachment carrying a ransomware, other parts of your system will remain unaffected : this is one of the key benefits of the [*security by compartmentalization*](https://www.qubes-os.org/faq/) approach taken by Qubes OS.
+<div class="alert alert-info" role="alert">
+    <i class="fa fa-question-circle"></i>
+    <b>Note : </b> Head over to the <a href="/doc/glossary/">glossary</a> or the <a href="/faq">FAQ</a> for more information.  
+</div>
 
-How does Qubes OS provide security?
-------------------------------------
+<h2>Features</h2>
 
-Behind the scenes, Qubes OS leverages virtualization and more specifically the [open-source Xen hypervisor](https://wiki.xen.org/wiki/Xen_Project_Software_Overview) to allow the creation and management of well-isolated virtual machines called *qubes*. Those qubes, which are also referred simply to as *domains* or *compartments*, have specific :
+  <div class="row more-bottom">
+    <div class="col-lg-4 col-md-4 col-xs-12">
+      <h3>Strong isolation</h3>
+      <p>Isolate software as if they were installed on separate physical machines using <a href="/doc/glossary/#pv">PV</a> or <a href="/doc/glossary/#hvm">HVM</a> virtualization techniques</p>
+    </div>
+    <div class="col-lg-4 col-md-4 col-xs-12">
+      <h3>Templating system</h3>
+      <p> Allow qubes called <a href="/getting-started/#appvms-qubes-and-templatevms">AppVMs</a> to share a root file system without sacrificing security using the innovative <a href="/doc/templates/">Template system</a></p>
+    </div>
+    <div class="col-lg-4 col-md-4 col-xs-12">
+      <h3>Multiple operating systems</h3>
+      <p> Use multiple operating systems at the same time, including <a href="/doc/templates/fedora">Fedora</a>, <a href="/doc/templates/debian">Debian</a>, or <a href="/doc/windows/">Windows</a></p>
+    </div>
+  </div>
 
-* **Purposes** : for personal or professional projects, to manage the USB or network stack.
-* **Natures** : full-fledged or stripped-down virtual machines which can be based on Fedora, Debian or even Windows.
-* **Levels of trust** : from complete to non-existent. 
+  <hr class="add-top more-bottom">
+  <div class="row more-bottom">
+    <div class="col-lg-4 col-md-4 col-xs-12">
+      <h3>Disposable VMs</h3>
+      <p>Create <a href="/doc/disposablevm/">disposable VMs</a> which are spawned quickly and destroyed when closed</p>
+    </div>
+    <div class="col-lg-4 col-md-4 col-xs-12">
+      <h3>Whonix integration</h3>
+      <p> Run Tor securely system-wide using <a href="/doc/whonix/">Whonix with Qubes</a></p>
+    </div>
+    <div class="col-lg-4 col-md-4 col-xs-12">
+      <h3>Controller isolation</h3>
+      <p>Secure <a href="/doc/device-handling/">device handling</a> through isolation of network cards and USB controllers</p>
+    </div>
+  </div>
 
-All of these isolated qubes are integrated into a single, usable system. Programs are isolated in their own separate qubes, but all windows are displayed in a single, unified desktop environment with [unforgeable colored
-window borders][getting started] so that you can easily identify windows from different security levels. Common attack vectors like network cards and USB controllers are isolated in their own hardware qubes while their functionality
-is preserved through secure [networking], [firewalls], and [USB device management][USB]. Integrated [file] and [clipboard] copy and paste operations make it easy to work across various qubes without compromising security. The
-innovative [Template] system separates software installation from software use, allowing qubes to share a root filesystem without sacrificing security (and saving disk space, to boot). Qubes even allows you to sanitize PDFs and images in a few clicks. Users concerned about privacy will appreciate the [integration][Qubes-Whonix] of [Whonix] with Qubes, which makes it easy to use [Tor] securely, while those concerned about physical hardware attacks will
-benefit from [Anti Evil Maid].
+  <hr class="add-top more-bottom">
+  <div class="row more-bottom">
+    <div class="col-lg-4 col-md-4 col-xs-12">
+      <h3>Split GPG</h3>
+      <p>Utilise <a href="/doc/split-gpg/">Split GPG</a> to store private GPG keys in an AppVM</p>
+    </div>
+    <div class="col-lg-4 col-md-4 col-xs-12">
+      <h3>U2F proxy</h3>
+      <p>Operate<a href="/doc/u2f-proxy/">Qubes U2F proxy</a>to use two-factor authentication</p>
+    </div>
+    <div class="col-lg-4 col-md-4 col-xs-12">
+      <h3>Open-source</h3>
+      <p>Users are free to use, copy and modify Qubes OS and are encouraged to do so!</p>
+    </div>
+  </div>
 
-Qubes OS is open
-----------------
+<div class="alert alert-info" role="alert">
+    <i class="fa fa-question-circle"></i>
+    <b>Note : </b> Given the technical nature of Qubes OS, prior experience with a Linux distribution such as Ubuntu, Debian or Fedora is advisable.
+</div>
 
-Another distinct features of Qubes OS is that as a user, you are free to use, copy and modify it. In other words, Qubes OS is a free and open-source software. The source code, including the documentation, is openly available so that others can contribute to and audit it, which we strongly encourage you to do ! 
 
+Why Qubes OS ?
+--------------
+
+<h3>Physical isolation is a given safeguard that the digital world lacks</h3>
+
+  <div class="row">
+      <div class="col-lg-6 col-md-6 text-left">
+        <p>Throughout their lives, individuals engage in various activites such as going to school, working, voting, taking care of their families or visiting with friends. </p> 
+        <p>These activites are spatially and temporally bound : they happen in isolation of one another, in their own compartments, which often represent an essential safeguard, such as in the case of voting.</p> 
+        <p>In one's digital life, the situation is quite different : each activity, often intertwinded with its real-life counterpart, tends to happen on a single computing device.</p>
+      </div>
+      <div class="col-lg-6 col-md-6">
+        <img src="/attachment/wiki/GettingStarted/r2b1-qubes-manager-2.png" height="300" class="center-block">
+      </div>
+  </div>
+
+<h3>Qubes OS compartmentalizes one's digital life</h3>
+
+ <div class="row">
+      <div class="col-lg-3 col-md-3">
+        <img src="/attachment/icons/128x128/apps/qubes-logo-icon.png" height="128" class="center-block">
+      </div>
+      <div class="col-lg-9 col-md-9 text-left">
+        <p>Suprinsingly, personal computing devices aren't designed to offer means to enforce the same kind of isolation that people enjoy in the physical world.</p>
+        <p>Enter Qubes OS : Qubes OS' goal is to enforce, on a single computing device, a kind of digital compartmentalization that is almost as strong as physical isolation.</p> 
+        <p>Qubes OS allows users to compartmentalize various parts of their digital lives into well-isolated compartments.</p> 
+      </div>
+  </div>
+
+<h3>Made to support vulnerable users</h3>
+
+ <div class="row">
+    <div class="col-lg-12 col-md-12 text-left">
+        <p>Qubes allows users to do everything on the same physical computer without having to worry about a single successful cyberattack taking down their entire digital life in one fell swoop.</p>
+        <p>Thanks to Qubes OS, vulnerable or actively targeted individuals such as journalists, political activists, whistleblowers or researchers can enjoy the same benefit of using multiple computing devices at a fraction of the cost and without the associated loss of usability.</p> 
+        <p>Computing should remain a activity where mistakes can be made and where users can explore the web freely, downloading attachements and clicking on links without having to constantly evaluate a miriad of risk factors.</p> 
+        <p>Qubes OS strives to bring back this experience. It creates a place where users can feel safe.</p>
+    </div>
+ </div>
+
+ <p><img src="/attachment/wiki/GettingStarted/snapshot12.png" alt="snapshot12.png"/></p>
 
 <hr class="add-top more-bottom">
   <div class="row more-bottom">
@@ -63,17 +156,18 @@ Another distinct features of Qubes OS is that as a user, you are free to use, co
     </div>
   </div>
 
+
 More information
 ----------------
 
-This page is just a brief sketch of what Qubes is all about, and many
+This page is just a brief introduction to what Qubes is all about, and many
 technical details have been omitted here for the sake of presentation.
 
  * If you're a current or potential Qubes user, you may want to check out the
    [documentation][doc] and the [FAQ][user-faq].
  * If you're a developer, there's dedicated [documentation][system-doc]
    and an [FAQ][devel-faq] just for you.
- * Ready to give Qubes a try? Head on over to the [downloads] page.
+ * Ready to give Qubes a try? Head on over to the [downloads] page or the [installation guide].
 
 
 [disposable qube]: /doc/disposablevm/
@@ -96,4 +190,4 @@ technical details have been omitted here for the sake of presentation.
 [devel-faq]: /faq/#developers
 [downloads]: /downloads/
 [getting started]: /getting-started/
-
+[installation guide]: /doc/installation-guide/

--- a/introduction/intro.md
+++ b/introduction/intro.md
@@ -75,7 +75,7 @@ What is Qubes OS?
     </div>
     <div class="col-lg-4 col-md-4 col-xs-12">
       <h3>U2F proxy</h3>
-      <p>Operate<a href="/doc/u2f-proxy/">Qubes U2F proxy</a>to use two-factor authentication</p>
+      <p>Operate <a href="/doc/u2f-proxy/">Qubes U2F proxy</a> to use two-factor authentication</p>
     </div>
     <div class="col-lg-4 col-md-4 col-xs-12">
       <h3>Open-source</h3>

--- a/user/downloading-installing-upgrading/installation-guide.md
+++ b/user/downloading-installing-upgrading/installation-guide.md
@@ -19,110 +19,295 @@ redirect_from:
 Installation Guide
 ==================
 
+<h3>Qubes 4.0.1 Warning</h3>
 
-Qubes 4.0.1 Warning
--------------------
+<div class="alert alert-danger" role="alert">
+    <i class="fa fa-exclamation-circle"></i>
+    <b>Attention : </b> For those using Debian and Whonix templates, a vulnerability affects the latest stable Qubes OS release. Follow the instructions below to fix it.
+</div>
 
-Immediately after installing Qubes 4.0.1, please upgrade all of your Debian and Whonix TemplateVMs by executing the following commands in a dom0 terminal, as applicable for the templates you chose to install:
+Immediately after installing Qubes 4.0.1, upgrade all of your Debian and Whonix TemplateVMs by executing 
+the following commands in a dom0 terminal:
 
     $ sudo qubes-dom0-update --action=upgrade qubes-template-debian-9
     $ sudo qubes-dom0-update --enablerepo=qubes-templates-community --action=upgrade qubes-template-whonix-gw-14
     $ sudo qubes-dom0-update --enablerepo=qubes-templates-community --action=upgrade qubes-template-whonix-ws-14
 
-These upgrades are required in order to be protected from the APT update mechanism vulnerability that was announced and patched in [QSB #46], which was after the release of Qubes 4.0.1.
-This method is simpler than the method recommended in [QSB #46], but it is just as safe and effective so long as it is performed immediately after installing Qubes OS.
+These upgrades are required in order to be protected from the APT update mechanism vulnerability that was announced 
+and patched in [QSB #46], which followed the release of Qubes 4.0.1. This method is simpler than the method recommended 
+in [QSB #46], and it is just as safe/effective as long as it is performed immediately after installing Qubes OS.
 
+Pre-installation
+----------------
 
-Hardware Requirements
----------------------
+<h3>Hardware Requirements</h3>
 
-Please see the [system requirements] and [Hardware Compatibility List] pages for
-more information on required and recommended hardware.
+Qubes OS has very specific [system requirements].
+To ensure compatibility, we strongly recommend using [Qubes-certified hardware].
+Other hardware may require you to perform significant troubleshooting.
+You may also find it helpful to consult the [Hardware Compatibility List].
 
-**Note:** We don't recommend installing Qubes in a virtual machine! It will
-likely not work. Please don't send emails asking about it. You can, however,
-install it on an external USB hard drive (at least 32 GB) and run from it,
-at least for testing. Bear in mind, however, that such disks are typically
-*orders* of magnitude slower than even the slowest internal hard drives.
+Even on supported hardware, you must ensure that [IOMMU-based virtualization](https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit#Virtualization)
+ is activated in the BIOS. Without it, Qubes OS won't be able to enforce isolation. For Intel-based boards, 
+ this setting is called Intel Virtualization for Directed I/O (**Intel VT-d**) and for AMD-based boards, it is called 
+ AMD I/O Virtualization Technology (or simply **AMD-Vi**). This parameter should be activated in your computer's BIOS, 
+ alongside the standard Virtualization (**Intel VT-x**) and AMD Virtualization (**AMD-V**) extensions. This 
+ [external guide](https://www.intel.in/content/www/in/en/support/articles/000007139/server-products.html) made for
+  Intel-based boards can help you figure out how to enter your BIOS to locate and 
+ activate those settings. If those settings are not nested under the Advanced tab, you might find them under the Security tab.
 
+<div class="alert alert-info" role="alert">
+    <i class="fa fa-question-circle"></i>
+    <b>Note : </b> As Qubes OS has no control over what is happening before it takes control over the hardware, the motherboard firmware, which is responsible for bootstrapping the hardware and checking it, must be trusted, alongside the hardware itself.
+</div>
 
-Downloading the ISO
--------------------
+<div class="alert alert-success" role="alert">
+    <i class="fa fa-info-circle"></i>
+    <b>Tip : </b> It it up to the user to pick a combination of firmware and hardware that is trustworthy enough. One can think 
+    of <a href="https://www.coreboot.org/">Coreboot</a> and its security-oriented implementation <a href="http://osresearch.net/">Heads</a>, 
+    or <a href="https://github.com/merge/skulls">Skulls</a>, which strives to be easy to use. At present, they are only 
+    compatible with the Lenovo Thinkpad X230. See <a href="/doc/Qubes-certified hardware">Qubes-certified hardware</a> for other ideas.   
+</div>
 
-See the [downloads] page for ISO downloads. Remember, we have absolutely
-no control over those servers, so you should be assuming that they might be
-compromised, or just be serving compromised ISOs because their operators decided
-so, for whatever reason. Always verify the digital signature on the downloaded
-ISO. Make sure to read our guide on [verifying signatures] for more info about
-how to download and verify our PGP keys and verify the downloaded ISO.
+<div class="alert alert-info" role="alert">
+    <i class="fa fa-question-circle"></i>
+    <b>Note : </b> Qubes OS is not meant to be installed inside a virtual machine as a guest hypervisor. In other terms, <b>nested virtualization</b> is not supported. In order for a strict 
+     compartmentalization to be enforced, Qubes OS needs to be able to manage the hardware directly. 
+</div>
 
+<h3>Downloading the ISO</h3>
 
-Copying the ISO onto the installation medium
---------------------------------------------
+See the [downloads] page for ISO downloads. Remember, Qubes OS' team have absolutely no control over those servers, so you 
+should consider that they might be compromised, or just be serving compromised ISOs because their operators 
+decided so, for whatever reason. Always verify the digital signature on the downloaded ISO. Read 
+our guide on [verifying signatures] for more information about how to download and verify our PGP keys and verify the downloaded ISO.
 
-Once you verify this is an authentic ISO, you should copy it onto the
-installation medium of your choice, such as a DVD or a USB drive. (Please note
-that there are important [security considerations] to keep in mind when choosing
-an installation medium.)
+<h3>Copying the ISO onto the installation medium</h3>
 
-If you prefer to use a USB drive, then you just need to copy the ISO onto the
+Once the ISO has been verified as authentic, you should copy it onto the installation medium of your choice, such as
+ a DVD or a USB key. (Note that there are important [security considerations] to keep in mind when choosing
+  an installation medium.)
+
+If you choose to use a USB drive, copy the ISO onto the
 USB device, e.g. using `dd`:
 
-    dd if=Qubes-R3-x86_64.iso of=/dev/sdX bs=1048576 && sync
+    $ sudo dd if=Qubes-R3-x86_64.iso of=/dev/sdX bs=1048576 && sync
 
-Change `Qubes-R3-x86_64.iso` to the filename of the version you're installing,
-and change `/dev/sdX` to the correct target device (e.g., `/dev/sdc`).
-**Warning:** Choosing the wrong device could result in data loss. Make sure to
-write to the entire device (e.g., `/dev/sdc`) rather than just a single
-partition (e.g., `/dev/sdc1`).
+Change `Qubes-R3-x86_64.iso` to the filename of the version you're installing, and change `/dev/sdX` to the correct target device (e.g., `/dev/sdc`). 
 
-On Windows, you can use the [Rufus] tool. Be sure to select "DD image" mode (you
-need to do that **after** selecting the Qubes ISO):
+Make sure to write to the entire device (e.g., `/dev/sdc`) rather than just a single partition (e.g., `/dev/sdc1`).
 
-**Warning:** If you do that on Windows 10, you can only install Qubes without 
-MediaTest, which isn't recommended. 
+<div class="alert alert-danger" role="alert">
+    <i class="fa fa-exclamation-circle"></i>
+    <b>Attention : </b> Choosing the wrong device could result in data loss.
+</div>
+
+On Windows, you can use the [Rufus] tool to write the ISO to a USB key. MediaTest is not recommended. Be sure to select "DD image" mode (you need to do that **after** selecting the Qubes ISO):
 
 <img src="/attachment/wiki/InstallationGuide/rufus-main-boxed.png" height="350">
 
-Before proceeding with the installation, you are encouraged to first read all
-the information on this page. When you're ready, boot your system from the
-installation source and follow the on-screen instructions. The installer is very
-simple and asks very few questions. (It's actually easier to install Qubes right
-now than most other Linux distributions!)
+If you are an advanced user and you would like to customize your installation, please see [Custom Installation]. Otherwise, follow the instructions below.
 
-The installer loads Xen right at the beginning, so chances are high that if you
-can see the installer's graphical screen and you pass the compatibility check that
-runs immediately after that, Qubes will work on your system. :)
+<div class="alert alert-info" role="alert">
+    <i class="fa fa-question-circle"></i>
+    <b>Note : </b> This guide will demonstrate a simple installation using mostly default settings. 
+</div>
 
-If you're an advanced user, and you'd like to customize your installation, please see [Custom Installation].
+Installation
+------------
 
+<h3>Getting to the boot screen</h3>
 
-Installing to a USB drive
--------------------------
+Just after you power on your machine, make the Qubes OS medium available to the computer by inserting the DVD or USB key you have previously copied the 
+Qubes OS image to. Shortly after the Power-on self-test (POST) is completed, you should be greeted with the Qubes OS boot screen. 
 
-Installing an operating system onto a USB drive can be a convenient and secure
-method of ensuring that your data is protected. Be advised that a minimum
-storage of 32 GB is required on the USB drive. This installation process may
-take longer than an installation on a standard hard disk. The installation
-process is identical to using a hard disk in conjunction with two exceptions:
+<img src="/attachment/wiki/InstallationGuide/boot-screen.png">
 
-* Select the USB as the storage location for the OS. 
+From there, you can navigate the boot screen using the arrow keys on your keyboard. Pressing the "Tab" key will reveal options. You can choose one of three options : install Qubes OS ; test this media and install Qubes OS ; troubleshooting. Select the option to test this media and install Qubes OS. 
 
-* Leave the option checked to “Automatically configure my Qubes installation to
-the disk(s) I selected and return me to the main menu”.
+If the boot screen does not appear, there are several options to troubleshoot. First, try rebooting your computer. If it still loads your currently installed operating
+system or does not pick up your installation medium, make sure the boot order is set up appropriately. The process to change the boot order varies depending on
+the currently installed system and the motherboard manufacturer. If **Windows 10** is installed on your machine, you may need to follow specific instructions to 
+change the boot order. This may require an [advanced reboot](https://support.microsoft.com/en-us/help/4026206/windows-10-find-safe-mode-and-other-startup-settings). 
+Ideally, you would temporarily select the USB device or DVD drive as a boot up option, so that the next time you boot, your internal storage device will be selected first. 
 
+<div class="alert alert-success" role="alert">
+    <i class="fa fa-info-circle"></i>
+    <b>Tip : </b> After the POST, you may have a chance to temporally pick a booting device. 
+</div>
 
-Upgrading
----------
+<img src="/attachment/wiki/InstallationGuide/boot-order.png">
 
-For instructions in upgrading an existing installation, please see [Upgrade Guides].
+<h3>The installer home screen</h3>
 
+On the first screen, you are asked to pick the language that will be used during the installation process. When you are done, select "Continue". 
+
+<img src="/attachment/wiki/InstallationGuide/welcome-to-qubes-os-installation-screen.png">
+
+Prior to the next screen, a compatibility test runs to check whether IOMMU-virtualization is active or not. If the test fails, a window will pop up. 
+
+<img src="/attachment/wiki/InstallationGuide/unsupported-hardware-detected.png">
+
+Do not panic : it may simply indicate that IOMMU-virtualization hasn't been activated in the BIOS. Return to the [Hardware Requirements](/doc/installation-guide/#hardware-requirements) 
+section to learn how to activate it. If the setting is not configured correctly, it means that your hardware won't be able to leverage some of Qubes OS security features such as a strict isolation of the network and USB adapter. 
+
+If the test passes, you will reach the Installation summary screen.
+
+<div class="alert alert-info" role="alert">
+    <i class="fa fa-info-circle"></i>
+    <b>Note : </b> The installer loads Xen right at the beginning, so if you can see the installer's graphical screen and you pass the compatibility check that
+    runs immediately after that, Qubes OS is likely to work on your system !
+</div>
+
+<div class="alert alert-info" role="alert">
+    <i class="fa fa-question-circle"></i>
+    <b>Note : </b> Like Fedora, Qubes OS uses the Anaconda installer. Those that are familiar with RPM-based distributions should feel at home. 
+</div>
+
+<h3>Installation summary</h3>
+
+The Installation summary screen allows you to change how the end-system will be installed and configured, including localization settings. 
+At minimum, you are required to pick a storage device on which Qubes OS will be installed. 
+
+<img src="/attachment/wiki/InstallationGuide/installation-summary-not-ready.png">
+
+<h3>Localization</h3>
+
+Let's assume you wish to add a German keyboard layout. Go to Keyboard Layout, press the "Plus" symbol, search for "German" as indicated in the screenshot 
+and press "Add". If you want it be your default language, select the "German" entry in the list and press the arrow button. Click on "Done" in the upper left corner and you are ready to go ! 
+
+<img src="/attachment/wiki/InstallationGuide/keyboard-layout-selection.png">
+
+The process to select a new language is similar to the process to select a new keyboard layout. Follow the same process in the "Language Support" entry.
+
+<img src="/attachment/wiki/InstallationGuide/language-support-selection.png">
+
+<div class="alert alert-info" role="alert">
+    <i class="fa fa-question-circle"></i>
+    <b>Note : </b> You can have as many keyboard layout and languages as you want. Post-install, you will be able to switch between them and install others. 
+</div>
+
+Don't forget to select your time and date by clicking on the Time & Date entry.
+
+<img src="/attachment/wiki/InstallationGuide/time-and-date.png">
+
+<h3>Software</h3>
+
+Under the Software section, you can change the installation source. As we are demonstrating a simple installation, it is assumed that you are installing Qubes OS using 
+a local medium such as a DVD, so this option won't be illustrated.
+
+<img src="/attachment/wiki/InstallationGuide/add-ons.png">
+
+Go instead to the Software selection tab, where you can choose which software to install alongside Qubes OS. Two Add-Ons are available :
+
+* **Debian 9 (stretch) template** : Install these templates if you wish to base some of your Qubes virtual machines on Debian instead of Fedora. 
+* **Whonix** : Install Whonix templates if you wish some of your qubes to be based on Whonix. Whonix let you route your entire network traffic trough Tor if you see fit. For more information about Whonix, have a look at their [website](https://www.whonix.org/). Depending on your threat model, you may need to install Whonix templates right away.
+
+Note that you will also be able to install  Add-Ons after the installation is completed. If you wish for your system to be more lightweight, 
+do not hesitate to un-check those options. 
+
+<div class="alert alert-info" role="alert">
+    <i class="fa fa-question-circle"></i>
+    <b> Note : </b> By default, Qubes OS comes preinstalled with the lightweight Xfce desktop environnement for dom0, the main domain. Other desktop environments will be available to you after the installation is completed, although they may not be officially supported. 
+</div>
+
+Click on "Done" as soon as you have made your choice to go back to Installation summary screen. 
+
+<h3>Installation destination</h3>
+
+Under the System section, you need to pick the installation destination. For this step to be completed, you need to select which storage device you would like your system to be installed on. By default, only local storage devices are shown. Under the Device Selection section, make sure that you select the correct installation destination. Ensure that your your target destination has a least 32 GiB of free space available.   
+
+For this setup, options will be left unchanged. By default, Qubes OS will partition the system itself using LUKS encryption on top of LVM, and will claim the entire storage device.
+
+<img src="/attachment/wiki/InstallationGuide/select-storage-device.png">
+
+<div class="alert alert-danger" role="alert">
+    <i class="fa fa-exclamation-circle"></i>
+    <b>Attention : </b> Any data on the target storage device will be destroyed during the installation process, including any available partitions, so make your selection carefully. 
+</div>
+
+As soon as you leave the current window by pressing "Done", Qubes OS will ask you to pick a passphrase to unlock encrypted partition. The passphrase should be complex. Keep it in a safe place. Make sure that your keyboard layout reflects what keyboard you are actually 
+using and click on "Done" to start the installation process !
+
+<img src="/attachment/wiki/InstallationGuide/select-storage-passphrase.png">
+
+Installing an operating system onto a USB drive can be a convenient and secure method of ensuring that your data is protected and remains portable. 
+If you want to install Qubes OS onto a USB drive, just select the USB device as the storage location for the OS. Be advised that a minimum storage of 32 
+GB is required and that a *fast* USB 3.0 compatible drive is mandatory to achieve decent performance. Also, bear in mind that the installation process is likely 
+to take longer than an installation on a internal storage disk.
+
+<div class="alert alert-info" role="alert">
+    <i class="fa fa-question-circle"></i>
+    <b>Note : </b> See <a href="/doc/custom-install/">the Custom Installation</a> for more options. 
+</div>
+
+You are now ready to go. Press the "Begin Installation" button.
+
+<img src="/attachment/wiki/InstallationGuide/installation-summary-ready.png">
+
+<h3>Pick your user name</h3>
+
+While the installation is ongoing, a new user needs to be created. Click on "User Creation" to define a new user with administrator privileges and a password. 
+Just as for the disk encryption, this password should be complex. The root account is deactivated and should remain as such.
+
+<img src="/attachment/wiki/InstallationGuide/account-name-and-password.png">
+
+When the installation is complete, click on the "Reboot" button. Don't forget to remove the installation media, otherwise you may end up seeing the Qubes OS boot screen again. 
+
+<div class="alert alert-info" role="alert">
+    <i class="fa fa-question-circle"></i>
+    <b>Note : </b> By design, Qubes OS is a single user operating system. 
+</div>
+
+Post-installation
+-----------------
+
+<h3>First boot</h3>
+
+If Qubes OS has been successfully installed, you should see the GRUB menu during the booting process.
+
+<img src="/attachment/wiki/InstallationGuide/grub-boot-menu.png">
+
+Just after this screen, you will be asked to unlock your storage device. 
+
+<img src="/attachment/wiki/InstallationGuide/unlock-storage-device-screen.png">
+
+<h3>Initial Setup</h3>
+
+You're almost done. Before you can start using Qubes OS, some configuration is needed. By default, Qubes OS will create a number of qubes, based 
+on Fedora templates or Whonix templates, so that you can have a more ready-to-use environnement from the get-go.
+
+<img src="/attachment/wiki/InstallationGuide/initial-setup-menu.png">
+
+* **Create default system qubes** : it is recommended to use system qubes as they offer some of the core functionalities brought by Qubes OS, including network isolation and disposable qubes  
+* **Create default application qubes** : application qubes are pre-configured qubes meant to be used for specific purposes/categories, such as work or personal. 
+* **Create Whonix Gateway and Workstation qubes** : in order to be able to use Tor for dedicated qubes, you need this option to be activated. 
+    * **Enabling system and template updates over the Tor anonymity network using Whonix** : this option allows the use of Tor system-wide rather than only for specific qubes.  
+* **Create USB qube holding all USB controllers** : just like the network qube for the network stack, the USB qube allows to capture the USB controller and to manage USB devices through it. 
+    * Use sys-net qube for both networking and USB devices : **???**
+* **Do not configure anything** : If you would rather not configure anything for now, check this box.
+
+<img src="/attachment/wiki/InstallationGuide/initial-setup-menu-configuration.png">
+
+When you are satisfied with you choices, click on "Done". Pre-selected qubes will be installed and configured, which can take up to 15 minutes. 
+
+After the configuration is done, you will be greeted by a login screen. Enter your password and log in.
+
+<img src="/attachment/wiki/InstallationGuide/login-screen.png">
+
+Congratulations, you are now ready to use Qubes OS !
+
+<img src="/attachment/wiki/InstallationGuide/desktop-menu.png">
+
+Upgrading Qubes OS
+------------------
+
+For instructions on upgrading an existing installation, see [Upgrade Guides].
 
 Getting Help
 ------------
 
- * We work very hard on making the [documentation] accurate, comprehensive, and
-   useful. We urge you to read it! It may very well contain the answers to your
+ * We work very hard to make the [documentation] accurate, comprehensive useful and user friendly. We urge you to read it! It may very well contain the answers to your
    questions. (Since the documentation is a community effort, we'd also greatly
    appreciate your help in [improving] it!)
 
@@ -136,6 +321,7 @@ Getting Help
 
 [QSB #46]: /news/2019/01/23/qsb-46/
 [system requirements]: /doc/system-requirements/
+[Qubes-certified hardware]: /doc/certified-hardware/
 [Hardware Compatibility List]: /hcl/
 [live USB]: /doc/live-usb/
 [downloads]: /downloads/
@@ -148,4 +334,3 @@ Getting Help
 [improving]: /doc/doc-guidelines/
 [mailing lists]: /support/
 [help]: /help/
-


### PR DESCRIPTION
What I have tried to do is condense the page and remove information that I believe is a better fit for the FAQ page. If a comparison is still needed ("How does Qubes OS compare to XYZ"), I suggest a table rather than entire sections. The text has been copy-edited. Also, a section on : is "Qubes OS good for me (or a good fit for me)" might be a good idea. Finally, a diagram will eventually be incorporated (discussion on this [here](https://github.com/QubesOS/qubes-issues/issues/5357)).  