### PR TITLE
add link to external documentation

### DIFF
--- a/developer/general/documentation-style-guide.md
+++ b/developer/general/documentation-style-guide.md
@@ -244,7 +244,7 @@ the maintainers of the [Qubes Community](https://github.com/Qubes-Community)
 project should regularly submit PRs against the documentation index (see [How
 to edit the documentation
 index](/doc/how-to-edit-the-documentation/#how-to-edit-the-documentation-index))
-to add and update Qubes Community links in the "External Documentation" section
+to add and update Qubes Community links in the ["External Documentation"](https://www.qubes-os.org/doc/#external-documentation) section
 of the documentation table of contents.
 
 The main difference between **core** (or **official**) and **external** (or


### PR DESCRIPTION
I just copy & pasted this part of the page into an [answer on the forum](https://forum.qubes-os.org/t/6189/) and realized it would be nice if "External documentation" would also be hyperlinked. If there is a reason this was not done, please just ignore this PR.