### PR TITLE
Updated "Building archlinux template"

### DIFF
--- a/external/building-guides/building-archlinux-template.md
+++ b/external/building-guides/building-archlinux-template.md
@@ -163,6 +163,7 @@ $ make linux-utils-vm
 $ make core-agent-linux-vm
 $ make gui-common-vm
 $ make gui-agent-linux-vm
+$ make app-linux-split-gpg-vm
 $ make vmm-xen-vm
 $ make core-vchan-xen-vm
 $ make core-qubesdb-vm
@@ -170,6 +171,7 @@ $ make linux-utils-vm
 $ make core-agent-linux-vm
 $ make gui-common-vm
 $ make gui-agent-linux-vm
+$ make app-linux-split-gpg-vm
 ```
 
 8:   Make the actual Archlinux template


### PR DESCRIPTION
When we make the individual components the doc was missing `make app-linux-split-gpg-vm` which would, if chosen this way, not be built and thus resulting in an error.

Please further refer to https://github.com/QubesOS/qubes-issues/issues/5769#issuecomment-612684970 as well as the makefiles.