### PR TITLE
Clarification Points

### DIFF
--- a/user/templates/debian/debian.md
+++ b/user/templates/debian/debian.md
@@ -12,14 +12,14 @@ title: Debian templates
 ---
 
 The Debian [template](/doc/templates/) is an officially [supported](/doc/supported-releases/#templates) template in Qubes OS.  
-This page is about the standard (or "full") Debian template.
-For the minimal version, please see the [Minimal templates](/doc/templates/minimal/) page.
+This page is about the standard (or "Full") Debian template.
+For the Minimal version, please see the [Minimal templates](/doc/templates/minimal/) page.
 There is also a [Qubes page on the Debian Wiki](https://wiki.debian.org/Qubes).
 
 
-| Release Version        |  Initial Release Date & Status*       |  Does a Qubes OS "full" Template yet exist for this? |  Does a Qubes OS "minimal" Template yet exist for this? |
+| Release Version        |  Initial Release Date & Status*       |  "Full" Qubes OS template available? |  "Minimal" Qubes OS template available? |
 | :---                   |  :---                                 |  :---                                                |  :---                                                  |
-| Debian 11 "bullseye"   | 14 Aug 2021, current stable           |  No                                                  |  No                                                     |
+| Debian 11 "bullseye"   | 14 Aug 2021, current stable           |  —Not Yet—                                           |  —Not Yet—                                                     |
 | Debian 10 "buster"     | 06 Jul 2019, current oldstable            |  Yes                                             |  Yes                                                    |
 | Debian 9 "stretch"     | 27 Jun 2017, oldoldstable under LTS       |  Decomissioned                                   | Decomissioned                                           |
 | Debian 8 "jessie"      | 26 Apr 2015, archived under Extended LTS  |  Decomissioned                                   | Decomissioned                                           |

--- a/user/templates/debian/debian.md
+++ b/user/templates/debian/debian.md
@@ -16,7 +16,6 @@ This page is about the standard (or "full") Debian template.
 For the minimal version, please see the [Minimal templates](/doc/templates/minimal/) page.
 There is also a [Qubes page on the Debian Wiki](https://wiki.debian.org/Qubes).
 
-Building a template in Qubes OS is not a trivial process. Below is a (tally?) of known Debian releases, and the status of their Qubes OS templates. Release-specific installation notes, are at the bottom of the page below the general installation notes. 
 
 | Release Version        |  Initial Release Date & Status*       |  Does a Qubes OS "full" Template yet exist for this? |  Does a Qubes OS "minimal" Template yet exist for this? |
 | :---                   |  :---                                 |  :---                                                |  :---                                                  |

--- a/user/templates/debian/debian.md
+++ b/user/templates/debian/debian.md
@@ -11,10 +11,20 @@ ref: 134
 title: Debian templates
 ---
 
-The Debian [template](/doc/templates/) is an officially [supported](/doc/supported-releases/#templates) template in Qubes OS.
+The Debian [template](/doc/templates/) is an officially [supported](/doc/supported-releases/#templates) template in Qubes OS.  
 This page is about the standard (or "full") Debian template.
 For the minimal version, please see the [Minimal templates](/doc/templates/minimal/) page.
 There is also a [Qubes page on the Debian Wiki](https://wiki.debian.org/Qubes).
+
+Building a template in Qubes OS is not a trivial process. Below is a (tally?) of known Debian releases, and the status of their Qubes OS templates. Release-specific installation notes, are at the bottom of the page below the general installation notes. 
+
+| Release Version        |  Initial Release Date & Status*       |  Does a Qubes OS "full" Template yet exist for this? |  Does a Qubes OS "minimal" Template yet exist for this? |
+| :---                   |  :---                                 |  :---                                                |  :---                                                  |
+| Debian 11 "bullseye"   | 14 Aug 2021, current stable           |  No                                                  |  No                                                     |
+| Debian 10 "buster"     | 06 Jul 2019, current oldstable            |  Yes                                             |  Yes                                                    |
+| Debian 9 "stretch"     | 27 Jun 2017, oldoldstable under LTS       |  Decomissioned                                   | Decomissioned                                           |
+| Debian 8 "jessie"      | 26 Apr 2015, archived under Extended LTS  |  Decomissioned                                   | Decomissioned                                           |
+| Debian 7 "wheezy"      | 04 May 2013, obsolete stable              |  Decomissioned                                   | Decomissioned
 
 ## Installing
 

--- a/user/templates/templates.md
+++ b/user/templates/templates.md
@@ -13,9 +13,11 @@ title: Templates
 
 In [Getting Started](/doc/getting-started/), we covered the distinction
 in Qubes OS between where you *install* your software and where you *run* your
-software. Your software is installed in [templates](/doc/glossary/#template).
+software. Software that you use in most everyday tasks, is installed within [templates](/doc/glossary/#template).
 
-When using Qubes OS, you will typically begin a task by opening an application in an [app qube](/doc/glossary/#app-qube). App qubes are built from a *template* qube (or more simply, just *a template*). App qubes inherit all characteristics from their template—from the template's operating stystem or distro, to installed applications, to stored data, so its "[root filesystem](https://opensource.com/life/16/10/introduction-linux-filesystems)." App qubes do not, however, persist their data back to the Template. 
+When using Qubes OS, you will typically begin a task by opening an application in an [app qube](/doc/glossary/#app-qube). App qubes are built from a *template* qube (or more simply, just *a template*). As such, app qubes they _inherit_ all data from their template—from the template's OS or distro, to installed applications, to stored files—so its "[root filesystem](https://opensource.com/life/16/10/introduction-linux-filesystems)." App qubes do not, however, _persist_ their data back to the Template. 
+
+An understanding of [Inheritance and Persistence](#inheritance-and-persistence) concepts will help inform a clear understanding of this essential concept within Qubes OS. [Standalones](/doc/glossary/#standalone) are the only qubes in the Qubes OS ecosystem that neither _persist_ nor _inherit_ their filesystems to or from other qubes. 
 
 Templates are always built by developers, and are typically categorized by which OS or Linux distro each is based on. Qubes OS officially supports Debian and Fedora templates, and our community of developers has built and made available many more. When installing Qubes OS, officially supported templates may be installed. If you wish to add additional templates, you will need to download and install them.
 
@@ -38,7 +40,7 @@ The template system has significant benefits:
 
 An important side effect of this system is that any software installed in an
 app qube (rather than in the template on which it is based) will disappear
-after the app qube reboots (see [Inheritance and
+when the app qube shuts down (per [Inheritance and
 Persistence](#inheritance-and-persistence)). For this reason, we recommend
 installing most of your software in templates, not app qubes.
 

--- a/user/templates/templates.md
+++ b/user/templates/templates.md
@@ -15,7 +15,7 @@ In [Getting Started](/doc/getting-started/), we covered the distinction
 in Qubes OS between where you *install* your software and where you *run* your
 software. Your software is installed in [templates](/doc/glossary/#template).
 
-When using Qubes OS, you will typically begin a task by opening an application in an [app qube](/doc/glossary/#app-qube). App qubes are built from a *template* qube (or more simply, just *a template*). App qubes inherit all characteristics from their template—from the template's operating stystem or distro, to installed applications, to stored data, so its "root filesystem." App qubes do not, however, persist their data back to the Template. 
+When using Qubes OS, you will typically begin a task by opening an application in an [app qube](/doc/glossary/#app-qube). App qubes are built from a *template* qube (or more simply, just *a template*). App qubes inherit all characteristics from their template—from the template's operating stystem or distro, to installed applications, to stored data, so its "[root filesystem](https://opensource.com/life/16/10/introduction-linux-filesystems)." App qubes do not, however, persist their data back to the Template. 
 
 Templates are always built by developers, and are typically categorized by which OS or Linux distro each is based on. Qubes OS officially supports Debian and Fedora templates, and our community of developers has built and made available many more. When installing Qubes OS, officially supported templates may be installed. If you wish to add additional templates, you will need to download and install them.
 

--- a/user/templates/templates.md
+++ b/user/templates/templates.md
@@ -14,9 +14,10 @@ title: Templates
 In [Getting Started](/doc/getting-started/), we covered the distinction
 in Qubes OS between where you *install* your software and where you *run* your
 software. Your software is installed in [templates](/doc/glossary/#template).
-Each template shares its root filesystem (i.e., all of its programs and system
-files) with all the qubes based on it. [App qubes](/doc/glossary/#app-qube) are
-where you run your software and store your data.
+
+When using Qubes OS, you will typically begin a task by opening an application in an [app qube](/doc/glossary/#app-qube). App qubes are built from a *template* qube (or more simply, just *a template*). App qubes inherit all characteristics from their template—from the template's operating stystem or distro, to installed applications, to stored data, so its "root filesystem." App qubes do not, however, persist their data back to the Template. 
+
+Templates are always built by developers, and are typically categorized by which OS or Linux distro each is based on. Qubes OS officially supports Debian and Fedora templates, and our community of developers has built and made available many more. When installing Qubes OS, officially supported templates may be installed. If you wish to add additional templates, you will need to download and install them.
 
 The template system has significant benefits:
 


### PR DESCRIPTION
- Added a table to the "Debian Full" page, to manage user expectations around which releases have templates available for them
- Edited beginning of main "Templates" page, to explain templates in more human terms and to explicitly state they're _installed packages_ built by developers, not downloaded distros. Because—well, yes. 
