### PR TITLE
Add another possible reason for "WARNING: This key is not certified...

### DIFF
--- a/project-security/verifying-signatures.md
+++ b/project-security/verifying-signatures.md
@@ -595,10 +595,13 @@ first.](#3-verify-your-qubes-iso))
 ### Why am I getting "WARNING: This key is not certified with a trusted
 signature! There is no indication that the signature belongs to the owner."?
 
-Either you don't have the [Qubes Master Signing
-Key](#1-get-the-qubes-master-signing-key-and-verify-its-authenticity), or you
-didn't [set its trust level
-correctly](#1-get-the-qubes-master-signing-key-and-verify-its-authenticity).
+Several possibilities:
+* you don't have the [Qubes Master Signing
+Key](#1-get-the-qubes-master-signing-key-and-verify-its-authenticity)
+* you didn't [set its trust level
+correctly](#1-get-the-qubes-master-signing-key-and-verify-its-authenticity)
+* in the case of verifying a Git commit or tag, you haven't yet chosen to
+place ultimate PGP trust in the individual signer's key
 
 ### Why am I getting "X signature not checked due to a missing key"?
 


### PR DESCRIPTION
...with a trusted signature! There is no indication that the signature
belongs to the owner."

With this edit, I'm aiming to assist the beginner reader who walked the
following breadcrumbs:

Should I trust this website?
==> verify the PGP signatures on the commits and/or tags

Detailed steps suggested by the docs along these breadcrumbs:
1) `git clone git@github.com:QubesOS/qubesos.github.io.git`
2) Verify the PGP sigs on the commits and/or tags
  a) get properly validated GPG keys (available in the Qubes Security Pack)
    i.   `git clone https://github.com/QubesOS/qubes-secpack.git`
    ii.  `gpg --import qubes-secpack/keys/*/*`
    iii. Verify/trust the QMSK (details given on the page)
  b) `cd qubesos.github.io`
  c) `git verify-commit 45ca80e8` (one of Andrew's recent commits)

RESULT: The WARNING pops up, because the user has not yet ultimately PGP
  trusted Andrew's E11D 15C6 D204 3576 9FFA  A456 8CE1 3735 2A01 9A17
  key.