### PR TITLE
Add table of contents

### DIFF
--- a/doc.md
+++ b/doc.md
@@ -13,6 +13,33 @@ redirect_from:
 - /en/community/
 - /community/
 ---
+## Table of Contents
+1. [Introduction](#introduction)
+2. [Project Security](#project-security)
+3. [User Documentation](#user-documentation)\
+   3.1. [Choosing Your Hardware](#choosing-your-hardware)\
+   3.2. [Downloading, Installing, and Upgrading Qubes](#downloading-installing-and-upgrading-qubes)\
+   3.3. [Common Tasks](#common-tasks)\
+   3.4. [Managing Operating Systems within Qubes](#common-tasks)\
+   3.5. [Security in Qubes](#security-in-qubes)\
+   3.6. [Advanced Configuration](#advanced-configuration)\
+   3.7. [Reference Pages](#reference-pages)
+4. [Developer Documentation](#developer-documentation)\
+   4.1. [General](#general)\
+   4.2. [Code](#code)\
+   4.3. [System](#system)\
+   4.4. [Services](#services)\
+   4.5. [Debugging](#debugging)\
+   4.6. [Building](#building)\
+   4.7. [Releases](#releases)
+5. [External Documentation](#external-documentation)\
+   5.1. [Operating System Guides](#operating-system-guides)\
+   5.2. [Security Guides](#security-guides)\
+   5.3. [Privacy Guides](#privacy-guides)\
+   5.4. [Configuration Guides](#configuration-guides)\
+   5.5. [Customization Guides](#customization-guides)\
+   5.6. [Troubleshooting](#troubleshooting)\
+   5.7. [Building Guides](#building-guides)
 
 ## Introduction
 


### PR DESCRIPTION
As Qubes documentation is getting better with more content and topics, the docs page is also getting longer. But if a user searches for any specific topic in `\docs`, he/she has to scroll throughout the page. For instance, if someone is searching for troubleshooting guides in docs, they have to reach the bottom in external documentation while looking for it in each topic.

Hence, a table of contents helps users locate and redirect to any topic without scrolling from top to bottom and save a lot of time. It also outlines and organizes all contents for a better view of docs.