### PR TITLE
Update installation-guide.md

### DIFF
--- a/user/downloading-installing-upgrading/installation-guide.md
+++ b/user/downloading-installing-upgrading/installation-guide.md
@@ -72,7 +72,7 @@ Once the ISO has been verified as authentic, you should copy it onto the install
 
 If you choose to use a USB drive, copy the ISO onto the USB device, e.g. using `dd`:
 
-    $ sudo dd if=Qubes-R3-x86_64.iso of=/dev/sdX bs=1048576 && sync
+    $ sudo dd if=Qubes-R3-x86_64.iso of=/dev/sdX status=progress bs=1048576 && sync
 
 Change `Qubes-R3-x86_64.iso` to the filename of the version you're installing, and change `/dev/sdX` to the correct target device e.g., `/dev/sdc`). 
 


### PR DESCRIPTION
Copying more than 4GB of data to USB takes time which may create confusion for some users who hit the command and see the blank picture until it finishes. They cannot see how much data is copied and left in real-time. 

**Before:** No status info

![before](https://user-images.githubusercontent.com/22962336/82129525-3ae8ea00-97e1-11ea-8943-5a1dfad98a3a.png)

Hence, we can add `status=progress` that will display the live progress of data writing to USB so that user can monitor it and get a clear picture. It will also be useful in case copying takes more than usual time.

**After:** Status info

![after](https://user-images.githubusercontent.com/22962336/82129527-40463480-97e1-11ea-9d19-7ff0b62cfb86.png)


 