### PR TITLE
Windows users can't verify ISO integrity. Warn them of this

### DIFF
--- a/project-security/verifying-signatures.md
+++ b/project-security/verifying-signatures.md
@@ -50,7 +50,9 @@ There are three basic steps in this process:
  2. [Get the Release Signing Key][RSK]
  3. [Verify your Qubes ISO][signature file]
 
-If you run into any problems, please consult the [Troubleshooting FAQ] below.
+If you run into any problems, please consult the [Troubleshooting FAQ] below. 
+
+If you are using windows these instructions do not apply.
 
 ### 1. Get the Qubes Master Signing Key and verify its authenticity
 


### PR DESCRIPTION
The [installation instructions](https://www.qubes-os.org/doc/installation-guide/) warn people to verify the signatures and also include instructions

Some windows users might get really lost if they are reading this. 

The text is just a draft and probably needs something else telling them how to proceed if they want to verify the signature.

----

Instead of this PR another solution could be breaking down the ISO download and USB burning into a Windows and Linux Section. Then there could be a message there telling people they cannot verify the integrity on windows, currently.