### PR TITLE
Fix incorrect self-link in gsod.md

### DIFF
--- a/developer/general/gsod.md
+++ b/developer/general/gsod.md
@@ -150,7 +150,7 @@ This could be helped by writing consolidated guide with with a clear list of sym
 [team]: /team/
 [gsod-doc]: https://developers.google.com/season-of-docs/docs/
 [gsod-faq]: https://developers.google.com/season-of-docs/docs/faq
-[gsod.md]: https://github.com/QubesOS/qubes-doc/blob/master/basics_dev/gsod.md
+[gsod.md]: https://github.com/QubesOS/qubes-doc/blob/master/developer/general/gsod.md
 [gsod-2020-thread]: https://groups.google.com/d/msgid/qubes-project/aac9b148-4081-ebd8-cb9d-9a9191033484%40qubes-os.org
 [Documentation Guidelines]: /doc/doc-guidelines/
 [Help, Support, and Mailing Lists]: /support/


### PR DESCRIPTION
[gsod.md] self-link redirects to the 404 page as "/basic_dev/gsod.md" page does not exist.

Hence, I've replaced it with the correct one.