### PR TITLE
Add set_crypt_gpgme=no to the example muttrc. 

### DIFF
--- a/external/configuration-guides/mutt.md
+++ b/external/configuration-guides/mutt.md
@@ -106,6 +106,10 @@ set crypt_replysignencrypted=yes
 # automatically verify the sign of a message when opened
 set crypt_verify_sig=yes
 
+# disable use of gpgme, which interferes with Split-GPG
+# and defaults to 'yes' on Debian 9 and higher
+set crypt_use_gpgme=no
+
 send-hook "~A" set pgp_autoinline=no crypt_autoencrypt=no
 send-hook "~t @invisiblethingslab\.com" set crypt_autoencrypt=yes
 


### PR DESCRIPTION
`set_crypt_gpgme` defaults to `yes` on Debian 9 and higher (actually considered a bug [1]). In doing so, it breaks Split GPG both for encryption, decryption on Debian AppVMs. It must be set to no for Split GPG to work.

[1] https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=855123#14