### PR TITLE
Fix redirect to 404 from /doc/disposablevm

### DIFF
--- a/user/how-to-guides/how-to-use-disposables.md
+++ b/user/how-to-guides/how-to-use-disposables.md
@@ -6,6 +6,7 @@ redirect_from:
 - /doc/how-to-use-disposablevms/
 - /doc/disposable/
 - /doc/dispvm/
+- /doc/disposablevm
 - /en/doc/dispvm/
 - /doc/DisposableVms/
 - /wiki/disposables/

--- a/user/how-to-guides/how-to-use-disposables.md
+++ b/user/how-to-guides/how-to-use-disposables.md
@@ -6,7 +6,7 @@ redirect_from:
 - /doc/how-to-use-disposablevms/
 - /doc/disposable/
 - /doc/dispvm/
-- /doc/disposablevm
+- /doc/disposablevm/
 - /en/doc/dispvm/
 - /doc/DisposableVms/
 - /wiki/disposables/


### PR DESCRIPTION
The link appears on the first page of a search result for "qubes disposable", but it is not redirecting correctly.