### PR TITLE
Rework Kali Template documentation

### DIFF
--- a/external/os-guides/pentesting/kali.md
+++ b/external/os-guides/pentesting/kali.md
@@ -37,7 +37,7 @@ If you need to install custom kernel modules (wifi drivers, …) you need to use
 The steps can be summarized as:
 
 1. Install Qubes stable Debian template
-2. Upgrade the template to Debian testing release
+2. Add `testing` and `securitytesting` Qubes repositories
 3. Add the Kali repository
 4. Update the template
 
@@ -45,7 +45,8 @@ Get Kali Linux PGP key
 -----------------------
 **CAUTION:** Before proceeding, please carefully read [On Digital Signatures and Key Verification][qubes-verifying-signatures].
 This website cannot guarantee that any PGP key you download from the Internet is authentic.
-Always obtain a trusted key fingerprint via other channels, and always check any key you download against your trusted copy of the fingerprint.
+In order to obtain a trusted fingerprint, check its value against multiple sources.
+Then, check the keys you download against your trusted fingerprint.
 
 This step is required since by (security) default TemplateVM do not have a
 direct Internet connectivity. Users understanding the risks of enabling such
@@ -54,7 +55,7 @@ access can change this configuration in firewall settings for the TemplateVM.
 1. Retrieve the Kali Linux PGP key using a DisposableVM.
 
 ```shell_session
-$ gpg --keyserver hkp://keys.gnupg.net --recv-key 44C6513A8E4FB3D30875F758ED444FF07D8D0BF6
+$ gpg --keyserver hkps://keys.gnupg.net --recv-key 44C6513A8E4FB3D30875F758ED444FF07D8D0BF6
 $ gpg --list-keys --with-fingerprint 44C6513A8E4FB3D30875F758ED444FF07D8D0BF6 
 $ gpg --export --armor 44C6513A8E4FB3D30875F758ED444FF07D8D0BF6 > kali-key.asc
 ```
@@ -76,52 +77,30 @@ These instructions will show you how to upgrade a Debian TemplateVM to Kali Linu
 # qubes-dom0-update <latest Debian template>
 ```
 
-2. Start your Debian template
-
-```shell_session
-$ qvm-start debian-<X>
-$ qvm-run -a debian-<X> gnome-terminal
-```
-
-3. Update it
-
-4. And then close it
-
-```shell_session
-$ qvm-shutdown debian-<X>
-```
-
-5. Clone `debian-X` template
+2. Clone `debian-X` template
 
 ```shell_session
 $ qvm-clone debian-<X> kali-rolling
 ```
 
-6. Check the name of currently used repository in `/etc/apt/sources.list` and current testing [Debian release][Debian-releases]. Update repository list accordingly
+3. Check the name of currently used repository in `/etc/apt/sources.list.d/qubes-r<X>.list` and current testing [Debian release][Debian-releases]. Update repository list accordingly
 
 ```shell_session
-# sed -i 's/<current stable>/<current testing>/g' /etc/apt/sources.list
 # sed -i 's/<current stable>/<current testing>/g' /etc/apt/sources.list.d/qubes-r<X>.list
 ```
 
 e.g. in this example we update `buster` stable repository to `bullseye` testing repository
 
 ```shell_session
-# sed -i 's/buster/bullseye/g' /etc/apt/sources.list
 # sed -i 's/buster/bullseye/g' /etc/apt/sources.list.d/qubes-r<X>.list
 ```
-        
-For installation based on Debian 10 stable, please note that the security repository of Debian testing has [recently been renamed][Debian-security-naming-convention] from `<current testing>/update` to `<current-testing>-security`. To account for that change, execute the following command.
 
-```shell_session
-# sed -i 's%bullseye/updates%bullseye-security%g' /etc/apt/sources.list
-```
+4. Enable the QubesOS `testing` and `securitytesting` repositories
 
-5. Update the template
+In `/etc/apt/sources.list.d/qubes-r<X>.list`, enable the 'testing' and 'securitytesting' repository.
+We do that to reduce the 'dependency hell' between Qubes repository and Kali repository.
 
-**Note:** During execution of the update, carefully read list of packages to be removed. If it contains `qubes-*` packages, terminate operation and try to resolve `qubes-*` packages missing dependencies first.
-
-6. Copy the Kali PGP key from the DisposableVM to the new template:
+5. Copy the Kali PGP key from the DisposableVM to the new template:
 
 ```shell_session
 $ qvm-copy kali-key.asc
@@ -129,7 +108,7 @@ $ qvm-copy kali-key.asc
 
    The DisposableVM can now be turned off.
 
-7. Add the Kali PGP key to the list of keys trusted to authenticate packages:
+6. Add the Kali PGP key to the list of keys trusted to authenticate packages:
 
 ```shell_session
 # cat /home/user/QubesIncoming/dispXXX/kali-key.asc | apt-key add -
@@ -137,18 +116,17 @@ $ qvm-copy kali-key.asc
 
    This command should return: `OK`.
 
-8. Add the Kali repository
+7. Replace Debian repositories with Kali repository
 
 ```shell_session
-# cat <<EOF > /etc/apt/sources.list.d/kali.list
-# Kali Linux repository
-deb https://http.kali.org/kali kali-rolling main non-free contrib
-EOF
+# echo 'deb https://http.kali.org/kali kali-rolling main non-free contrib' > /etc/apt/sources.list
 ```
 
-9. Update the template 
+8. Update the template 
 
-10. Ensure a terminal can be opened in the new template.
+**Note:** During execution of the update, carefully read list of packages to be removed. If it contains `qubes-vm-dependencies` package, terminate operation and try to resolve missing dependencies first. For other `qubes-*` packages, it is up to you to decide if you need them.
+
+9. Ensure a terminal can be opened in the new template.
 
 ```shell_session
 $ qvm-run -a kali-rolling gnome-terminal

--- a/external/os-guides/pentesting/kali.md
+++ b/external/os-guides/pentesting/kali.md
@@ -122,7 +122,7 @@ $ qvm-copy kali-key.asc
 # echo 'deb https://http.kali.org/kali kali-rolling main non-free contrib' > /etc/apt/sources.list
 ```
 
-8. Replace gcc8
+8. Replace `gcc8`
 
 ```shell_session
 # apt-get remove libgcc-8-dev && apt-get install libc6-dev

--- a/external/os-guides/pentesting/kali.md
+++ b/external/os-guides/pentesting/kali.md
@@ -6,52 +6,32 @@ redirect_from:
 - /doc/kali/
 ---
 
-# How to create a Kali Linux VM
+How to create a Kali Linux VM
+===============================
+Warnings
+--------------
+* The installation scripts and provided tools may have bugs, be vulnerable to Man in the Middle (MitM) attacks or other vulnerabilities.
+* Adding additional repositories or tools for installing software extends your trust to those tool providers.
+* Please keep in mind that using such a VM or VM's based on the template for security and privacy critical tasks is not recommended.
+* Kali Linux distribution is a rolling distribution based constantly on Debian testing release, so it always will have newer software base than available in Qubes OS debian template. Keep in mind that it may result in problems (especially in regard to package dependency) not covered by this tutorial.
 
-## Warnings
-
-- The installation scripts and provided tools may have bugs, be vulnerable to Man in the Middle (MitM) attacks or other vulnerabilities.
-
-- Adding additional repositories or tools for installing software extends your trust to those tool providers.
-
-- Please keep in mind that using such a VM or VM's based on the template for security and privacy critical tasks is not recommended.
-
-- Kali Linux distribution is a rolling distribution based constantly on Debian testing release, so it always will have newer software base than available in Qubes OS debian template. Keep in mind that it may result in problems (especially in regard to package dependency) not covered by this tutorial.
-
-
-## Qubes 4.0
-
-### How to Create a Kali Linux VM
-
-This guide is being created to give guidance on ways in which you could create a [Kali Linux][kali] penetration testing VM (qube) in Qubes OS.
-
-Kali Linux is the most widely used penetration testing Linux distribution.
-
-There are multiple ways to create a Kali Linux VM:
-
- 1. Create a HVM and use the official ISO to install the system or convert a [Virtual Image][kali-vbox]. Explained [here](#hvm4_0).
- 2. Clone the Qubes OS latest Debian template image and turn it into a Kali Linux distribution:
-    - using [katoolin]. Explained [here](#katoolin4_0).
-    - manually. Explained [here](#templatevm-from-debian4_0).
-
-### Kali Linux HVM <a name="hvm4_0"/>
+From the official ISO file <a name="hvm4_0"/>
+==================================================
+Only use this method if you want to have the full Kali GUI (desktop, fancy menus, ...), it come at the cost of much greater resources consumption.
 
 1. Download the Kali installation DVD
-
 2. Create a new HVM
-
 3. Start the HVM with attached CD/DVD
-
 ```shell_session
 $ qvm-start <hvm-name> --cdrom <vm-name>:/home/user/Downloads/<iso-name>.iso
 ```
 
-### Kali Linux TemplateVM from a Debian template  <a name="templatevm-from-debian4_0"/>
+From a Debian template  <a name="templatevm-from-debian4_0"/>
+================================================================
+This is the recommanded method.
+Easier to maintain and less demanding on resources, but you won't have the full Kali GUI.
 
-This section will explain how to create your own [Kali] Linux TemplateVM based
-on a current stable Debian TemplateVM. The basic idea is to personalize the
-template with all the tools needed, and then spin up isolated AppVMs based on
-the template.
+If you need to install custom kernel modules (wifi drivers, ...) you need use the kernel provided by Kali instead of the kernel provided by Qubes, see [Managing VM Kernel][managing-vm-kernel]
 
 The steps can be summarised as:
 
@@ -60,8 +40,8 @@ The steps can be summarised as:
 3. Add the Kali repository
 4. Update the template
 
-#### Get Kali Linux GPG key
-
+Get Kali Linux GPG key
+-----------------------
 **CAUTION:** Before proceeding, please carefully read [On Digital Signatures and Key Verification][qubes-verifying-signatures].
 This website cannot guarantee that any PGP key you download from the Internet is authentic.
 Always obtain a trusted key fingerprint via other channels, and always check any key you download against your trusted copy of the fingerprint.
@@ -70,7 +50,7 @@ This step is required since by (security) default a TemplateVM do not have a
 direct Internet connectivity. Users understanding the risks of enabling such
 access can change this configuration in firewall settings for the TemplateVM.
 
-1. Retrive the Kali Linux GPG key using a DispVM.
+1. Retrive the Kali Linux GPG key using a DisposableVM.
 
 ```shell_session
 $ gpg --keyserver hkp://keys.gnupg.net --recv-key 44C6513A8E4FB3D30875F758ED444FF07D8D0BF6
@@ -78,14 +58,14 @@ $ gpg --list-keys --with-fingerprint 44C6513A8E4FB3D30875F758ED444FF07D8D0BF6
 $ gpg --export --armor 44C6513A8E4FB3D30875F758ED444FF07D8D0BF6 > kali-key.asc
 ```
 
-2. **DO NOT TURN OFF** the DispVM, the `kali-key.asc` file will be copied to
+2. **DO NOT TURN OFF** the DisposableVM, the `kali-key.asc` file will be copied to
    the Kali Linux template in a further step.
 
 3. Make sure the key is the authentic Kali key.
    See the [Kali website] for further advice and instructions on verification.
 
-#### Create a Kali Linux (rolling) template
-
+Create a Kali Linux (rolling) template
+----------------------------------------
 These instructions will show you how to upgrade a Debian TemplateVM to Kali Linux.
 
 1. (Optional) Check for latest Debian stable template and install it (if not already done)
@@ -125,7 +105,6 @@ $ qvm-clone debian-<X> kali-rolling
 
 e.g. in this example we update `buster` stable repository to `bullseye` testing repository
 
-
 ```shell_session
 # sed -i 's/buster/bullseye/g' /etc/apt/sources.list
 # sed -i 's/buster/bullseye/g' /etc/apt/sources.list.d/qubes-r<X>.list
@@ -141,13 +120,13 @@ For installation based on Debian 10 stable, please note that the security reposi
 
 **Note:** During execution of the update, read carefully list of packages to be removed. If it contains `qubes-*` packages, terminate operation and try to resolve `qubes-*` packages missing dependencies first.
 
-6. Copy the Kali GPG key from the DispVM to the new template:
+6. Copy the Kali GPG key from the DisposableVM to the new template:
 
 ```shell_session
 $ qvm-copy kali-key.asc
 ```
 
-   The DispVM can now be turned off.
+   The DisposableVM can now be turned off.
 
 7. Add the Kali GPG key to the list of keys trusted to authenticate packages:
 
@@ -174,21 +153,20 @@ EOF
 $ qvm-run -a kali-rolling gnome-terminal
 ```
 
-#### Install the Kali tools
-
+Install the Kali tools
+------------------------------
 At this point you should have a working template and you can install the tools you need.
-Keep in mind that the tools you will install can easily take more than 10GB, [so you will need to **grow** the size of the VM1][qubes-resize-disk-image]
+Keep in mind that the tools you will install can easily take more than 10GB, [so you will need to **grow** the size of the VM][qubes-resize-disk-image]
 
-### Alternative Options to Kali Linux
-
- * [PenTester Framework][PTF], with [PTF Qubes OS guide][qubes-ptf]
- * BlackArch Linux, with [BA Qubes OS guide][qubes-blackarch]
- * [KATOOLIN][katoolin-howto]
- * more on the [Penetration Testing page][qubes-pentesting]
+Alternative Options to Kali Linux
+===================================
+* [PenTester Framework][PTF], with [PTF Qubes OS guide][qubes-ptf]
+* BlackArch Linux, with [BA Qubes OS guide][qubes-blackarch]
+* more on the [Penetration Testing page][qubes-pentesting]
  
 
-## Notes
-
+Notes
+=============
 Thanks to the people in [the discussion thread](https://github.com/QubesOS/qubes-issues/issues/1981).
 
 [qubes-verifying-signatures]: /security/verifying-signatures/

--- a/external/os-guides/pentesting/kali.md
+++ b/external/os-guides/pentesting/kali.md
@@ -122,11 +122,19 @@ $ qvm-copy kali-key.asc
 # echo 'deb https://http.kali.org/kali kali-rolling main non-free contrib' > /etc/apt/sources.list
 ```
 
-8. Update the template 
+8. Replace gcc8
+
+```shell_session
+# apt-get remove libgcc-8-dev && apt-get install libc6-dev
+```
+
+**Note:** This step is currently needed. But it will not always be the case.
+
+9. Update the template 
 
 **Note:** During execution of the update, carefully read list of packages to be removed. If it contains `qubes-vm-dependencies` package, terminate operation and try to resolve missing dependencies first. For other `qubes-*` packages, it is up to you to decide if you need them.
 
-9. Ensure a terminal can be opened in the new template.
+10. Ensure a terminal can be opened in the new template.
 
 ```shell_session
 $ qvm-run -a kali-rolling gnome-terminal

--- a/external/os-guides/pentesting/kali.md
+++ b/external/os-guides/pentesting/kali.md
@@ -12,8 +12,8 @@ Warnings
 --------------
 * The installation scripts and provided tools may have bugs, be vulnerable to Man in the Middle (MitM) attacks or other vulnerabilities.
 * Adding additional repositories or tools for installing software extends your trust to those tool providers.
-* Please keep in mind that using such template for security and privacy critical tasks is not recommended.
-* Kali Linux distribution is a rolling distribution constantly based on Debian testing release, so it will always have a newer software base than available in Qubes OS Debian template. Keep in mind that it may result in problems (especially in regard to package dependency) not covered by this tutorial.
+* Please keep in mind that using such a template for security and privacy critical tasks is not recommended.
+* Kali Linux distribution is a rolling distribution based on Debian testing release, so it will always have a newer software base than available in the Qubes OS Debian template. Keep in mind that this may result in problems (especially in regard to package dependencies) not covered by this tutorial.
 
 From the official ISO file <a name="hvm4_0"/>
 ==================================================
@@ -41,17 +41,17 @@ The steps can be summarized as:
 3. Add the Kali repository
 4. Update the template
 
-Get Kali Linux GPG key
+Get Kali Linux PGP key
 -----------------------
 **CAUTION:** Before proceeding, please carefully read [On Digital Signatures and Key Verification][qubes-verifying-signatures].
-This website cannot guarantee that any GPG key you download from the Internet is authentic.
-Always obtain a trusted key fingerprint via other channels, and always check key you download against your trusted copy of the fingerprint.
+This website cannot guarantee that any PGP key you download from the Internet is authentic.
+Always obtain a trusted key fingerprint via other channels, and always check any key you download against your trusted copy of the fingerprint.
 
 This step is required since by (security) default TemplateVM do not have a
 direct Internet connectivity. Users understanding the risks of enabling such
 access can change this configuration in firewall settings for the TemplateVM.
 
-1. Retrieve the Kali Linux GPG key using a DisposableVM.
+1. Retrieve the Kali Linux PGP key using a DisposableVM.
 
 ```shell_session
 $ gpg --keyserver hkp://keys.gnupg.net --recv-key 44C6513A8E4FB3D30875F758ED444FF07D8D0BF6
@@ -59,7 +59,7 @@ $ gpg --list-keys --with-fingerprint 44C6513A8E4FB3D30875F758ED444FF07D8D0BF6
 $ gpg --export --armor 44C6513A8E4FB3D30875F758ED444FF07D8D0BF6 > kali-key.asc
 ```
 
-2. **DO NOT TURN OFF** the DisposableVM, the `kali-key.asc` file will be copied to
+2. **DO NOT TURN OFF** the DisposableVM, the `kali-key.asc` file will be copied in
    the Kali Linux template for a further step.
 
 3. Make sure the key is the authentic Kali key.
@@ -69,14 +69,14 @@ Create a Kali Linux (rolling) template
 ----------------------------------------
 These instructions will show you how to upgrade a Debian TemplateVM to Kali Linux.
 
-1. (Optional) Check for latest Debian stable templates and install it (if not already done)
+1. (Optional) Check for latest Debian stable template and install it (if not already done)
 
 ```shell_session
 # qubes-dom0-update --action="search all" qubes-template-debian
 # qubes-dom0-update <latest Debian template>
 ```
 
-2. Start your latest Debian template
+2. Start your Debian template
 
 ```shell_session
 $ qvm-start debian-<X>
@@ -114,14 +114,14 @@ e.g. in this example we update `buster` stable repository to `bullseye` testing 
 For installation based on Debian 10 stable, please note that the security repository of Debian testing has [recently been renamed][Debian-security-naming-convention] from `<current testing>/update` to `<current-testing>-security`. To account for that change, execute the following command.
 
 ```shell_session
-# sed -i 's/bullseye\/updates/bullseye-security/g' /etc/apt/sources.list
+# sed -i 's%bullseye/updates%bullseye-security%g' /etc/apt/sources.list
 ```
 
 5. Update the template
 
 **Note:** During execution of the update, carefully read list of packages to be removed. If it contains `qubes-*` packages, terminate operation and try to resolve `qubes-*` packages missing dependencies first.
 
-6. Copy the Kali GPG key from the DisposableVM to the new template:
+6. Copy the Kali PGP key from the DisposableVM to the new template:
 
 ```shell_session
 $ qvm-copy kali-key.asc
@@ -129,7 +129,7 @@ $ qvm-copy kali-key.asc
 
    The DisposableVM can now be turned off.
 
-7. Add the Kali GPG key to the list of keys trusted to authenticate packages:
+7. Add the Kali PGP key to the list of keys trusted to authenticate packages:
 
 ```shell_session
 # cat /home/user/QubesIncoming/dispXXX/kali-key.asc | apt-key add -
@@ -157,7 +157,7 @@ $ qvm-run -a kali-rolling gnome-terminal
 Install the Kali tools
 ------------------------------
 At this point you should have a working template and you can install the tools you need.
-Keep in mind that the tools you will install can easily take more than 10 GB, [so you will need to **grow** the size of the VM.][qubes-resize-disk-image]
+Keep in mind that the tools you will install can easily take more than 10 GB, [so you will need to **grow** the size of the VM system storage.][qubes-resize-disk-image]
 
 Alternative Options to Kali Linux
 ===================================

--- a/external/os-guides/pentesting/kali.md
+++ b/external/os-guides/pentesting/kali.md
@@ -148,7 +148,7 @@ $ qvm-run -a kali-rolling gnome-terminal
 Install the Kali tools
 ------------------------------
 At this point you should have a working template and you can install the tools you need.
-You can find [a list of Kali Linux Metapackages here](https://tools.kali.org/kali-metapackages)
+You can find [a list of Kali Linux `Metapackages` here](https://tools.kali.org/kali-metapackages)
 Keep in mind that the tools you will install can easily take more than 10 GB, [so you will need to **grow** the size of the VM system storage.][qubes-resize-disk-image]
 
 Alternative Options to Kali Linux

--- a/external/os-guides/pentesting/kali.md
+++ b/external/os-guides/pentesting/kali.md
@@ -19,291 +19,6 @@ redirect_from:
 - Kali Linux distribution is a rolling distribution based constantly on Debian testing release, so it always will have newer software base than available in Qubes OS debian template. Keep in mind that it may result in problems (especially in regard to package dependency) not covered by this tutorial.
 
 
-## Qubes 3.2
-
-### How to Create a Kali Linux VM
-
-This guide is being created to give guidance on ways in which you could create a [Kali Linux][kali] penetration testing VM (qube) in Qubes OS.
-
-Kali Linux is the most widely used penetration testing Linux distribution.
-
-There are multiple ways to create a Kali Linux VM:
-
- 1. Create a HVM and use the official ISO to install the system or convert a [Virtual Image][kali-vbox]. Explained [here](#hvm3_2).
- 2. Clone the Qubes OS latest Debian template image and turn it into a Kali Linux distribution:
-    - using [katoolin]. Explained [here](#katoolin3_2).
-    - manually. Explained [here](#templatevm-from-debian3_2).
-
-### Kali Linux HVM <a name="hvm3_2"/>
-
-1. Download the Kali installation DVD
-
-2. Create a new HVM
-
-3. Start the HVM with attached CD/DVD
-
-        [user@dom0 ~]$ qvm-start <hvm-name> --cdrom <vm-name>:/home/user/Downloads/<iso-name>.iso
-
-### Debian based Kali Template with Katoolin <a name="katoolin3_2"/>
-
-**Note:** The prompt on each line indicates where each command should be entered (`@dom0`, `@debian-<X>` or `@kali`).
-
-1. (Optional) Check for latest Debian stable template and install it (if not already done)
-
-        [user@dom0 ~]$ sudo qubes-dom0-update --action="search all" qubes-template-debian
-        [user@dom0 ~]$ sudo qubes-dom0-update <latest Debian template>
-
-2. Start, update and close your latest Debian template
-
-        [user@dom0 ~]$ qvm-start debian-<X>
-        [user@dom0 ~]$ qvm-run -a debian-<X> gnome-terminal
-        [user@debian-<X> ~]$ sudo apt-get update
-        [user@debian-<X> ~]$ sudo apt-get upgrade
-        [user@dom0 ~]$ qvm-shutdown debian-<X>
-
-3. Clone `debian-<X>` template (two options)
-
-    1. Via Qubes VM Manager
-
-        ![Clone Debian Template](/attachment/wiki/Kali/clone-kali.png)
-
-    2. Via command line
-
-           [user@dom0 ~]$ qvm-clone debian-<X> kali
-
-4. Check the name of currently used repository in `/etc/apt/sources.list` and current testing [Debian release][Debian-releases]. Update repository list accordingly
-
-        [user@kali ~]$ sudo sed -i 's/<current stable>/<current testing>/g' /etc/apt/sources.list
-        [user@kali ~]$ sudo sed -i 's/<current stable>/<current testing>/g' /etc/apt/sources.list.d/qubes-r<X>.list
-      
-      e.g. in this example we update `stretch` stable repository to `buster` testing repository
-      
-        [user@kali ~]$ sudo sed -i 's/stretch/buster/g' /etc/apt/sources.list
-        [user@kali ~]$ sudo sed -i 's/stretch/buster/g' /etc/apt/sources.list.d/qubes-r<X>.list
-
-5. Upgrade `kali` template to latest Debian testing release
-
-        [user@kali ~]$ sudo apt-get update
-        [user@kali ~]$ sudo apt-get dist-upgrade
-        [user@kali ~]$ sudo apt-get autoremove
-
-   **Note:** During execution of a `dist-upgrade` command read carefully list of packages to be removed. 
-   If it contains `qubes-*` packages, terminate operation and try to resolve `qubes-*` packages missing dependencies first.
-
-6. Install Katoolin and add Kali Linux repositories
-
-    1. Install Katoolin
-
-           [user@kali ~]$ sudo apt-get install git
-           [user@kali ~]$ git clone https://github.com/LionSec/katoolin.git
-           [user@kali ~]$ sudo cp katoolin/katoolin.py /usr/bin/katoolin
-           [user@kali ~]$ sudo chmod +x /usr/bin/katoolin
-           [user@kali ~]$ rm -rf katoolin
-
-    2. Add Kali Linux repositories
-
-        - start katoolin
-
-                [user@kali ~]$ sudo katoolin
-
-        - select 'Add Kali repositories & Update'
-
-                1) Add Kali repositories & Update
-                2) View Categories
-                3) Install classicmenu indicator
-                4) Install Kali menu
-                5) Help
-
-                kat > 1
-
-            ![Add Kali repositories and Update menu](/attachment/wiki/Kali/katoolin-add-update-repo-menu.png)
-
-        - select 'Add kali linux repositories'
-
-                1) Add kali linux repositories
-                2) Update
-                3) Remove all kali linux repositories
-                4) View the contents of sources.list file
-
-                What do you want to do ?> 1
-
-            ![Add Kali repositories](/attachment/wiki/Kali/katoolin-add-repos-menu.png)
-
-        - update Kali repositories
-
-
-                1) Add kali linux repositories
-                2) Update
-                3) Remove all kali linux repositories
-                4) View the contents of sources.list file
-
-                What do you want to do ?> 2
-
-        - quit katoolin by pressing `CRTL` + `c` keys
-
-                What do you want to do ?> ^CShutdown requested...Goodbye...
-
-7. Clean up and update `kali` template
-
-       [user@kali ~]$ sudo apt-get dist-upgrade
-       [user@kali ~]$ sudo apt-get autoremove
-
-8. Shut down `kali` template
-
-       [user@kali ~]$ sudo shutdown -h now
-
-9. Start image
-
-        [user@dom0 ~]$ qvm-start kali
-
-10. Install tools
-
-    **Note** [Resize the template disk image][qubes-resize-disk-image] to at least 20GB if you plan on installing all packages from Kali distribution.
-
-    1. View Categories
-
-        - start katoolin
-
-                [user@kali ~]$ sudo katoolin
-
-        - select `2) View Categories`
-
-    2. Select the categories/tools you want to install
-
-        - For more information on how to use Katoolin see [How to Auto Install All Kali Linux Tools Using “Katoolin” on Debian/Ubuntu][katoolin-howto].
-
-        - **Note:** The `all` option does not work for `Information Gathering`, `Web Apps`, `Forensic Tools`, `Reverse Engineering` and `Extra`.
-
-11. Create a AppVMs based on the `kali` template
-
-    - (Optional) Attach necessary devices
-
-### Kali Linux TemplateVM from a Debian template  <a name="templatevm-from-debian3_2"/>
-
-This section will explain how to create your own [Kali] Linux TemplateVM based
-on a current stable Debian TemplateVM. The basic idea is to personalize the
-template with all the tools needed, and then spin up isolated AppVMs based on
-the template.
-
-The steps can be summarised as:
-
-1. Install Qubes stable Debian template
-2. Upgrade the template to Debian testing release
-3. Install Kali Linux through the ``kali-linux-full`` package
-4. Use the template to build AppVM so that you can maintain isolation between
-   e.g. pentesting jobs
-
-#### Get Kali Linux GPG key
-
-**CAUTION:** Before proceeding, please carefully read [On Digital Signatures and Key Verification][qubes-verifying-signatures].
-This website cannot guarantee that any PGP key you download from the Internet is authentic.
-Always obtain a trusted key fingerprint via other channels, and always check any key you download against your trusted copy of the fingerprint.
-
-This step is required since by (security) default a TemplateVM do not have a
-direct Internet connectivity. Users understanding the risks of enabling such
-access can change this configuration in firewall settings for the TemplateVM.
-
-**Note:** The prompt on each line indicates where each command should be entered
-(`@dom0`, `@kali-rolling`, `@xxxx-dvm` or `@debian-<X>`).
-
-1. Retrive the Kali Linux GPG key using a DispVM.
-
-        [user@xxxx-dvm ~]$ gpg --keyserver hkp://keys.gnupg.net --recv-key 44C6513A8E4FB3D30875F758ED444FF07D8D0BF6
-        [user@xxxx-dvm ~]$ gpg --list-keys --with-fingerprint 44C6513A8E4FB3D30875F758ED444FF07D8D0BF6 
-        [user@xxxx-dvm ~]$ gpg --export --armor 44C6513A8E4FB3D30875F758ED444FF07D8D0BF6 > kali-key.asc
-
-2. **DO NOT TURN OFF** the DispVM, the `kali-key.asc` file will be copied to
-   the Kali Linux template in a further step.
-
-3. Make sure the key is the authentic Kali key.
-   See the [Kali website] for further advice and instructions on verification.
-
-#### Create a Kali Linux (rolling) template
-
-These instructions will show you how to upgrade a Debian TemplateVM to Kali Linux.
-
-1. (Optional) Check for latest Debian stable template and install it (if not already done)
-
-        [user@dom0 ~]$ sudo qubes-dom0-update --action="search all" qubes-template-debian
-        [user@dom0 ~]$ sudo qubes-dom0-update <latest Debian template>
-
-2. Start, update and close your latest Debian template
-
-        [user@dom0 ~]$ qvm-start debian-<X>
-        [user@dom0 ~]$ qvm-run -a debian-<X> gnome-terminal
-        [user@debian-<X> ~]$ sudo apt-get update
-        [user@debian-<X> ~]$ sudo apt-get upgrade
-        [user@dom0 ~]$ qvm-shutdown debian-<X>
-
-3. Clone `debian-X` template
-
-        [user@dom0 ~]$ qvm-clone debian-<X> kali-rolling
-
-4. Check the name of currently used repository in `/etc/apt/sources.list` and current testing [Debian release][Debian-releases]. Update repository list accordingly
-
-        [user@kali-rolling ~]$ sudo sed -i 's/<current stable>/<current testing>/g' /etc/apt/sources.list
-        [user@kali-rolling ~]$ sudo sed -i 's/<current stable>/<current testing>/g' /etc/apt/sources.list.d/qubes-r<X>.list
-      
-      e.g. in this example we update `stretch` stable repository to `buster` testing repository
-      
-        [user@kali-rolling ~]$ sudo sed -i 's/stretch/buster/g' /etc/apt/sources.list
-        [user@kali-rolling ~]$ sudo sed -i 's/stretch/buster/g' /etc/apt/sources.list.d/qubes-r<X>.list
-
-5. Upgrade `kali-rolling` template to latest Debian testing release
-
-        [user@kali-rolling ~]$ sudo apt-get update
-        [user@kali-rolling ~]$ sudo apt-get dist-upgrade
-        [user@kali-rolling ~]$ sudo apt-get autoremove
-
-**Note:** During execution of a `dist-upgrade` command read carefully list of packages to be removed. If it contains `qubes-*` packages, terminate operation and try to resolve `qubes-*` packages missing dependencies first.
-
-6. Copy the Kali GPG key from the DispVM to the new template:
-
-        [user@xxxx-dvm ~]$ qvm-copy-to-vm kali-rolling kali-key.asc
-
-   The DispVM can now be turned off.
-
-7. Add the Kali GPG key to the list of keys trusted to authenticate packages:
-
-        [user@kali-rolling ~]$ cat /home/user/QubesIncoming/dispXXX/kali-key.asc | sudo apt-key add -
-
-   This command should return `OK` on a line by itself.
-
-8. Attempt the upgrade process in the new template.
-
-        [user@kali-rolling ~]$ sudo cat <<EOF > /etc/apt/sources.list.d/kali.list
-        # Kali Linux repository
-        deb http://http.kali.org/kali kali-rolling main non-free contrib
-        EOF
-        [user@kali-rolling ~]$ sudo apt-get update
-        [user@kali-rolling ~]$ sudo apt-get dist-upgrade
-        [user@kali-rolling ~]$ sudo apt-get autoremove
- 
-9. Shut down the new template.
-
-        [user@dom0 ~]$ qvm-shutdown kali-rolling
-
-10. Ensure a terminal can be opened in the new template.
-
-        [user@dom0 ~]$ qvm-run -a kali-rolling gnome-terminal
-
-#### Install the Kali tools
-
-At this point you should have a working template and you can install the tools you need.
-
-1. [Resize the template disk image][qubes-resize-disk-image] if you plan on installing the full Kali distribution. For example to install `kali-linux-full` you must **grow** the size of the VM system from 10GB to at least 20GB.
-
-2. Install Kali Linux tools:
-
-        [user@kali-rolling ~]$ sudo apt-get install kali-linux-full
-        
-3. (Optional) Customise the template's home directory (e.g. install your licensed copy of Burp Suite Professional)
-        
-#### Use the template
-
-The template is ready to be used. You can now spin up AppVMs based on the `kali-rolling` template.
-
-
 ## Qubes 4.0
 
 ### How to Create a Kali Linux VM
@@ -327,137 +42,9 @@ There are multiple ways to create a Kali Linux VM:
 
 3. Start the HVM with attached CD/DVD
 
-        [user@dom0 ~]$ qvm-start <hvm-name> --cdrom <vm-name>:/home/user/Downloads/<iso-name>.iso
-
-### Debian based Kali Template with Katoolin <a name="katoolin4_0"/>
-
-**Note:** The prompt on each line indicates where each command should be entered (`@dom0`, `@debian-<X>` or `@kali`).
-
-1. (Optional) Check for latest Debian stable template and install it (if not already done)
-
-        [user@dom0 ~]$ sudo qubes-dom0-update --action="search all" qubes-template-debian
-        [user@dom0 ~]$ sudo qubes-dom0-update <latest Debian template>
-
-2. Start, update and close your latest Debian template
-
-        [user@dom0 ~]$ qvm-start debian-<X>
-        [user@dom0 ~]$ qvm-run -a debian-<X> gnome-terminal
-        [user@debian-<X> ~]$ sudo apt-get update
-        [user@debian-<X> ~]$ sudo apt-get upgrade
-        [user@dom0 ~]$ qvm-shutdown debian-<X>
-
-3. Clone `debian-<X>` template (two options)
-
-    1. Via Qubes VM Manager
-
-        ![Clone Debian Template](/attachment/wiki/Kali/clone-kali.png)
-
-    2. Via command line
-
-           [user@dom0 ~]$ qvm-clone debian-<X> kali
-
-4. Check the name of currently used repository in `/etc/apt/sources.list` and current testing [Debian release][Debian-releases]. Update repository list accordingly.
-
-        [user@kali ~]$ sudo sed -i 's/<current stable>/<current testing>/g' /etc/apt/sources.list
-        [user@kali ~]$ sudo sed -i 's/<current stable>/<current testing>/g' /etc/apt/sources.list.d/qubes-r<X>.list
-      
-      e.g. in this example we update `stretch` stable repository to `buster` testing repository
-      
-        [user@kali ~]$ sudo sed -i 's/stretch/buster/g' /etc/apt/sources.list
-        [user@kali ~]$ sudo sed -i 's/stretch/buster/g' /etc/apt/sources.list.d/qubes-r<X>.list
-        
-For installation based on Debian 10 stable, please note that the security repository of Debian testing has [recently been renamed][Debian-security-naming-convention] from `<current testing>/update` to `<current-testing>-security`. To account for that change, execute the following command.
-
-        [user@kali ~]$ sudo sed -i 's/bullseye\/updates/bullseye-security/g' /etc/apt/sources.list
-        
-5. Upgrade `kali` template to latest Debian testing release
-
-        [user@kali ~]$ sudo apt-get update
-        [user@kali ~]$ sudo apt-get dist-upgrade
-        [user@kali ~]$ sudo apt-get autoremove
-
-   **Note:** During execution of a `dist-upgrade` command read carefully list of packages to be removed. 
-   If it contains `qubes-*` packages, terminate operation and try to resolve `qubes-*` packages missing dependencies first.
-
-6. Install Katoolin and add Kali Linux repositories
-
-    1. Install Katoolin
-
-           [user@kali ~]$ sudo apt-get install git
-           [user@kali ~]$ git clone https://github.com/LionSec/katoolin.git
-           [user@kali ~]$ sudo cp katoolin/katoolin.py /usr/bin/katoolin
-           [user@kali ~]$ sudo chmod +x /usr/bin/katoolin
-           [user@kali ~]$ rm -rf katoolin
-
-    2. Add Kali Linux repositories
-
-        - start katoolin
-
-                [user@kali ~]$ sudo katoolin
-
-        - select 'Add Kali repositories & Update'
-
-                1) Add Kali repositories & Update
-                2) View Categories
-                3) Install classicmenu indicator
-                4) Install Kali menu
-                5) Help
-
-                kat > 1
-
-            ![Add Kali repositories and Update menu](/attachment/wiki/Kali/katoolin-add-update-repo-menu.png)
-
-        - select 'Add kali linux repositories'
-
-                1) Add kali linux repositories
-                2) Update
-                3) Remove all kali linux repositories
-                4) View the contents of sources.list file
-
-                What do you want to do ?> 1
-
-            ![Add Kali repositories](/attachment/wiki/Kali/katoolin-add-repos-menu.png)
-
-        - update Kali repositories
-
-
-                1) Add kali linux repositories
-                2) Update
-                3) Remove all kali linux repositories
-                4) View the contents of sources.list file
-
-                What do you want to do ?> 2
-
-        - quit katoolin by pressing `CRTL` + `c` keys
-
-                What do you want to do ?> ^CShutdown requested...Goodbye...
-
-7. Clean up and update `kali` template
-
-       [user@kali ~]$ sudo apt-get dist-upgrade
-       [user@kali ~]$ sudo apt-get autoremove
-
-8. Install tools
-
-    **Note** [Resize the template disk image][qubes-resize-disk-image] to at least 20GB if you plan on installing all packages from Kali distribution.
-
-    1. View Categories
-
-        - start katoolin
-
-                [user@kali ~]$ sudo katoolin
-
-        - select `2) View Categories`
-
-    2. Select the categories/tools you want to install
-
-        - For more information on how to use Katoolin see [How to Auto Install All Kali Linux Tools Using “Katoolin” on Debian/Ubuntu][katoolin-howto].
-
-        - **Note:** The `all` option does not work for `Information Gathering`, `Web Apps`, `Forensic Tools`, `Reverse Engineering` and `Extra`.
-
-9. Create a AppVMs based on the `kali` template
-
-    - (Optional) Attach necessary devices
+```shell_session
+$ qvm-start <hvm-name> --cdrom <vm-name>:/home/user/Downloads/<iso-name>.iso
+```
 
 ### Kali Linux TemplateVM from a Debian template  <a name="templatevm-from-debian4_0"/>
 
@@ -470,9 +57,8 @@ The steps can be summarised as:
 
 1. Install Qubes stable Debian template
 2. Upgrade the template to Debian testing release
-3. Install Kali Linux through the ``kali-linux-full`` package
-4. Use the template to build AppVM so that you can maintain isolation between
-   e.g. pentesting jobs
+3. Add the Kali repository
+4. Update the template
 
 #### Get Kali Linux GPG key
 
@@ -484,14 +70,13 @@ This step is required since by (security) default a TemplateVM do not have a
 direct Internet connectivity. Users understanding the risks of enabling such
 access can change this configuration in firewall settings for the TemplateVM.
 
-**Note:** The prompt on each line indicates where each command should be entered
-(`@dom0`, `@kali-rolling`, `@xxxx-dvm` or `@debian-<X>`).
-
 1. Retrive the Kali Linux GPG key using a DispVM.
 
-        [user@xxxx-dvm ~]$ gpg --keyserver hkp://keys.gnupg.net --recv-key 44C6513A8E4FB3D30875F758ED444FF07D8D0BF6
-        [user@xxxx-dvm ~]$ gpg --list-keys --with-fingerprint 44C6513A8E4FB3D30875F758ED444FF07D8D0BF6 
-        [user@xxxx-dvm ~]$ gpg --export --armor 44C6513A8E4FB3D30875F758ED444FF07D8D0BF6 > kali-key.asc
+```shell_session
+$ gpg --keyserver hkp://keys.gnupg.net --recv-key 44C6513A8E4FB3D30875F758ED444FF07D8D0BF6
+$ gpg --list-keys --with-fingerprint 44C6513A8E4FB3D30875F758ED444FF07D8D0BF6 
+$ gpg --export --armor 44C6513A8E4FB3D30875F758ED444FF07D8D0BF6 > kali-key.asc
+```
 
 2. **DO NOT TURN OFF** the DispVM, the `kali-key.asc` file will be copied to
    the Kali Linux template in a further step.
@@ -505,85 +90,94 @@ These instructions will show you how to upgrade a Debian TemplateVM to Kali Linu
 
 1. (Optional) Check for latest Debian stable template and install it (if not already done)
 
-        [user@dom0 ~]$ sudo qubes-dom0-update --action="search all" qubes-template-debian
-        [user@dom0 ~]$ sudo qubes-dom0-update <latest Debian template>
+```shell_session
+$ sudo qubes-dom0-update --action="search all" qubes-template-debian
+$ sudo qubes-dom0-update <latest Debian template>
+```
 
-2. Start, update and close your latest Debian template
+2. Start your latest Debian template
 
-        [user@dom0 ~]$ qvm-start debian-<X>
-        [user@dom0 ~]$ qvm-run -a debian-<X> gnome-terminal
-        [user@debian-<X> ~]$ sudo apt-get update
-        [user@debian-<X> ~]$ sudo apt-get upgrade
-        [user@dom0 ~]$ qvm-shutdown debian-<X>
+```shell_session
+$ qvm-start debian-<X>
+$ qvm-run -a debian-<X> gnome-terminal
+```
 
-3. Clone `debian-X` template
+3. Update it
 
-        [user@dom0 ~]$ qvm-clone debian-<X> kali-rolling
+4. And then close it
 
-4. Check the name of currently used repository in `/etc/apt/sources.list` and current testing [Debian release][Debian-releases]. Update repository list accordingly
+```shell_session
+$ qvm-shutdown debian-<X>
+```
 
-        [user@kali-rolling ~]$ sudo sed -i 's/<current stable>/<current testing>/g' /etc/apt/sources.list
-        [user@kali-rolling ~]$ sudo sed -i 's/<current stable>/<current testing>/g' /etc/apt/sources.list.d/qubes-r<X>.list
-      
-      e.g. in this example we update `stretch` stable repository to `buster` testing repository
-      
-        [user@kali-rolling ~]$ sudo sed -i 's/stretch/buster/g' /etc/apt/sources.list
-        [user@kali-rolling ~]$ sudo sed -i 's/stretch/buster/g' /etc/apt/sources.list.d/qubes-r<X>.list
+5. Clone `debian-X` template
+
+```shell_session
+$ qvm-clone debian-<X> kali-rolling
+```
+
+6. Check the name of currently used repository in `/etc/apt/sources.list` and current testing [Debian release][Debian-releases]. Update repository list accordingly
+
+```shell_session
+# sed -i 's/<current stable>/<current testing>/g' /etc/apt/sources.list
+# sed -i 's/<current stable>/<current testing>/g' /etc/apt/sources.list.d/qubes-r<X>.list
+```
+
+e.g. in this example we update `buster` stable repository to `bullseye` testing repository
+
+
+```shell_session
+# sed -i 's/buster/bullseye/g' /etc/apt/sources.list
+# sed -i 's/buster/bullseye/g' /etc/apt/sources.list.d/qubes-r<X>.list
+```
         
 For installation based on Debian 10 stable, please note that the security repository of Debian testing has [recently been renamed][Debian-security-naming-convention] from `<current testing>/update` to `<current-testing>-security`. To account for that change, execute the following command.
 
-        [user@kali ~]$ sudo sed -i 's/bullseye\/updates/bullseye-security/g' /etc/apt/sources.list
+```shell_session
+# sed -i 's/bullseye\/updates/bullseye-security/g' /etc/apt/sources.list
+```
 
-5. Upgrade `kali-rolling` template to latest Debian testing release
+5. Update the template
 
-        [user@kali-rolling ~]$ sudo apt-get update
-        [user@kali-rolling ~]$ sudo apt-get dist-upgrade
-        [user@kali-rolling ~]$ sudo apt-get autoremove
-
-**Note:** During execution of a `dist-upgrade` command read carefully list of packages to be removed. If it contains `qubes-*` packages, terminate operation and try to resolve `qubes-*` packages missing dependencies first.
+**Note:** During execution of the update, read carefully list of packages to be removed. If it contains `qubes-*` packages, terminate operation and try to resolve `qubes-*` packages missing dependencies first.
 
 6. Copy the Kali GPG key from the DispVM to the new template:
-      
-        [user@xxxx-dvm ~]$ qvm-copy kali-key.asc
+
+```shell_session
+$ qvm-copy kali-key.asc
+```
 
    The DispVM can now be turned off.
 
 7. Add the Kali GPG key to the list of keys trusted to authenticate packages:
 
-        [user@kali-rolling ~]$ cat /home/user/QubesIncoming/dispXXX/kali-key.asc | sudo apt-key add -
+```shell_session
+# cat /home/user/QubesIncoming/dispXXX/kali-key.asc | apt-key add -
+```
 
    This command should return `OK` on a line by itself.
 
-8. Attempt the upgrade process in the new template.
+8. Add the Kali repository
 
-        [user@kali-rolling ~]$ sudo cat <<EOF > /etc/apt/sources.list.d/kali.list
-        # Kali Linux repository
-        deb http://http.kali.org/kali kali-rolling main non-free contrib
-        EOF
-        [user@kali-rolling ~]$ sudo apt-get update
-        [user@kali-rolling ~]$ sudo apt-get dist-upgrade
-        [user@kali-rolling ~]$ sudo apt-get autoremove
+```shell_session
+# cat <<EOF > /etc/apt/sources.list.d/kali.list
+# Kali Linux repository
+deb https://http.kali.org/kali kali-rolling main non-free contrib
+EOF
+```
 
-9. Ensure a terminal can be opened in the new template.
+9. Update the template 
 
-        [user@dom0 ~]$ qvm-run -a kali-rolling gnome-terminal
+10. Ensure a terminal can be opened in the new template.
+
+```shell_session
+$ qvm-run -a kali-rolling gnome-terminal
+```
 
 #### Install the Kali tools
 
 At this point you should have a working template and you can install the tools you need.
-
-1. [Resize the template disk image][qubes-resize-disk-image] if you plan on installing the full Kali distribution. For example to install `kali-linux-full` you must **grow** the size of the VM system from 10GB to at least 20GB.
-
-2. Install Kali Linux tools:
-
-        [user@kali-rolling ~]$ sudo apt-get install kali-linux-full
-        
-3. (Optional) Customise the template's home directory (e.g. install your licensed copy of Burp Suite Professional)
-        
-#### Use the template
-
-The template is ready to be used. You can now spin up AppVMs based on the `kali-rolling` template.
-
+Keep in mind that the tools you will install can easily take more than 10GB, [so you will need to **grow** the size of the VM1][qubes-resize-disk-image]
 
 ### Alternative Options to Kali Linux
 

--- a/external/os-guides/pentesting/kali.md
+++ b/external/os-guides/pentesting/kali.md
@@ -97,7 +97,7 @@ e.g. in this example we update `buster` stable repository to `bullseye` testing 
 
 4. Enable the QubesOS `testing` and `securitytesting` repositories
 
-In `/etc/apt/sources.list.d/qubes-r<X>.list`, enable the 'testing' and 'securitytesting' repository.
+In `/etc/apt/sources.list.d/qubes-r<X>.list`, enable the `testing` and `securitytesting` repository.
 We do that to reduce the 'dependency hell' between Qubes repository and Kali repository.
 
 5. Copy the Kali PGP key from the DisposableVM to the new template:

--- a/external/os-guides/pentesting/kali.md
+++ b/external/os-guides/pentesting/kali.md
@@ -12,14 +12,15 @@ Warnings
 --------------
 * The installation scripts and provided tools may have bugs, be vulnerable to Man in the Middle (MitM) attacks or other vulnerabilities.
 * Adding additional repositories or tools for installing software extends your trust to those tool providers.
-* Please keep in mind that using such a VM or VM's based on the template for security and privacy critical tasks is not recommended.
-* Kali Linux distribution is a rolling distribution based constantly on Debian testing release, so it always will have newer software base than available in Qubes OS debian template. Keep in mind that it may result in problems (especially in regard to package dependency) not covered by this tutorial.
+* Please keep in mind that using such template for security and privacy critical tasks is not recommended.
+* Kali Linux distribution is a rolling distribution constantly based on Debian testing release, so it will always have a newer software base than available in Qubes OS Debian template. Keep in mind that it may result in problems (especially in regard to package dependency) not covered by this tutorial.
 
 From the official ISO file <a name="hvm4_0"/>
 ==================================================
-Only use this method if you want to have the full Kali GUI (desktop, fancy menus, ...), it come at the cost of much greater resources consumption.
+Only use this method if you want the full Kali GUI (desktop, fancy menus, etc.).
+It comes at the cost of much greater resources consumption.
 
-1. Download the Kali installation DVD
+1. Download the Kali ISO
 2. Create a new HVM
 3. Start the HVM with attached CD/DVD
 ```shell_session
@@ -28,12 +29,12 @@ $ qvm-start <hvm-name> --cdrom <vm-name>:/home/user/Downloads/<iso-name>.iso
 
 From a Debian template  <a name="templatevm-from-debian4_0"/>
 ================================================================
-This is the recommanded method.
-Easier to maintain and less demanding on resources, but you won't have the full Kali GUI.
+This is the recommended method.
+Easier to maintain and less demanding on resources, but you won’t have the full Kali GUI.
 
-If you need to install custom kernel modules (wifi drivers, ...) you need use the kernel provided by Kali instead of the kernel provided by Qubes, see [Managing VM Kernel](/doc/managing-vm-kernel/)
+If you need to install custom kernel modules (wifi drivers, …) you need to use the kernel provided by Kali instead of the kernel provided by Qubes, see [Managing VM Kernel.](/doc/managing-vm-kernel/)
 
-The steps can be summarised as:
+The steps can be summarized as:
 
 1. Install Qubes stable Debian template
 2. Upgrade the template to Debian testing release
@@ -43,14 +44,14 @@ The steps can be summarised as:
 Get Kali Linux GPG key
 -----------------------
 **CAUTION:** Before proceeding, please carefully read [On Digital Signatures and Key Verification][qubes-verifying-signatures].
-This website cannot guarantee that any PGP key you download from the Internet is authentic.
-Always obtain a trusted key fingerprint via other channels, and always check any key you download against your trusted copy of the fingerprint.
+This website cannot guarantee that any GPG key you download from the Internet is authentic.
+Always obtain a trusted key fingerprint via other channels, and always check key you download against your trusted copy of the fingerprint.
 
-This step is required since by (security) default a TemplateVM do not have a
+This step is required since by (security) default TemplateVM do not have a
 direct Internet connectivity. Users understanding the risks of enabling such
 access can change this configuration in firewall settings for the TemplateVM.
 
-1. Retrive the Kali Linux GPG key using a DisposableVM.
+1. Retrieve the Kali Linux GPG key using a DisposableVM.
 
 ```shell_session
 $ gpg --keyserver hkp://keys.gnupg.net --recv-key 44C6513A8E4FB3D30875F758ED444FF07D8D0BF6
@@ -59,7 +60,7 @@ $ gpg --export --armor 44C6513A8E4FB3D30875F758ED444FF07D8D0BF6 > kali-key.asc
 ```
 
 2. **DO NOT TURN OFF** the DisposableVM, the `kali-key.asc` file will be copied to
-   the Kali Linux template in a further step.
+   the Kali Linux template for a further step.
 
 3. Make sure the key is the authentic Kali key.
    See the [Kali website] for further advice and instructions on verification.
@@ -68,11 +69,11 @@ Create a Kali Linux (rolling) template
 ----------------------------------------
 These instructions will show you how to upgrade a Debian TemplateVM to Kali Linux.
 
-1. (Optional) Check for latest Debian stable template and install it (if not already done)
+1. (Optional) Check for latest Debian stable templates and install it (if not already done)
 
 ```shell_session
-$ sudo qubes-dom0-update --action="search all" qubes-template-debian
-$ sudo qubes-dom0-update <latest Debian template>
+# qubes-dom0-update --action="search all" qubes-template-debian
+# qubes-dom0-update <latest Debian template>
 ```
 
 2. Start your latest Debian template
@@ -118,7 +119,7 @@ For installation based on Debian 10 stable, please note that the security reposi
 
 5. Update the template
 
-**Note:** During execution of the update, read carefully list of packages to be removed. If it contains `qubes-*` packages, terminate operation and try to resolve `qubes-*` packages missing dependencies first.
+**Note:** During execution of the update, carefully read list of packages to be removed. If it contains `qubes-*` packages, terminate operation and try to resolve `qubes-*` packages missing dependencies first.
 
 6. Copy the Kali GPG key from the DisposableVM to the new template:
 
@@ -134,7 +135,7 @@ $ qvm-copy kali-key.asc
 # cat /home/user/QubesIncoming/dispXXX/kali-key.asc | apt-key add -
 ```
 
-   This command should return `OK` on a line by itself.
+   This command should return: "`OK".`
 
 8. Add the Kali repository
 
@@ -156,7 +157,7 @@ $ qvm-run -a kali-rolling gnome-terminal
 Install the Kali tools
 ------------------------------
 At this point you should have a working template and you can install the tools you need.
-Keep in mind that the tools you will install can easily take more than 10GB, [so you will need to **grow** the size of the VM][qubes-resize-disk-image]
+Keep in mind that the tools you will install can easily take more than 10 GB, [so you will need to **grow** the size of the VM.][qubes-resize-disk-image]
 
 Alternative Options to Kali Linux
 ===================================

--- a/external/os-guides/pentesting/kali.md
+++ b/external/os-guides/pentesting/kali.md
@@ -21,7 +21,7 @@ Only use this method if you want the full Kali GUI (desktop, fancy menus, etc.).
 It comes at the cost of much greater resources consumption.
 
 1. Download the Kali ISO
-2. Create a new HVM
+2. [Create a new HVM][qubes-new-hvm]
 3. Start the HVM with attached CD/DVD
 ```shell_session
 $ qvm-start <hvm-name> --cdrom <vm-name>:/home/user/Downloads/<iso-name>.iso
@@ -37,9 +37,10 @@ If you need to install custom kernel modules (wifi drivers, …) you need to use
 The steps can be summarized as:
 
 1. Install Qubes stable Debian template
-2. Add `testing` and `securitytesting` Qubes repositories
-3. Add the Kali repository
-4. Update the template
+2. Upgrade from Debian `stable` to Debian `testing` for Qubes repositories
+3. Add `testing` and `securitytesting` Qubes repositories
+4. Replace the content of `/etc/apt/sources.list` file with the Kali repository
+5. Update the template
 
 Get Kali Linux PGP key
 -----------------------
@@ -128,8 +129,10 @@ $ qvm-copy kali-key.asc
 # apt-get remove libgcc-8-dev && apt-get install libc6-dev
 ```
 
-**Note:** This kind of dependency issues will pop up and disappear without notice.
-It depends on the differences of dependencies between the Kali repository, the testing Qubes repository and the dependency issues related to the upgrade from stable Debian to testing Debian/Kali.
+**Note:** This kind of dependency issue will pop up and disappear without notice.
+Such issues arise because of the differences of dependencies in packages from
+the Kali repository, the Qubes testing repository and the Debian testing
+repository.
 So this step [step 8] is currently needed. But it will not always be the case.
 
 9. Update the template 
@@ -145,6 +148,7 @@ $ qvm-run -a kali-rolling gnome-terminal
 Install the Kali tools
 ------------------------------
 At this point you should have a working template and you can install the tools you need.
+You can find [a list of Kali Linux Metapackages here](https://tools.kali.org/kali-metapackages)
 Keep in mind that the tools you will install can easily take more than 10 GB, [so you will need to **grow** the size of the VM system storage.][qubes-resize-disk-image]
 
 Alternative Options to Kali Linux
@@ -164,6 +168,7 @@ Thanks to the people in [the discussion thread](https://github.com/QubesOS/qubes
 [qubes-ptf]: /doc/pentesting/ptf/
 [qubes-template-debian-install]: /doc/templates/debian/#install
 [qubes-resize-disk-image]: /doc/resize-disk-image/
+[qubes-new-hvm]: /doc/standalone-and-hvm/
 
 [kali]: https://www.kali.org/
 [kali-vbox]: https://www.offensive-security.com/kali-linux-vmware-virtualbox-image-download/

--- a/external/os-guides/pentesting/kali.md
+++ b/external/os-guides/pentesting/kali.md
@@ -135,7 +135,7 @@ $ qvm-copy kali-key.asc
 # cat /home/user/QubesIncoming/dispXXX/kali-key.asc | apt-key add -
 ```
 
-   This command should return: "`OK".`
+   This command should return: `OK`.
 
 8. Add the Kali repository
 

--- a/external/os-guides/pentesting/kali.md
+++ b/external/os-guides/pentesting/kali.md
@@ -122,13 +122,15 @@ $ qvm-copy kali-key.asc
 # echo 'deb https://http.kali.org/kali kali-rolling main non-free contrib' > /etc/apt/sources.list
 ```
 
-8. Replace `gcc8`
+8. Replace `gcc8` to work around a dependency issue
 
 ```shell_session
 # apt-get remove libgcc-8-dev && apt-get install libc6-dev
 ```
 
-**Note:** This step is currently needed. But it will not always be the case.
+**Note:** This kind of dependency issues will pop up and disappear without notice.
+It depends on the differences of dependencies between the Kali repository, the testing Qubes repository and the dependency issues related to the upgrade from stable Debian to testing Debian/Kali.
+So this step [step 8] is currently needed. But it will not always be the case.
 
 9. Update the template 
 

--- a/external/os-guides/pentesting/kali.md
+++ b/external/os-guides/pentesting/kali.md
@@ -31,7 +31,7 @@ From a Debian template  <a name="templatevm-from-debian4_0"/>
 This is the recommanded method.
 Easier to maintain and less demanding on resources, but you won't have the full Kali GUI.
 
-If you need to install custom kernel modules (wifi drivers, ...) you need use the kernel provided by Kali instead of the kernel provided by Qubes, see [Managing VM Kernel][managing-vm-kernel]
+If you need to install custom kernel modules (wifi drivers, ...) you need use the kernel provided by Kali instead of the kernel provided by Qubes, see [Managing VM Kernel](/doc/managing-vm-kernel/)
 
 The steps can be summarised as:
 


### PR DESCRIPTION
My issues with the current Kali template documentation
-------------------------------------------------------------------------
- Contains and start with obsolete QubesOS version (r3.X)
- The "Katoolin" tools haven't been updated for quite some times, never succeeded to create a Kali template with it.
- The package "kali-linux-full" doesn't exist anymore

Main modification I am trying to make
--------------------------------------------------
* Delete all the obsolete part, and keep only documentation for 4.0, and only the method "from the iso" and the method "from a debian template"
* Try to explain the advantages and disadvantages of both way of creating a Kali VM, and recommend one


