### PR TITLE
Don't use "class" technical jargon in the glossary

### DIFF
--- a/user/reference/glossary.md
+++ b/user/reference/glossary.md
@@ -100,7 +100,7 @@ AppVM
 -----
 
 Application Virtual Machine.
-A [VM](#vm) class.
+A type of [VM](#vm).
 Synonymous with [TemplateBasedVM](#templatebasedvm).
 
 NetVM


### PR DESCRIPTION
Seems friendlier for inexperienced users this way.