### PR TITLE
builder: add note about default selinux policy blocking the builder on fedora host

### DIFF
--- a/developer/building/qubes-iso-building.md
+++ b/developer/building/qubes-iso-building.md
@@ -19,6 +19,11 @@ Fedora 32 has been successfully used to build Qubes R4.1 with the below steps.
 Other rpm-based operating systems may also work.
 Travis-CI uses Ubuntu 18.04 to perform test builds, except it can not test the `./setup` script.
 
+**Notes:** On modern Fedora system (like Fedora 37) SeLinux is enforced by
+default and is blocking the build system. You would get error like 
+"can't create transaction lock on /.../rpm/.rpm.lock (Permission denied)". 
+
+
 In `dom0`, install the Fedora 32 template if you don't already have it.
 
 ~~~

--- a/developer/building/qubes-iso-building.md
+++ b/developer/building/qubes-iso-building.md
@@ -21,7 +21,12 @@ Travis-CI uses Ubuntu 18.04 to perform test builds, except it can not test the `
 
 **Notes:** On modern Fedora system (like Fedora 37) SeLinux is enforced by
 default and is blocking the build system. You would get error like 
-"can't create transaction lock on /.../rpm/.rpm.lock (Permission denied)". 
+"can't create transaction lock on /.../rpm/.rpm.lock (Permission denied)".
+You can set SeLinux to permissive mode with 
+
+~~~bash
+sudo setenforce 0
+~~~
 
 
 In `dom0`, install the Fedora 32 template if you don't already have it.


### PR DESCRIPTION
On modern fedora system like Fedora 37, SeLinux is enforced by default and is blocking the qubes-builder with error like this "can't create transaction lock on /.../rpm/.rpm.lock (Permission denied)". 

Adding a note so other people will spend less time understanding why the builder doesn't work out of the box. 
I personally just switched SeLinux to Permissive 