### PR TITLE
Changed xl console to qvm-console-dispvm

### DIFF
--- a/user/advanced-configuration/gui-configuration.md
+++ b/user/advanced-configuration/gui-configuration.md
@@ -57,7 +57,7 @@ If you can start your VM, but can't launch any applications, then you need to fi
 
 ```sh
 qvm-start <VMname> # Make sure the VM is started
-sudo xl console <VMname>
+qvm-console-dispvm <VMname>
 ```
 
 ### Tips


### PR DESCRIPTION
Due to changes documented in https://github.com/QubesOS/qubes-issues/issues/4544 , we can now use the (safer) qvm-console-dispvm instead of a raw xl console.