### PR TITLE
clarify language around openvpn config files

### DIFF
--- a/external/configuration-guides/vpn.md
+++ b/external/configuration-guides/vpn.md
@@ -124,13 +124,11 @@ Before proceeding, you will need to download a copy of your VPN provider's confi
        sudo mkdir /rw/config/vpn
 
    Copy your VPN configuration files to `/rw/config/vpn`.
-   Your VPN config file should be named `openvpn-client.ovpn` so you can use the scripts below as is without modification. Otherwise you would have to replace the file name. Files accompanying the main config such as `*.crt` and `*.pem` should also be placed in the `/rw/config/vpn` folder.
+   Your VPN config file should be named `openvpn-client.ovpn` so you can use the scripts below as is without modification. Otherwise you would have to replace the file name. Files accompanying the main config, such as `*.crt` and `*.pem`, should also be placed in the `/rw/config/vpn` folder. Make sure to check that these accompanying files are not referenced by absolute paths such as `/etc/...` inside `openvpn-client.ovpn`.
 
    Check or modify configuration file contents using a text editor:
 
        sudo gedit /rw/config/vpn/openvpn-client.ovpn
-
-   Files referenced in `openvpn-client.ovpn` should not use absolute paths such as `/etc/...`.
 
    The config should route all traffic through your VPN's interface after a connection is created; For OpenVPN the directive for this is `redirect-gateway def1`.
 


### PR DESCRIPTION
While trying to follow this doc I was quite confused by the line `Files referenced in openvpn-client.ovpn should not use absolute paths such as /etc/...`

Many openvpn config files will include absolute paths like `up /etc/openvpn/update-resolve-conf`. I don't think replacing those with relative paths would make much sense.

I began following the git history back and here: https://github.com/QubesOS/qubes-doc/blame/2778fbccc8f6ecc71091223a4fa339148774c344/configuration/vpn.md#L79 it becomes clear that originally the warning about absolute paths was meant to be specifically about accompanying *.crt and *.pem files.