### PR TITLE
Verify the release key with --check-signatures

### DIFF
--- a/project-security/verifying-signatures.md
+++ b/project-security/verifying-signatures.md
@@ -169,15 +169,22 @@ There are several ways to get the Release Signing Key for your Qubes release.
 
 The Release Signing Key should be signed by the Qubes Master Signing Key:
 
-    $ gpg2 --list-sigs "Qubes OS Release X Signing Key"
+    $ gpg2 --check-signatures "Qubes OS Release X Signing Key"
     pub   rsa4096 2017-03-06 [SC]
           5817A43B283DE5A9181A522E1848792F9E2795E9
     uid           [  full  ] Qubes OS Release X Signing Key
-    sig 3        1848792F9E2795E9 2017-03-06  Qubes OS Release X Signing Key
-    sig          DDFA1A3E36879494 2017-03-08  Qubes Master Signing Key
+    sig!3        1848792F9E2795E9 2017-03-06  Qubes OS Release X Signing Key
+    sig!         DDFA1A3E36879494 2017-03-08  Qubes Master Signing Key
+
+    gpg: 2 good signatures
 
 This is just an example, so the output you receive will not look exactly the same.
-What matters is that the last line shows that this key is signed by the Qubes Master Signing Key, which verifies the authenticity of the Release Signing Key.
+What matters is the line that shows that this key is signed by the Qubes Master
+Signing Key with a `sig!` prefix.  This verifies the authenticity of the
+Release Signing Key.  Note that the `!` flag after the `sig` tag is important
+because it means that the key signature is valid.  A `sig-` prefix would
+indicate a bad signature and `sig%` would mean that gpg encountered an error
+while verifying the signature.
 It is not necessary to independently verify the authenticity of the Release Signing Key.
 
 


### PR DESCRIPTION
The original instructions on how to verify the release signing key used
the `--list-sigs` option for gpg.  However, unlike `--check-signatures`,
the `--list-sigs` option does not verify the authenticity of key
signatures.

See gpg2(1):

    --list-signatures
    --list-sigs
        Same as --list-keys, but the signatures are listed too.
        [...]
        Note that in contrast to --check-signatures the key signatures
        are not verified.
        [...]

    --check-signatures
    --check-sigs
        Same  as  --list-keys, but the key signatures are verified and
        listed too.
        [...]

This updates the documentation to use `--check-signatures` instead.