### PR TITLE
Added path and instructions to remove backup template VMs from application menu

### DIFF
--- a/user/managing-os/templates.md
+++ b/user/managing-os/templates.md
@@ -112,6 +112,10 @@ If the Applications Menu entry doesn't go away after you uninstall a TemplateVM,
 
     $ rm ~/.local/share/applications/<template-vm-name>
 
+Applications Menu entries for backups of removed VMs can also be found in `/usr/local/share/applications/` of dom0.
+
+    $ rm /usr/local/share/applications/<template-vm-name>
+
 
 ## Reinstalling
 


### PR DESCRIPTION
Uninstalling a template VM can create a backup of that VM which can clutter the application menu. Issue #5193 talks about this but the documentation hadn't been updated. 