### PR TITLE
Explicit commands for installing software

### DIFF
--- a/user/common-tasks/software-update-domu.md
+++ b/user/common-tasks/software-update-domu.md
@@ -22,9 +22,7 @@ To permanently install new software in a TemplateVM:
 
  1. Start the TemplateVM.
  2. Start either a terminal (e.g. `gnome-terminal`) or a dedicated software management application, such as `gpk-application`.
- 3. Install software as normally instructed inside that operating system (e.g. using `dnf`, or the dedicated GUI application).
-     * on the terminal for VMs based on fedora: `sudo dnf install <PACKAGE_NAME>`
-     * on the terminal for VMs based on debian: `sudo apt install <PACKAGE_NAME>`
+ 3. Install software as normally instructed inside that operating system (e.g. `sudo dnf install <PACKAGE_NAME>` on Fedora, `sudo apt install <PACKAGE_NAME>` on Debian, or with the appropriate GUI application).
  4. Shut down the TemplateVM.
  5. Restart all [TemplateBasedVMs] based on the TemplateVM.
  6. (Optional) In the relevant [TemplateBasedVMs]' **Qube Settings**, go to the **Applications** tab, select the new application(s) from the list, and press OK.

--- a/user/common-tasks/software-update-domu.md
+++ b/user/common-tasks/software-update-domu.md
@@ -23,6 +23,8 @@ To permanently install new software in a TemplateVM:
  1. Start the TemplateVM.
  2. Start either a terminal (e.g. `gnome-terminal`) or a dedicated software management application, such as `gpk-application`.
  3. Install software as normally instructed inside that operating system (e.g. using `dnf`, or the dedicated GUI application).
+     * on the terminal for VMs based on fedora: `sudo dnf install <PACKAGE_NAME>`
+     * on the terminal for VMs based on debian: `sudo apt install <PACKAGE_NAME>`
  4. Shut down the TemplateVM.
  5. Restart all [TemplateBasedVMs] based on the TemplateVM.
  6. (Optional) In the relevant [TemplateBasedVMs]' **Qube Settings**, go to the **Applications** tab, select the new application(s) from the list, and press OK.


### PR DESCRIPTION
After coming across [this thread](https://qubes-os.discourse.group/t/untrusted-application-launcher/1692) and taking a look at the this doc page, I realized there were no explicit instructions to install software on fedora or debian.

It is arguable, Qubes is a generic system, but Fedora and Debian are the default and installing software is a key thing. So I think it could make a service to new users to tell them explicitly the install commands.