### PR TITLE
Fix git commit code signing command

### DIFF
--- a/developer/code/code-signing.md
+++ b/developer/code/code-signing.md
@@ -104,7 +104,7 @@ your Git commits.
    Alternatively, manually specify when a commit is to be signed:
 
    ~~~
-   commit -S
+   git commit -S
    ~~~
 
 3. (Optional) Create signed tags.


### PR DESCRIPTION
Minor fix. I tested and `git commit -S` works for me to sign commits separately.