### PR TITLE
add extra case for installation freezing

### DIFF
--- a/user/troubleshooting/installation-troubleshooting.md
+++ b/user/troubleshooting/installation-troubleshooting.md
@@ -81,6 +81,8 @@ For more information, look at the [Nvidia Troubleshooting guide](https://github.
  
 If you are facing this problem on an Apple computer, check out the [Macbook Troubleshooting guide](https://github.com/Qubes-Community/Contents/blob/master/docs/troubleshooting/macbook-troubleshooting.md).
 
+If you are installing Qubes 4.0 on an external storage device, you may have forgotten do disable `sys-usb` during the [initial setup](/doc/installation-guide/#initial-setup), which is generally required for that setup to work.
+
 This issue occurs due to the network card, which may be missing some drivers or is incompatible with Qubes. 
 
 First, install all available drivers for the card. 

--- a/user/troubleshooting/installation-troubleshooting.md
+++ b/user/troubleshooting/installation-troubleshooting.md
@@ -81,7 +81,7 @@ For more information, look at the [Nvidia Troubleshooting guide](https://github.
  
 If you are facing this problem on an Apple computer, check out the [Macbook Troubleshooting guide](https://github.com/Qubes-Community/Contents/blob/master/docs/troubleshooting/macbook-troubleshooting.md).
 
-If you are installing Qubes 4.0 on an external storage device, you may have forgotten do disable `sys-usb` during the [initial setup](/doc/installation-guide/#initial-setup), which is generally required for that setup to work.
+If you are installing Qubes 4.0 on an external storage device, you may have forgotten to disable `sys-usb` during the [initial setup](/doc/installation-guide/#initial-setup), which is generally required for that setup to work.
 
 This issue occurs due to the network card, which may be missing some drivers or is incompatible with Qubes. 
 


### PR DESCRIPTION
If installing in external SSD sometimes and when the user forgets to disable sys-usb the initial setup also
fails after setup networking.

[Another user and myself](https://forum.qubes-os.org/t/aborts-installation-at-installing-network-drivers-and-then-enters-into-a-black-screen-with-a-single-curser-in-the-top-left-corner/5238/4) have experience this issue after installing Qubes on an external SSD and forgetting to disable sys-usb during the initial setup. @hyperfekt was this your case as well?