### PR TITLE
Mention customizing TorBrowser in whonix DispVMs is different

### DIFF
--- a/user/advanced-configuration/disposablevm-customization.md
+++ b/user/advanced-configuration/disposablevm-customization.md
@@ -58,7 +58,7 @@ If you wish to use a [Minimal TemplateVM](/doc/templates/minimal/) as a Disposab
 It is possible to change the settings for each new DisposableVM.
 This can be done by customizing the DisposableVM Template on which it is based:
 
-> _**Note:**_ these changes do not work for customizing Tor Browser in Whonix DisposableVMs. You can find instruction for that in the (external documentation) [whonix wiki](https://www.whonix.org/wiki/Tor_Browser/Advanced_Users#DVM_Template_Customization).
+**Note:** If you are trying to customize Tor Browser in a Whonix DisposableVM, please consult the [Whonix documentation](https://www.whonix.org/wiki/Tor_Browser/Advanced_Users#DVM_Template_Customization).
 
 1.  Start a terminal in the `fedora-26-dvm` qube (or another DisposableVM Template) by running the following command in a dom0 terminal. (If you enable `appmenus-dispvm` feature (as explained at the top), applications menu for this VM (`fedora-26-dvm`) will be "Disposable: fedora-26-dvm" (instead of "Domain: fedora-26-dvm") and entries there will start new DisposableVM based on that VM (`fedora-26-dvm`). Not in that VM (`fedora-26-dvm`) itself).
 

--- a/user/advanced-configuration/disposablevm-customization.md
+++ b/user/advanced-configuration/disposablevm-customization.md
@@ -55,10 +55,10 @@ If you wish to use a [Minimal TemplateVM](/doc/templates/minimal/) as a Disposab
 
 ## Customization of DisposableVM
 
+_**Note:** If you are trying to customize Tor Browser in a Whonix DisposableVM, please consult the [Whonix documentation](https://www.whonix.org/wiki/Tor_Browser/Advanced_Users#DVM_Template_Customization)._
+
 It is possible to change the settings for each new DisposableVM.
 This can be done by customizing the DisposableVM Template on which it is based:
-
-**Note:** If you are trying to customize Tor Browser in a Whonix DisposableVM, please consult the [Whonix documentation](https://www.whonix.org/wiki/Tor_Browser/Advanced_Users#DVM_Template_Customization).
 
 1.  Start a terminal in the `fedora-26-dvm` qube (or another DisposableVM Template) by running the following command in a dom0 terminal. (If you enable `appmenus-dispvm` feature (as explained at the top), applications menu for this VM (`fedora-26-dvm`) will be "Disposable: fedora-26-dvm" (instead of "Domain: fedora-26-dvm") and entries there will start new DisposableVM based on that VM (`fedora-26-dvm`). Not in that VM (`fedora-26-dvm`) itself).
 

--- a/user/advanced-configuration/disposablevm-customization.md
+++ b/user/advanced-configuration/disposablevm-customization.md
@@ -58,6 +58,8 @@ If you wish to use a [Minimal TemplateVM](/doc/templates/minimal/) as a Disposab
 It is possible to change the settings for each new DisposableVM.
 This can be done by customizing the DisposableVM Template on which it is based:
 
+> _**Note:**_ these changes do not work for customizing Tor Browser in Whonix DisposableVMs. You can find instruction for that in the (external documentation) [whonix wiki](https://www.whonix.org/wiki/Tor_Browser/Advanced_Users#DVM_Template_Customization).
+
 1.  Start a terminal in the `fedora-26-dvm` qube (or another DisposableVM Template) by running the following command in a dom0 terminal. (If you enable `appmenus-dispvm` feature (as explained at the top), applications menu for this VM (`fedora-26-dvm`) will be "Disposable: fedora-26-dvm" (instead of "Domain: fedora-26-dvm") and entries there will start new DisposableVM based on that VM (`fedora-26-dvm`). Not in that VM (`fedora-26-dvm`) itself).
 
         [user@dom0 ~]$ qvm-run -a fedora-26-dvm gnome-terminal


### PR DESCRIPTION
Some users like to change the default security slider for Tor Browser to Disposable Whonix-WS qubes,
but that is utterly intuitive since changes do not persist across reboots in the template for the disposable
qube -- and need to be done in the TemplateVM (with some other quirks).

The added note should avoid some user frustration.

This PR is a result of user frustration shown in the following discussions:
  * https://forums.whonix.org/t/how-do-i-customise-tor-browser-in-a-whonix-templatebased-dvm-in-whonix-14/5580/
  * https://qubes-os.discourse.group/t/how-to-securely-customize-tor-browser-in-whonix-with-add-ons-and-about-config-entries/506

I'm just not sure if the note should be before (where it is now) or after the instructions.