### PR TITLE
USB Devices: Make requirement for USB qube more visible & remove redundant sentence

### DIFF
--- a/user/common-tasks/usb-devices.md
+++ b/user/common-tasks/usb-devices.md
@@ -100,7 +100,6 @@ This section exists for reference or in case something broke and you need to rei
 Under normal conditions, `qubes-usb-proxy` should already be installed and good to go.
 
 If you receive this error: `ERROR: qubes-usb-proxy not installed in the VM`, you can install the `qubes-usb-proxy` with the package manager in the VM you want to attach the USB device to.
-`qubes-usb-proxy` should be installed by default in the template VM.
 
 - Fedora: `sudo dnf install qubes-usb-proxy`
 - Debian/Ubuntu: `sudo apt-get install qubes-usb-proxy`

--- a/user/common-tasks/usb-devices.md
+++ b/user/common-tasks/usb-devices.md
@@ -12,7 +12,7 @@ redirect_from:
 
 If you are looking to handle USB *storage* devices (thumbdrives or USB-drives), please have a look at the [block device] page.
 
-**Note:** you cannot pass through devices from dom0 (in other words: a [USB qube][USB-qube howto] is required).
+**Note:** Attaching USB devices to VMs requires a [USB qube][USB-qube howto].
 
 **Important security warning:** USB passthrough comes with many security implications.
 Please make sure you carefully read and understand the **[security considerations]**.

--- a/user/common-tasks/usb-devices.md
+++ b/user/common-tasks/usb-devices.md
@@ -12,6 +12,8 @@ redirect_from:
 
 If you are looking to handle USB *storage* devices (thumbdrives or USB-drives), please have a look at the [block device] page.
 
+**Note:** you cannot pass through devices from dom0 (in other words: a [USB qube][USB-qube howto] is required).
+
 **Important security warning:** USB passthrough comes with many security implications.
 Please make sure you carefully read and understand the **[security considerations]**.
 Whenever possible, attach a [block device] instead.
@@ -98,7 +100,6 @@ This section exists for reference or in case something broke and you need to rei
 Under normal conditions, `qubes-usb-proxy` should already be installed and good to go.
 
 If you receive this error: `ERROR: qubes-usb-proxy not installed in the VM`, you can install the `qubes-usb-proxy` with the package manager in the VM you want to attach the USB device to.
-Note: you cannot pass through devices from dom0 (in other words: a [USB qube][USB-qube howto] is required).
 `qubes-usb-proxy` should be installed by default in the template VM.
 
 - Fedora: `sudo dnf install qubes-usb-proxy`


### PR DESCRIPTION
I was playing with `qvm-usb` a few days ago, only to find, after some failures and head-scratching, that a USB qube is required.

Issues such as QubesOS/qubes-issues#4345 also show the confusion of other users, so it should make sense to move the requirement to the beginning where it is more visible.

Also, I find that the sentence "`qubes-usb-proxy` should be installed..." to only reiterate what was being said in the previous paragraph, so I opt to remove it.