### PR TITLE
Path for hostname randomization on fedora

### DIFF
--- a/external/privacy-guides/anonymizing-your-mac-address.md
+++ b/external/privacy-guides/anonymizing-your-mac-address.md
@@ -86,8 +86,9 @@ set -e -o pipefail
 # Set a random hostname for a VM session.
 #
 # Instructions:
-# 1. This file must be placed and made executable as the file /etc/network/if-pre-up.d/00_hostname (owner: root) inside the template VM of your
-#  network VM.
+# 1. This file must be placed and made executable (owner: root) inside the template VM of your network VM such that it will be run before your hostname is sent over a network.
+# In a Fedora template, use `/etc/NetworkManager/dispatcher.d/pre-up.d/00_hostname`.
+# In a Debian template, use `/etc/network/if-pre-up.d/00_hostname`.
 # 2. Execute `sudo touch /etc/hosts.lock` inside the template VM of your network VM.
 # 3. Execute inside your network VM:
 #  `sudo bash -c 'mkdir -p /rw/config/protected-files.d/ && echo -e "/etc/hosts\n/etc/hostname" > /rw/config/protected-files.d/protect_hostname.txt'`


### PR DESCRIPTION
Specifies paths for the hostname randomization script that work on both Fedora and Debian systems.

I was unable to get my Fedora template (the default used for sys-net) to recognize and run the hostname randomization script when it was placed at `/etc/network/if-pre-up.d/00_hostname`. I looked around online and I *believe* that it should instead be placed at `/etc/NetworkManager/dispatcher.d/pre-up.d/00_hostname`.

I am not 100% confident in this because I don't have a firm grasp on the inner workings of NetworkManager. Can anyone confirm that when placed inside dispatcher.d/pre-up.d the hostname will never be leaked?

Hope so, and hope this helps!