### PR TITLE
## Backing up changes to dom0

### DIFF
--- a/user/how-to-guides/how-to-back-up-restore-and-migrate.md
+++ b/user/how-to-guides/how-to-back-up-restore-and-migrate.md
@@ -36,7 +36,7 @@ and RPC policies:
 $ mkdir -p ~/backup/etc/qubes/
 $ cp -a /etc/qubes/* ~/backup/etc/qubes/
 $ mkdir ~/backup/etc/qubes-rpc/
-$ cp -a /etc/qubes-rpc/* ~/systemfiles/etc/qubes-rpc/
+$ cp -a /etc/qubes-rpc/* ~/backup/etc/qubes-rpc/
 ```
 
 To restore these files, move them from the restored directory in dom0's home


### PR DESCRIPTION
I assume the last line in:

$ mkdir -p ~/backup/etc/qubes/
$ cp -a /etc/qubes/* ~/backup/etc/qubes/
$ mkdir ~/backup/etc/qubes-rpc/
$ cp -a /etc/qubes-rpc/* ~/systemfiles/etc/qubes-rpc/

should instead read:

$ mkdir -p ~/backup/etc/qubes/
$ cp -a /etc/qubes/* ~/backup/etc/qubes/
$ mkdir ~/backup/etc/qubes-rpc/
$ cp -a /etc/qubes-rpc/* ~/backup/etc/qubes-rpc/