### PR TITLE
mention HCL reports can be submitted in the forum

### DIFF
--- a/user/hardware/hcl.md
+++ b/user/hardware/hcl.md
@@ -42,7 +42,7 @@ and run `qubes-hcl-report <vm-name>`, where `<vm-name>` is the name of the VM to
 
 You are encouraged to submit your HCL report for the benefit of further Qubes development and other users.
 When submitting reports, test the hardware yourself, if possible.
-If you would like to submit your HCL report, please send the **HCL Info** `.yml` file to [\`qubes-users@googlegroups.com\`](/support/#qubes-users) with the subject `HCL - <your machine model name>`.
+If you would like to submit your HCL report, please send the **HCL Info** `.yml` file to [\`qubes-users@googlegroups.com\`](/support/#qubes-users) with the subject `HCL - <your machine model name>`. Alternatively you can also create a post in the [HCL Reports category](https://qubes-os.discourse.group/c/user-support/hcl-reports/23) of the forum.
 Please include any useful information about any Qubes features you may have tested (see the legend below), as well as general machine compatibility (video, networking, sleep, etc.).
 Please consider sending the **HCL Support Files** `.cpio.gz` file as well. To generate these add the `-s` or `--support` command line option.
 


### PR DESCRIPTION
A while ago it we opened an category in the forum for submitting HCL Reports. Since then we've been seeing a multiple reports there even though it's not advertised in the docs. @SvenSemmler, has been also been processing those. So I think it makes sense for that to be mentioned it in the docs.