### PR TITLE
Update gsod.md

### DIFF
--- a/developer/general/gsod.md
+++ b/developer/general/gsod.md
@@ -53,7 +53,7 @@ Here's a suggested template for adding project ideas:
 
 **Project**: Create guide on firstboot for new users
 
-**Brief explanation**: When a user first boots Qubes after installing it, there is an opportunity to introduce the user to some of the unique functionality Qubes has. This could be the same content as the [improved getting started page](#improve-getting-started-page).
+**Brief explanation**: When a user first boots Qubes after installing it, there is an opportunity to introduce the user to some of the unique functionality Qubes has. This could be the same content as the [improved getting started page](https://www.qubes-os.org/getting-started/).
 
 **Expected results**: 
 


### PR DESCRIPTION
[gsod.md] href link of `improved getting started page` redirect to completed project idea which is removed from the list. So, redirects to nowhere.

Hence, I've replaced it with a real getting started page so contributors can look at it.