### PR TITLE
Make template upgrade documentation user-friendly

### DIFF
--- a/user/managing-os/debian/debian-upgrade.md
+++ b/user/managing-os/debian/debian-upgrade.md
@@ -12,7 +12,7 @@ redirect_from:
 
 # Upgrading Debian TemplateVMs
 
-[Should I upgrade using a fresh installation or an in-place upgrade?][Upgrading Fedora TemplateVMs]
+[Should I upgrade using a fresh installation or an in-place upgrade?][Upgrading Debian TemplateVMs]
 
 This page provides instructions for performing an in-place upgrade of an installed [Debian TemplateVM].
 If you wish to install a new, unmodified Debian TemplateVM instead of upgrading a template that is already installed in your system, please see the [Debian TemplateVM] page instead.

--- a/user/managing-os/debian/debian-upgrade.md
+++ b/user/managing-os/debian/debian-upgrade.md
@@ -1,6 +1,6 @@
 ---
 layout: doc
-title: Upgrading Debian TemplateVMs
+title: In-place upgrade of Debian TemplateVMs
 permalink: /doc/template/debian/upgrade/
 redirect_from:
 - /doc/template/debian/upgrade-8-to-9/
@@ -11,6 +11,8 @@ redirect_from:
 ---
 
 # Upgrading Debian TemplateVMs
+
+[Should I upgrade using a fresh installation or an in-place upgrade?][Upgrading Fedora TemplateVMs]
 
 This page provides instructions for performing an in-place upgrade of an installed [Debian TemplateVM].
 If you wish to install a new, unmodified Debian TemplateVM instead of upgrading a template that is already installed in your system, please see the [Debian TemplateVM] page instead.

--- a/user/managing-os/debian/debian.md
+++ b/user/managing-os/debian/debian.md
@@ -46,7 +46,9 @@ Please see [Updating software in TemplateVMs].
 
 ## Upgrading
 
-Please see [Upgrading Debian TemplateVMs].
+There are two ways to upgrade a TemplateVM. The easiest way is to [install] the new Debian TemplateVM next to the Debian TemplateVM you are currently using. Then redo all desired template modifications, and switch everything that was set to the old template to the new template.To make this process as efficient as possible, document modifications to your TemplateVMs in a textfile. If you do not have this documentation yet, open a terminal in the old Debian TemplateVM, and use the `history` command. (There is currently no other way to gain a list of explicitly installed packages. Methods like `apt list --installed`, `dpkg -l` and `aptitude search '~i!~M'` all include packages that have been installed as dependencies.)
+
+You can also do an in-place upgrade of an installed Debian TemplateVM. Please see [Upgrading Debian TemplateVMs].
 
 
 ## Release-specific notes

--- a/user/managing-os/debian/debian.md
+++ b/user/managing-os/debian/debian.md
@@ -48,7 +48,7 @@ Please see [Updating software in TemplateVMs].
 
 ## Upgrading
 
-There are two ways to upgrade a TemplateVM. The easiest way is to [install] the new Debian TemplateVM next to the Debian TemplateVM you are currently using. Then redo all desired template modifications, and switch everything that was set to the old template to the new template.To make this process as efficient as possible, document modifications to your TemplateVMs in a textfile. If you do not have this documentation yet, open a terminal in the old Debian TemplateVM, and use the `history` command. (There is currently no other way to gain a list of explicitly installed packages. Methods like `apt list --installed`, `dpkg -l` and `aptitude search '~i!~M'` all include packages that have been installed as dependencies.)
+There are two ways to upgrade a TemplateVM. The easiest way is to [install] the new Debian TemplateVM next to the Debian TemplateVM you are currently using. Then redo all desired template modifications, and switch everything that was set to the old template to the new template.To make this process as efficient as possible, document modifications to your TemplateVMs in a text file. If you do not have this documentation yet, open a terminal in the old Debian TemplateVM, and use the `history` command. (There is currently no other way to gain a list of explicitly installed packages. Methods like `apt list --installed`, `dpkg -l` and `aptitude search '~i!~M'` all include packages that have been installed as dependencies.)
 
 You can also do an in-place upgrade of an installed Debian TemplateVM. Please see [Upgrading Debian TemplateVMs].
 

--- a/user/managing-os/fedora/fedora-upgrade.md
+++ b/user/managing-os/fedora/fedora-upgrade.md
@@ -1,6 +1,6 @@
 ---
 layout: doc
-title: Upgrading Fedora TemplateVMs
+title: In-place upgrade of Fedora TemplateVMs
 permalink: /doc/template/fedora/upgrade/
 redirect_from:
 - /doc/template/fedora/upgrade-26-to-27/
@@ -23,16 +23,13 @@ redirect_from:
 
 # Upgrading Fedora TemplateVMs
 
-There are two ways to upgrade a TemplateVM. The easiest way is to install a new, unmodified [Fedora TemplateVM], then redo all desired template modifications. You can also do an in-place upgrade of an installed [Fedora TemplateVM].
+[Should I upgrade using a fresh installation or an in-place upgrade?][Upgrading Fedora TemplateVMs]
 
-## Upgrading using a new TemplateVM
+This page provides instructions for performing an in-place upgrade of an installed [Fedora TemplateVM].
+If you wish to install a new, unmodified Fedora TemplateVM instead of upgrading a template that is already installed in your system, please see the [Fedora TemplateVM] page instead.
 
-1. Please see the [Fedora TemplateVM] page on how to install the TemplateVM with the Fedora version you want to upgrade to. 
-2. **Recommended:** [Switch everything that was set to the old template to the new template.][switch]
 
-To make the upgrade process as efficient as possible, document modifications to your TemplateVMs in a textfile. If you do not have this documentation yet, open a terminal in the old Fedora TemplateVM, and use the `history` command. (There is currently no other way to gain a list of explicitly installed packages. Methods like `dnf repoquery --userinstalled` and `rpm -qa` all include packages that have been installed as dependencies.)
-    
-## Summary instructions for in-place upgrade of standard Fedora TemplateVMs
+## Summary instructions for standard Fedora TemplateVMs
 
 **Note:** The prompt on each line indicates where each command should be entered: `dom0`, `fedora-<old>`, or `fedora-<new>`, where `<old>` is the Fedora version number *from* which you are upgrading, and `<new>` is the Fedora version number *to* which you are upgrading.
 
@@ -52,7 +49,7 @@ To make the upgrade process as efficient as possible, document modifications to 
 **Recommended:** [Switch everything that was set to the old template to the new template.][switch]
 
 
-## Detailed instructions for in-place upgrade of standard Fedora TemplateVMs
+## Detailed instructions for standard Fedora TemplateVMs
 
 These instructions will show you how to upgrade the standard Fedora TemplateVM.
 The same general procedure may be used to upgrade any template based on the standard Fedora TemplateVM.
@@ -146,7 +143,7 @@ The same general procedure may be used to upgrade any template based on the stan
         [user@dom0 ~]$ sudo dnf remove qubes-template-fedora-<old>
 
 
-## Summary instructions for in-place upgrade of Fedora Minimal TemplateVMs
+## Summary instructions for Fedora Minimal TemplateVMs
 
 **Note:** The prompt on each line indicates where each command should be entered: `dom0`, `fedora-<old>`, or `fedora-<new>`, where `<old>` is the Fedora version number *from* which you are upgrading, and `<new>` is the Fedora version number *to* which you are upgrading.
 
@@ -199,6 +196,7 @@ In this case, you have several options:
     However, you may end up having to increase the disk image size anyway (see previous option).
  3. Do the upgrade in parts, e.g., by using package groups.
     (First upgrade `@core` packages, then the rest.)
+ 4. Do not perform an in-place upgrade, see [Upgrading Fedora TemplateVMs].
 
 
 [Fedora TemplateVM]: /doc/templates/fedora/

--- a/user/managing-os/fedora/fedora-upgrade.md
+++ b/user/managing-os/fedora/fedora-upgrade.md
@@ -23,11 +23,16 @@ redirect_from:
 
 # Upgrading Fedora TemplateVMs
 
-This page provides instructions for performing an in-place upgrade of an installed [Fedora TemplateVM].
-If you wish to install a new, unmodified Fedora TemplateVM instead of upgrading a template that is already installed in your system, please see the [Fedora TemplateVM] page instead.
+There are two ways to upgrade a TemplateVM. The easiest way is to install a new, unmodified [Fedora TemplateVM], then redo all desired template modifications. You can also do an in-place upgrade of an installed [Fedora TemplateVM].
 
+## Upgrading using a new TemplateVM
 
-## Summary instructions for standard Fedora TemplateVMs
+1. Please see the [Fedora TemplateVM] page on how to install the TemplateVM with the Fedora version you want to upgrade to. 
+2. **Recommended:** [Switch everything that was set to the old template to the new template.][switch]
+
+To make the upgrade process as efficient as possible, document modifications to your TemplateVMs in a textfile. If you do not have this documentation yet, open a terminal in the old Fedora TemplateVM, and use the `history` command. (There is currently no other way to gain a list of explicitly installed packages. Methods like `dnf repoquery --userinstalled` and `rpm -qa` all include packages that have been installed as dependencies.)
+    
+## Summary instructions for in-place upgrade of standard Fedora TemplateVMs
 
 **Note:** The prompt on each line indicates where each command should be entered: `dom0`, `fedora-<old>`, or `fedora-<new>`, where `<old>` is the Fedora version number *from* which you are upgrading, and `<new>` is the Fedora version number *to* which you are upgrading.
 
@@ -47,7 +52,7 @@ If you wish to install a new, unmodified Fedora TemplateVM instead of upgrading 
 **Recommended:** [Switch everything that was set to the old template to the new template.][switch]
 
 
-## Detailed instructions for standard Fedora TemplateVMs
+## Detailed instructions for in-place upgrade of standard Fedora TemplateVMs
 
 These instructions will show you how to upgrade the standard Fedora TemplateVM.
 The same general procedure may be used to upgrade any template based on the standard Fedora TemplateVM.
@@ -141,7 +146,7 @@ The same general procedure may be used to upgrade any template based on the stan
         [user@dom0 ~]$ sudo dnf remove qubes-template-fedora-<old>
 
 
-## Summary instructions for Fedora Minimal TemplateVMs
+## Summary instructions for in-place upgrade of Fedora Minimal TemplateVMs
 
 **Note:** The prompt on each line indicates where each command should be entered: `dom0`, `fedora-<old>`, or `fedora-<new>`, where `<old>` is the Fedora version number *from* which you are upgrading, and `<new>` is the Fedora version number *to* which you are upgrading.
 
@@ -194,11 +199,6 @@ In this case, you have several options:
     However, you may end up having to increase the disk image size anyway (see previous option).
  3. Do the upgrade in parts, e.g., by using package groups.
     (First upgrade `@core` packages, then the rest.)
- 4. Do not perform an in-place upgrade.
-    Instead, simply download and install a new template package, then redo all desired template modifications.
-    Here are some useful messages from the mailing list that also apply to TemplateVM management and migration in general from
-    [Marek](https://groups.google.com/d/msg/qubes-users/mCXkxlACILQ/dS1jbLRP9n8J) and
-    [Jason M](https://groups.google.com/d/msg/qubes-users/mCXkxlACILQ/5PxDfI-RKAsJ).
 
 
 [Fedora TemplateVM]: /doc/templates/fedora/

--- a/user/managing-os/fedora/fedora.md
+++ b/user/managing-os/fedora/fedora.md
@@ -38,7 +38,9 @@ Please see [Updating software in TemplateVMs].
 
 ## Upgrading
 
-Please see [Upgrading Fedora TemplateVMs].
+There are two ways to upgrade a TemplateVM. The easiest way is to [install] the new Fedora TemplateVM next to the Fedora TemplateVM you are currently using. Then redo all desired template modifications, and switch everything that was set to the old template to the new template.To make this process as efficient as possible, document modifications to your TemplateVMs in a textfile. If you do not have this documentation yet, open a terminal in the old Fedora TemplateVM, and use the `history` command. (There is currently no other way to gain a list of explicitly installed packages. Methods like `dnf repoquery --userinstalled` and `rpm -qa` all include packages that have been installed as dependencies.)
+
+You can also do an in-place upgrade of an installed Fedora TemplateVM. Please see [Upgrading Fedora TemplateVMs].
 
 
 ## Release-specific notes

--- a/user/managing-os/fedora/fedora.md
+++ b/user/managing-os/fedora/fedora.md
@@ -40,7 +40,7 @@ Please see [Updating software in TemplateVMs].
 
 ## Upgrading
 
-There are two ways to upgrade a TemplateVM. The easiest way is to [install] the new Fedora TemplateVM next to the Fedora TemplateVM you are currently using. Then redo all desired template modifications, and switch everything that was set to the old template to the new template.To make this process as efficient as possible, document modifications to your TemplateVMs in a textfile. If you do not have this documentation yet, open a terminal in the old Fedora TemplateVM, and use the `history` command. (There is currently no other way to gain a list of explicitly installed packages. Methods like `dnf repoquery --userinstalled` and `rpm -qa` all include packages that have been installed as dependencies.)
+There are two ways to upgrade a TemplateVM. The easiest way is to [install] the new Fedora TemplateVM next to the Fedora TemplateVM you are currently using. Then redo all desired template modifications, and switch everything that was set to the old template to the new template.To make this process as efficient as possible, document modifications to your TemplateVMs in a text file. If you do not have this documentation yet, open a terminal in the old Fedora TemplateVM, and use the `history` command. (There is currently no other way to gain a list of explicitly installed packages. Methods like `dnf repoquery --userinstalled` and `rpm -qa` all include packages that have been installed as dependencies.)
 
 You can also do an in-place upgrade of an installed Fedora TemplateVM. Please see [Upgrading Fedora TemplateVMs].
 


### PR DESCRIPTION
Upgrading TemplateVM's by installing a new TemplateVM, then redo changes is way more user friendly, and technically there are benefits too. This option is currently behind a link at the bottom of this page , but it should be at the top. 

- User friendlyness: The commands involved are less in number, less error prone, and far less complex.
- The technical benefit is that you are getting a fresh OS, which can not have issues that are possibly inherited from older versions. The fact that this is possible without reinstalling your laptop is actually one of the benefits of Qubes.
- Of course there are users who are lacking diskspace or who are on a slow or metered internet connection. They can still use the other method.

I want to explicitly include the part 'There is currently ... dependencies.' (line 33). Installing extra packages is the main thing users do in a TemplateVM, so including this saves users time from searching for such a method themselves, and it will prompt somebody who in fact does know a way to report this, because it would be a great addition. To be clear, a list of packages to be installed, should not include dependencies, because when the user manually installs packages formerly installed as dependencies, the packagemanager will not remove them automatically anymore when they are no longer needed.

My addition deviates a little bit from the succinct and technical style of the rest of the page, but given that upgrading templates is a frequent operation in Qubes that no user can avoid, I think this is fair.