### PR TITLE
LibreOffice was almost unusable slow in Debian 10

### DIFF
--- a/user/managing-os/debian/debian-upgrade.md
+++ b/user/managing-os/debian/debian-upgrade.md
@@ -111,6 +111,7 @@ This section contains notes about upgrading to specific releases.
 
 Please see [Debian's Buster upgrade instructions][buster].
 
+* Noticed LibreOffice being very slow to work in after upgrade, unchecked the setting Tools/Options/Libre Office/View/Use hardware acceleration 
 
 ### Debian 9 ("Stretch")
 


### PR DESCRIPTION
I dont know if this is the right place, but LibreOffice 6.1.5-3 on Debian 10 Buster was definitely different than before on Debian 9. LibreOffice is also an application that I expect lots of users use.