### PR TITLE
Add debian-security rewrite

### DIFF
--- a/user/templates/debian/debian-upgrade.md
+++ b/user/templates/debian/debian-upgrade.md
@@ -38,6 +38,19 @@ In general, upgrading a Debian template follows the same process as [upgrading a
 [user@debian-<new> ~]$ sudo apt dist-upgrade
 [user@dom0 ~]$ qvm-shutdown debian-<new>
 ```
+**Note:** when upgrading from Debian 10 "buster" to Debian 11 "bullseye" an additional `sed` command is needed before running `sudo apt update`: 
+
+```
+[user@dom0 ~]$ qvm-clone debian-<old> debian-<new>
+[user@dom0 ~]$ qvm-run -a debian-<new> gnome-terminal
+[user@debian-<new> ~]$ sudo sed -i 's/<old-name>/<new-name>/g' /etc/apt/sources.list
+[user@debian-<new> ~]$ sudo sed -i 's/debian-security bullseye\/updates/debian-security bullseye-security/g' /etc/apt/sources.list
+[user@debian-<new> ~]$ sudo sed -i 's/<old-name>/<new-name>/g' /etc/apt/sources.list.d/qubes-r4.list
+[user@debian-<new> ~]$ sudo apt update
+[user@debian-<new> ~]$ sudo apt upgrade
+[user@debian-<new> ~]$ sudo apt dist-upgrade
+[user@dom0 ~]$ qvm-shutdown debian-<new>
+```
 
 **Recommended:** [Switch everything that was set to the old template to the new template.](/doc/templates/#switching)
 


### PR DESCRIPTION
When upgrading from buster to bullseye the 'debian-security buster/updates' must change into 'debian-security bullseye-security'. I tested this with my 10+ debian-minimal templates on R4.0.4, but see no reason this should be any different for the full Debian template. Needs review by @unman.

I used 'bullseye' instead of '\<new-name\>' so it would silently fail in case of any other upgrade.