### PR TITLE
Doc: accelerated video w/o GPU on fedora-minimal

### DIFF
--- a/user/templates/minimal-templates.md
+++ b/user/templates/minimal-templates.md
@@ -194,6 +194,9 @@ Also, there are packages to provide additional services:
   idle.
 - `qubes-mgmt-salt-vm-connector`: If you want to use salt management on the
   template and qubes.
+- `mesa-dri-drivers`: If you want to run applications (e.g. videogames)
+  that require OpenGL or Vulkan API without attaching a real video card
+  to the qube.
 
 You may also wish to consider additional packages from the `qubes-core-agent`
 suite.

--- a/user/templates/minimal-templates.md
+++ b/user/templates/minimal-templates.md
@@ -194,7 +194,7 @@ Also, there are packages to provide additional services:
   idle.
 - `qubes-mgmt-salt-vm-connector`: If you want to use salt management on the
   template and qubes.
-- `mesa-dri-drivers`: If you want to run applications (e.g. videogames)
+- `mesa-dri-drivers`: If you want to run applications (e.g. video games)
   that require OpenGL or Vulkan API without attaching a real video card
   to the qube.
 


### PR DESCRIPTION
* Many applications will fail to run or have reduced functionality if OpenGL and/or Vulkan is not available.
* Due to how QubesOS handles GPU giving a qube access to a real GPU is not an option for some users.
* Software implementations of the OpenGL and Vulkan API exist, but are not installed by default in minimal templates. ~TODO: check if full templates have them.~

Solution: add instructions on how to install mesa-dri-drivers to the customization guide