### PR TITLE
Update stanalones-and-hvms.md 

### DIFF
--- a/user/advanced-topics/standalones-and-hvms.md
+++ b/user/advanced-topics/standalones-and-hvms.md
@@ -402,7 +402,7 @@ a temporary location in dom0, typing this in a dom0 terminal:
 qvm-run --pass-io untrusted 'cat "/media/user/externalhd/win10.raw"' > /home/user/win10-root.img
 ```
 
-If you image is not 10Gb size, extend it to 10Gb:
+If your image is not 10Gb size, extend it to 10Gb:
 ```
 dd if=/dev/zero of=/home/user/win10-root.img count=0 bs=1 seek=10737418240
 ```

--- a/user/advanced-topics/standalones-and-hvms.md
+++ b/user/advanced-topics/standalones-and-hvms.md
@@ -402,6 +402,11 @@ a temporary location in dom0, typing this in a dom0 terminal:
 qvm-run --pass-io untrusted 'cat "/media/user/externalhd/win10.raw"' > /home/user/win10-root.img
 ```
 
+If you image is not 10Gb size, extend it to 10Gb:
+```
+dd if=/dev/zero of=/home/user/win10-root.img count=0 bs=1 seek=10737418240
+```
+
 From within dom0, create a new HVM (here called `win10`) with the root image we
 just copied to dom0 (change the amount of RAM in GB as you wish):
 


### PR DESCRIPTION
To fix image size mismatch error when creating VM : "app: Error importing root volume (but VM created): Data import failed: not enough data (copied XXXX bytes, expected 10737418240)