### PR TITLE
note possibility to add rpc services in app qube

### DIFF
--- a/developer/services/qrexec.md
+++ b/developer/services/qrexec.md
@@ -106,7 +106,9 @@ If no policy rule is matched, the action is denied.
 If the policy file does not exist, the user is prompted to create one.
 If there is still no policy file after prompting, the action is denied.
 
-In the target VM, the file `/etc/qubes-rpc/RPC_ACTION_NAME` must exist, containing the file name of the program that will be invoked, or being that program itself -- in which case it must have executable permission set (`chmod +x`).
+In the target VM, a file in either of the following locations must exist, containing the file name of the program that will be invoked, or being that program itself -- in which case it must have executable permission set (`chmod +x`):
+  - `/etc/qubes-rpc/RPC_ACTION_NAME` when you make it in the template qube;
+  - `/usr/local/etc/qubes-rpc/RPC_ACTION_NAME` for making it only in an app qube.
 
 ### Making an RPC call
 


### PR DESCRIPTION
It's useful to be able to have an RPC service only for a specific app qube and not all of the app qubes based on a template. Since this is possible technically, we might as well document it.

The technical possibility can be found here: https://github.com/QubesOS/qubes-issues/issues/3003.

