### PR TITLE
docs: describe keyboard login authorization

### DIFF
--- a/user/advanced-topics/usb-qubes.md
+++ b/user/advanced-topics/usb-qubes.md
@@ -14,7 +14,7 @@ title: USB qubes
 
 If during installation you enabled the creation of a USB-qube, your system should be setup already and none of the mentioned steps here should be necessary. (Unless you want to [remove your USB-qube](#removing-a-usb-qube).) If for any reason no USB-qube was created during installation, this guide will show you how to do so.
 
-**Caution:** If you want to use a USB-keyboard, please beware of the possibility to lock yourself out! To avoid this problem [enable your keyboard for login](#enable-a-usb-keyboard-for-login)!
+**Caution:** If you want to use a USB-keyboard and do not already hav a keyboard that is enabled for logins, please be aware that you could become unable to login to this system if you do not enable your USB-keyboard for login! To avoid this problem [enable your keyboard for login](#enable-a-usb-keyboard-for-login)!
 
 ## Creating and Using a USB qube ##
 


### PR DESCRIPTION
Here are what we had to say about this change:
```
15:54 < remote> "If you want to use a USB-keyboard, please beware that in the event that you do not have a non-USB keyboard functional on this system it is possible to lock yourself out!"
15:54 < remote> sounds weak
15:55 < remote> "If you want to use a USB-keyboard on a system without an alternative functional keyboard, please beware of the possibility to lock yourself out!"
15:55 < remote> better yeah?
15:56 < wwrrtt> sounds better, yeah
15:56 < wwrrtt> idk, I'd just replace "in the event that" with "if"
15:57 < ouin> "lock out" is also more a brief nuisance than an actual problem.
15:58 < wwrrtt> Is there a style guide for Qubes docs?
15:58 -!- Tangent-Man [~Tang3nt-M@cpc145602-basl14-2-0-cust33.20-1.cable.virginm.net] has joined #qubes
15:59 < wwrrtt> For example, should we say "please do X" or "do X"?
16:00 < wwrrtt> It would be nice to have a unified style for all the docs, but I understand that's probably at the very bottom of important things to do for the project
16:01 < remote> **Caution:** If you want to use a USB-keyboard and do not already hav a keyboard that is enabled for logins, please be aware that you could become unable to login to this 
                system if you do not enable your USB-keyboard for login! To avoid this problem [enable your keyboard for login](#enable-a-usb-keyboard-for-login)!
16:01 < wwrrtt> the Qubes' docs are one of the best I've seen, btw, especially for a project led by so few people
16:01 < wwrrtt> "hav"
16:02 < wwrrtt> the first sentence is really long
16:02 < remote> yes I'm a pro for this
16:02 < remote> I was thinking since it's clear enough it outweights the it being long, do you think it's clear enough?
16:02 < remote> I feel like it's "clearer"
16:04 < wwrrtt> It is clearer. I also like long sentences, but most people don't seem to, at least according to various style guides I've read that discourage that.
```