### PR TITLE
make config file example more accurate

### DIFF
--- a/user/advanced-configuration/config-files.md
+++ b/user/advanced-configuration/config-files.md
@@ -85,29 +85,30 @@ Sample config (included in default installation):
 
 ~~~
 # Sample configuration file for Qubes GUI daemon
-#  For syntax go http://www.hyperrealm.com/libconfig/libconfig_manual.html
+#  For syntax go https://www.hyperrealm.com/libconfig/libconfig_manual.html
 
 global: {
   # default values
   #allow_fullscreen = false;
+  #override_redirect_protection = true;
   #allow_utf8_titles = false;
   #secure_copy_sequence = "Ctrl-Shift-c";
   #secure_paste_sequence = "Ctrl-Shift-v";
   #windows_count_limit = 500;
-  #audio_low_latency = false;
+  #audio_low_latency = true;
   #log_level = 1;
   #trayicon_mode = "border1";
-  #startup_timeout = 91;
+  #startup_timeout = 45;
 };
 
 # most of setting can be set per-VM basis
 
 VM: {
   work: {
-    #allow_utf8_titles = true;
+    allow_utf8_titles = true;
   };
   video-vm: {
-    #allow_fullscreen = true;
+    allow_fullscreen = true;
   };
 };
 ~~~


### PR DESCRIPTION
please confirm my changes are correct. 

if we are showing an example of applying some configuration values (like ... `= true`), then it should be not be commented out, to make clear this is what the user needs to do to apply a configuration.

also if the default of audio_low_latency is true, then (and in my dom0 it is the case) that it should be by default set to `true` not `false`. also updated the language to reflect what the `guid.conf` looks like by default.