### PR TITLE
"installing kernel in Debian VM": add Minimal Template support

### DIFF
--- a/user/advanced-configuration/managing-vm-kernel.md
+++ b/user/advanced-configuration/managing-vm-kernel.md
@@ -290,7 +290,7 @@ Install distribution kernel image, kernel headers and the grub.
 sudo apt install linux-image-amd64 linux-headers-amd64 grub2 qubes-kernel-vm-support
 ~~~
 
-If you are doing that on a qube based on "Debian Minimal" template, a grub gui will popup during the installation, asking you where you want to install the grub loader. You must select /dev/xvda (check the box using the "Spacebar", and validate your choice with "Enter".)
+If you are doing that on a qube based on "Debian Minimal" template, a grub gui will popup during the installation, asking you where you want to install the grub loader. You must select /dev/xvda (check the box using the space bar, and validate your choice with "Enter".)
 
 
 You can safely ignore this error message:

--- a/user/advanced-configuration/managing-vm-kernel.md
+++ b/user/advanced-configuration/managing-vm-kernel.md
@@ -284,23 +284,14 @@ Apply the following instruction in a Debian TemplateVM or in a Debian Standalone
 
 Using a distribution kernel package the initramfs and kernel modules should be handled automatically.
 
-Create folder `/boot/grub`.
+Install distribution kernel image, kernel headers and the grub.
 
 ~~~
-sudo mkdir -p /boot/grub
+sudo apt install linux-image-amd64 linux-headers-amd64 grub2 qubes-kernel-vm-support
 ~~~
 
-Install distribution kernel image, kernel headers and the grub configuration generator.
+If you are doing that on a qube based on "Debian Minimal" template, a grub gui will popup during the installation, asking you where you want to install the grub loader. You must select /dev/xvda (check the box using the "Spacebar", and validate your choice with "Enter".)
 
-~~~
-sudo apt install --no-install-recommends linux-image-amd64 linux-headers-amd64 grub2-common qubes-kernel-vm-support
-~~~
-
-Generate the grub configuration file.
-
-~~~
-sudo update-grub
-~~~
 
 You can safely ignore this error message:
 `grub2-probe: error: cannot find a GRUB drive for /dev/mapper/dmroot. Check your device.map`


### PR DESCRIPTION
fix https://github.com/QubesOS/qubes-issues/issues/5733

Going a bit further, and removing the previous instructions: 
~~~
sudo mkdir -p /boot/grub
sudo apt install --no-install-recommends linux-image-amd64 linux-headers-amd64 grub2-common qubes-kernel-vm-support
sudo update-grub
~~~

The directory "/boot/grub/" already exist on the "Debian Template", and will be created by "grub2" if it doesn't exist (like for the "Debian Minimal Template"). 

Tested the modification on a qube based on Debian Template, and on a qube based on Debian Minimal Template. Both seems to work correctly.