### PR TITLE
Document use of xl info to find total memory

### DIFF
--- a/developer/services/qmemman.md
+++ b/developer/services/qmemman.md
@@ -75,3 +75,8 @@ Whenever *qmemman* is asked to return X megabytes of memory to Xen free pool, th
 4.  wait BALOON\_DELAY (0.1s)
 5.  if some domain have not given back any memory, remove it from the donors list, and go to step 2, unless we already did MAX\_TRIES (20) iterations (then return error).
 
+
+Notes
+-----
+
+Conventional means of viewing the memory available to Qubes will give incorrect values for `dom0` since commands such as `free` will only show the memory allocated for `dom0`. Run the `xl info` command in `dom0` and read the `total_memory` field to see the total memory available to Qubes.


### PR DESCRIPTION
I had to do some digging to figure out why I thought dom0 was reporting an incorrect amount of total memory available, and finally found this command. This document comes up very high in the search results for Qubes memory so I thought I'd put it here since it provides some concrete context to the architecture.