### PR TITLE
Add single line cmd to set gui-videoram-min

### DIFF
--- a/user/advanced-configuration/gui-configuration.md
+++ b/user/advanced-configuration/gui-configuration.md
@@ -28,6 +28,11 @@ Where `$WIDTH`×`$HEIGHT` is the maximum desktop size that you anticipate needin
 For example, if you expect to use a 1080p display and a 4k display side-by-side, that is `(1920 + 3840) × 2160 × 4 / 1024 = 48600`, or slightly more than 48 MiB per qube.
 After making these adjustments, the qubes need to be restarted.
 
+In the case of multiple display with different orientations or if you plug/unplug displays, the following code will set correct memory size using xrandr.
+```sh
+qvm-features dom0 gui-videoram-min $(xrandr --verbose | grep "Screen 0" | sed -e 's/.*current //' -e 's/\,.*//' | awk '{print $1*$3*4/1024}')
+```
+
 The amount of memory allocated per qube is the maximum of:
 - `gui-videoram-min`
 - current display + `gui-videoram-overhead`


### PR DESCRIPTION
A bash pipe from xrandr to get total virtual screen pixels.
This will work with multiple displays and rotated display that will extend vertically the video memory usage by alot.