### PR TITLE
Use https to clone qubes-builder

### DIFF
--- a/developer/building/qubes-builder.md
+++ b/developer/building/qubes-builder.md
@@ -84,7 +84,7 @@ gpg --recv-keys 0xDDFA1A3E36879494
 wget https://keys.qubes-os.org/keys/qubes-developers-keys.asc
 gpg --import qubes-developers-keys.asc
 
-git clone git://github.com/QubesOS/qubes-builder.git qubes-builder
+git clone https://github.com/QubesOS/qubes-builder.git qubes-builder
 cd qubes-builder
 
 # Verify its integrity:

--- a/developer/building/qubes-iso-building.md
+++ b/developer/building/qubes-iso-building.md
@@ -57,7 +57,7 @@ See [verifying signatures](/security/verifying-signatures/#how-to-import-and-aut
 Now let's bootstrap the builder. Unfortunately, the builder cannot verify itself (the classic Chicken and Egg problem), so we need to verify the signature manually:
 
 ~~~
-git clone git://github.com/QubesOS/qubes-builder.git
+git clone https://github.com/QubesOS/qubes-builder.git
 cd qubes-builder
 git tag -v `git describe`
 ~~~


### PR DESCRIPTION
Builder config points at https for a long time, but the documentation
still used git:// protocol. Update that, especially as github
discontinued support for it.