### PR TITLE
Make replaceable text like <THIS> instead of <this>

### DIFF
--- a/user/advanced-topics/standalones-and-hvms.md
+++ b/user/advanced-topics/standalones-and-hvms.md
@@ -44,7 +44,7 @@ You can create a standalone in the Qube Manager by selecting the "Type" of "Stan
 Alternatively, from the dom0 command line:
 
 ```
-qvm-create --class StandaloneVM --label <label> --property virt_mode=hvm <vmname>
+qvm-create --class StandaloneVM --label <LABEL> --property virt_mode=hvm <VMNAME>
 ```
 
 (Note: Technically, `virt_mode=hvm` is not necessary for every standalone.
@@ -145,7 +145,7 @@ This mode can be used for any HVM (e.g. FreeBSD running in a HVM).
 In order to create a TemplateHVM you use the following command, suitably adapted:
 
 ~~~
-qvm-create --class TemplateVM <qube> --property virt_mode=HVM --property kernel=''  -l green
+qvm-create --class TemplateVM <QUBE> --property virt_mode=HVM --property kernel=''  -l green
 ~~~
 
 Set memory as appropriate, and install the OS into this template in the same way you would install it into a normal HVM.


### PR DESCRIPTION
[A user](https://qubes-os.discourse.group/t/criando-maquinas-virtuais-de-template-de-qualquer-sistema-operacional/4691) (in Portuguese) didn't see they had to replace <text>, possibly because it was not visibly out of place. If my impression is correct other documentations pages use the <CAPS_FORMATTING> which could help somehow this.