### PR TITLE
Make '/doc/template[s]/' paths consistent

### DIFF
--- a/user/templates/debian/debian-upgrade.md
+++ b/user/templates/debian/debian-upgrade.md
@@ -2,8 +2,10 @@
 advanced: true
 lang: en
 layout: doc
-permalink: /doc/template/debian/upgrade/
+permalink: /doc/templates/debian/in-place-upgrade/
 redirect_from:
+- /doc/template/debian/upgrade/
+- /doc/templates/debian/upgrade/
 - /doc/template/debian/upgrade-8-to-9/
 - /doc/debian-template-upgrade-8/
 - /en/doc/debian-template-upgrade-8/

--- a/user/templates/debian/debian.md
+++ b/user/templates/debian/debian.md
@@ -52,7 +52,7 @@ There are two ways to upgrade your template to a new Debian release:
 
 - **Recommended:** [Install a fresh template to replace the existing one.](#installing) **This option may be simpler for less experienced users.** After you install the new template, redo all desired template modifications and [switch everything that was set to the old template to the new template](/doc/templates/#switching). You may want to write down the modifications you make to your templates so that you remember what to redo on each fresh install. In the old Debian template, see `/var/log/dpkg.log` and `/var/log/apt/history.log` for logs of package manager actions.
 
-- **Advanced:** [Perform an in-place upgrade of an existing Debian template.](/doc/template/debian/upgrade/) This option will preserve any modifications you've made to the template, **but it may be more complicated for less experienced users.**
+- **Advanced:** [Perform an in-place upgrade of an existing Debian template.](/doc/templates/debian/in-place-upgrade/) This option will preserve any modifications you've made to the template, **but it may be more complicated for less experienced users.**
 
 ## Release-specific notes
 

--- a/user/templates/fedora/fedora-upgrade.md
+++ b/user/templates/fedora/fedora-upgrade.md
@@ -2,8 +2,10 @@
 advanced: true
 lang: en
 layout: doc
-permalink: /doc/template/fedora/upgrade/
+permalink: /doc/templates/fedora/in-place-upgrade/
 redirect_from:
+- /doc/template/fedora/upgrade/
+- /doc/templates/fedora/upgrade/
 - /doc/template/fedora/upgrade-26-to-27/
 - /doc/fedora-template-upgrade-26/
 - /en/doc/fedora-template-upgrade-26/

--- a/user/templates/fedora/fedora.md
+++ b/user/templates/fedora/fedora.md
@@ -44,4 +44,4 @@ There are two ways to upgrade your template to a new Fedora release:
 
 - **Recommended:** [Install a fresh template to replace the existing one.](#installing) **This option may be simpler for less experienced users.** After you install the new template, redo all desired template modifications and [switch everything that was set to the old template to the new template](/doc/templates/#switching). You may want to write down the modifications you make to your templates so that you remember what to redo on each fresh install. To see a log of package manager actions, open a terminal in the old Fedora template and use the `dnf history` command.
 
-- **Advanced:** [Perform an in-place upgrade of an existing Fedora template.](/doc/template/fedora/upgrade/) This option will preserve any modifications you've made to the template, **but it may be more complicated for less experienced users.**
+- **Advanced:** [Perform an in-place upgrade of an existing Fedora template.](/doc/templates/fedora/in-place-upgrade/) This option will preserve any modifications you've made to the template, **but it may be more complicated for less experienced users.**


### PR DESCRIPTION
Most pages were using the pattern '/doc/templates/[...]', but some were
using the pattern '/doc/template/[...]', which was confusing. This
commit unifies on the former.