### PR TITLE
Update+fix Win10 HVM create command for Qubes 4

### DIFF
--- a/user/managing-os/standalone-and-hvm.md
+++ b/user/managing-os/standalone-and-hvm.md
@@ -293,7 +293,7 @@ Convert vmdk to raw:
 qemu-img convert -O raw *.vmdk win10.raw
 ~~~
 
-Copy the root image file to a temporary location in Dom0:
+Copy the root image file to a temporary location, typing this in a Dom0 terminal:
 
 ~~~
 qvm-run --pass-io untrusted 'cat "/media/user/externalhd/win10.raw"' > /home/user/win10-root.img
@@ -302,7 +302,7 @@ qvm-run --pass-io untrusted 'cat "/media/user/externalhd/win10.raw"' > /home/use
 Create a new HVM in Dom0 with the root image we just copied to Dom0 (change the amount of RAM in GB as you wish):
 
 ~~~
-qvm-create --property virt_mode=hvm win10 --label red --mem=4096 --root-move-from /home/user/win10-root.img
+qvm-create --property=virt_mode=hvm --property=memory=4096 --property=kernel='' --label red --standalone --root-move-from /home/user/win10-root.img win10
 ~~~
 
 Start win10 VM:


### PR DESCRIPTION
qvm-create command behaves differently:
--standalone is needed now in order to use --root-move-from
--mem is now set with --property=memory
and VM name must go at end of command

Additionally kernel='' (for none) must be set in order for the Win10 GUI to start.