### PR TITLE
Fix missing property (default_template) in step 9

### DIFF
--- a/user/managing-os/fedora/fedora-upgrade.md
+++ b/user/managing-os/fedora/fedora-upgrade.md
@@ -133,7 +133,7 @@ The same general procedure may be used to upgrade any template based on the stan
 
  9. (Optional) Make the new template the global default.
 
-        [user@dom0 ~]$ qubes-prefs --set fedora-<new>
+        [user@dom0 ~]$ qubes-prefs --set default_template fedora-<new>
 
 10. (Optional) Remove the old template.
     (Make sure to type the name of the old template, not the new one.)


### PR DESCRIPTION
Minor change to add missing property value. Using existing command results in error that "fedora-31" is not a valid property, updated docs to add the property name so that command works.