### PR TITLE
Update minimal-templates.md

### DIFF
--- a/user/templates/minimal-templates.md
+++ b/user/templates/minimal-templates.md
@@ -254,7 +254,7 @@ list of packages to be installed):
   to configure it.
 - `default-mgmt-dvm`: requires `qubes-core-agent-passwordless-root` and
   `qubes-mgmt-salt-vm-connector`.
-- [Yubikey](/doc/yubikey/): You may need to install `xserver-xorg-input-all` for 2FA responses to work in web browsers like Firefox.
+- [Yubikey](/doc/yubikey/): You may need to install `xserver-xorg-input-libinput` for 2FA responses to work in web browsers like Firefox.
 
 In Qubes 4.0, additional packages from the `qubes-core-agent` suite may be
 needed to make the customized minimal template work properly. These packages

--- a/user/templates/minimal-templates.md
+++ b/user/templates/minimal-templates.md
@@ -254,6 +254,7 @@ list of packages to be installed):
   to configure it.
 - `default-mgmt-dvm`: requires `qubes-core-agent-passwordless-root` and
   `qubes-mgmt-salt-vm-connector`.
+- [Yubikey](/doc/yubkiey/), you may need to install `xserver-xorg-input-all` for 2fa responses to work in web-browsers like Firefox.
 
 In Qubes 4.0, additional packages from the `qubes-core-agent` suite may be
 needed to make the customized minimal template work properly. These packages

--- a/user/templates/minimal-templates.md
+++ b/user/templates/minimal-templates.md
@@ -254,7 +254,7 @@ list of packages to be installed):
   to configure it.
 - `default-mgmt-dvm`: requires `qubes-core-agent-passwordless-root` and
   `qubes-mgmt-salt-vm-connector`.
-- [Yubikey](/doc/yubkiey/), you may need to install `xserver-xorg-input-all` for 2fa responses to work in web-browsers like Firefox.
+- [Yubikey](/doc/yubikey/): You may need to install `xserver-xorg-input-all` for 2FA responses to work in web browsers like Firefox.
 
 In Qubes 4.0, additional packages from the `qubes-core-agent` suite may be
 needed to make the customized minimal template work properly. These packages


### PR DESCRIPTION
Yubikey works out of the box for 2fa responses in debian-11.template but not in the minimal. It isn't straight forward to know which package to include for that functionality to work. Others on the forum have had this issue also. I've found that package and included it here so others can easily add that functionality.