### PR TITLE
Update U2F proxy doc when having non standard sys-usb qubes name

### DIFF
--- a/user/security-in-qubes/u2f-proxy.md
+++ b/user/security-in-qubes/u2f-proxy.md
@@ -124,6 +124,8 @@ systemctl disable qubes-u2fproxy@sys-usb.service
 
 Replace `USB_QUBE` with the actual USB qube name.
 
+Do not forget to change the sys-usb qube name in the policy `/etc/qubes-rpc/policy/u2f.Authenticate`.
+
 ## Template and browser support
 
 The large number of possible combinations of template (Fedora 27, 28; Debian 8, 9) and browser (multiple Google Chrome versions, multiple Chromium versions, multiple Firefox versions) made it impractical for us to test every combination that users are likely to attempt with the Qubes U2F Proxy.


### PR DESCRIPTION
Hi all, when following the doc into setting up U2F proxy, I've found a potentially missing instruction.

Without this, the RPC call to U2F proxy won't be allowed.

Hope this might help :)