### PR TITLE
Move 'properly validated keys' guidance before git verification...

### DIFF
--- a/introduction/issue-tracking.md
+++ b/introduction/issue-tracking.md
@@ -273,9 +273,9 @@ you're using, as well as versions of related software packages ([how to copy
 information out of dom0](/doc/how-to-copy-from-dom0/)). If your issue is
 related to hardware, provide as many details as possible about the hardware. A
 great way to do this is by [generating and submitting a Hardware Compatibility
-List (HCL) report](/doc/hcl/#generating-and-submitting-new-reports), then
-linking to it in your issue. You may also need to use command-line tools such
-as `lspci`. If you're reporting a bug in a package that is in a
+List (HCL) report](/doc/how-to-use-the-hcl/#generating-and-submitting-new-reports),
+then linking to it in your issue. You may also need to use command-line tools
+such as `lspci`. If you're reporting a bug in a package that is in a
 [testing](/doc/testing/) repository, please reference the appropriate issue in
 the [updates-status](https://github.com/QubesOS/updates-status/issues)
 repository. Project maintainers really appreciate thorough explanations. It

--- a/introduction/support.md
+++ b/introduction/support.md
@@ -173,8 +173,8 @@ read. Put yourself in your readers' shoes. What essential information would
 they require in order to be able to help you? Make sure to include that
 information in your message. A great way to provide your hardware details is by
 [generating and submitting a Hardware Compatibility List (HCL)
-report](/doc/hcl/#generating-and-submitting-new-reports), then linking to it in
-your message. [Ask questions the smart
+report](/doc/how-to-use-the-hcl/#generating-and-submitting-new-reports), then
+linking to it in your message. [Ask questions the smart
 way.](http://www.catb.org/esr/faqs/smart-questions.html)
 
 ### Be patient

--- a/project-security/verifying-signatures.md
+++ b/project-security/verifying-signatures.md
@@ -507,6 +507,19 @@ signed tags or commits on top of them unless you personally vouch for the
 trustworthiness of the unsigned commits. Instead, ask the person who pushed the
 unsigned commits to sign them.
 
+You should always perform this verification on a trusted local machine with
+properly validated keys (which are available in the [Qubes Security
+Pack](/security/pack/)) rather than relying on a third party, such as GitHub.
+While the GitHub interface may claim that a commit has a verified signature
+from a member of the Qubes team, this is only trustworthy if GitHub has
+performed the signature check correctly, the account identity is authentic, the
+user's key has not been replaced by an admin, GitHub's servers have not been
+compromised, and so on. Since there's no way for you to be certain that all
+such conditions hold, you're much better off verifying signatures yourself.
+
+Also see: [Distrusting the
+Infrastructure](/faq/#what-does-it-mean-to-distrust-the-infrastructure)
+
 To verify a signature on a Git tag:
 
 ```shell_session
@@ -530,19 +543,6 @@ or
 ```shell_session
 $ git verify-commit <commit ID>
 ```
-
-You should always perform this verification on a trusted local machine with
-properly validated keys (which are available in the [Qubes Security
-Pack](/security/pack/)) rather than relying on a third party, such as GitHub.
-While the GitHub interface may claim that a commit has a verified signature
-from a member of the Qubes team, this is only trustworthy if GitHub has
-performed the signature check correctly, the account identity is authentic, the
-user's key has not been replaced by an admin, GitHub's servers have not been
-compromised, and so on. Since there's no way for you to be certain that all
-such conditions hold, you're much better off verifying signatures yourself.
-
-Also see: [Distrusting the
-Infrastructure](/faq/#what-does-it-mean-to-distrust-the-infrastructure)
 
 ## Troubleshooting FAQ
 

--- a/user/downloading-installing-upgrading/installation-guide.md
+++ b/user/downloading-installing-upgrading/installation-guide.md
@@ -501,7 +501,7 @@ securely and easily.
 
 Consider giving back to the Qubes community and helping other users by
 [generating and submitting a Hardware Compatibility List (HCL)
-report](/doc/hcl/#generating-and-submitting-new-reports).
+report](/doc/how-to-use-the-hcl/#generating-and-submitting-new-reports).
 
 ### Get Started
 

--- a/user/hardware/system-requirements.md
+++ b/user/hardware/system-requirements.md
@@ -77,9 +77,9 @@ title: System requirements
   of having a portable copy of Qubes, this allows users to test for hardware
   compatibility on multiple machines (e.g., at a brick-and-mortar computer
   store) before deciding on which computer to purchase. (See
-  [hcl-report](/doc/hcl/#generating-and-submitting-new-reports) for advice on
-  hardware compatibility testing.) Remember to change the devices assigned to
-  your NetVM and USB VM if you move between different machines.
+  [hcl-report](/doc/how-to-use-the-hcl/#generating-and-submitting-new-reports)
+  for advice on hardware compatibility testing.) Remember to change the devices
+  assigned to your NetVM and USB VM if you move between different machines.
 - [Advice on finding a VT-d capable
   notebook](https://groups.google.com/d/msg/qubes-users/Sz0Nuhi4N0o/ZtpJdoc0OY8J).
 - You can check whether an Intel processor has VT-x and VT-d on


### PR DESCRIPTION
...in the "How to Verify Qubes Repos" section, since you must have
properly validated keys before being able to perform a successful
`git verify-tag` or `git verify-commit`.