### PR TITLE
Update and improve Emergency backup restore v4 page

### DIFF
--- a/user/how-to-guides/backup-emergency-restore-v4.md
+++ b/user/how-to-guides/backup-emergency-restore-v4.md
@@ -19,8 +19,8 @@ GNU/Linux system by following the instructions on this page.
 
 **Important:** You may wish to store a copy of these instructions with your
 Qubes backups. All Qubes documentation, including this page, is available in
-plain text format in the the [qubes-doc](https://github.com/QubesOS/qubes-doc)
-Git repository.
+plain text format in the [qubes-doc](https://github.com/QubesOS/qubes-doc) Git
+repository.
 
 ## Required `scrypt` utility
 

--- a/user/how-to-guides/backup-emergency-restore-v4.md
+++ b/user/how-to-guides/backup-emergency-restore-v4.md
@@ -135,8 +135,8 @@ any GNU/Linux system.
 
         [user@restore ~]$ backup_id=20161020T123455-1234
 
- 7. Choose a qube whose data you wish to restore. Verify the data's integrity,
-    decrypt it, decompress it, and extract it.
+ 7. Choose a qube whose data you wish to restore (in this example, `vm1`).
+    Verify the data's integrity, decrypt it, decompress it, and extract it.
 
         [user@restore ~]$ find vm1 -name 'private.img.*.enc' | sort -V | while read f_enc; do \
             f_dec=${f_enc%.enc}; \

--- a/user/how-to-guides/backup-emergency-restore-v4.md
+++ b/user/how-to-guides/backup-emergency-restore-v4.md
@@ -79,7 +79,7 @@ any GNU/Linux system.
     such as `scrypt` or `bzip2`, you can make things easier by aliasing those
     binaries now, e.g.,
 
-        [user@restore ~]$ alias scrypt="/home/user/scrypt-*"
+        [user@restore ~]$ alias scrypt="$PWD/scrypt-*/usr/bin/scrypt"
         [user@restore ~]$ alias bzip2="/home/user/bzip2-*"
 
  2. Untar the main backup file.

--- a/user/how-to-guides/backup-emergency-restore-v4.md
+++ b/user/how-to-guides/backup-emergency-restore-v4.md
@@ -76,11 +76,10 @@ any GNU/Linux system.
 *compressed*.
 
  1. (Optional) If you're working with binaries that you saved with your backup,
-    such as `scrypt` or `bzip2`, you can make things easier by aliasing those
-    binaries now, e.g.,
+    such as `scrypt`, you can make things easier by aliasing those binaries now,
+    e.g.,
 
         [user@restore ~]$ alias scrypt="$PWD/scrypt-*/usr/bin/scrypt"
-        [user@restore ~]$ alias bzip2="/home/user/bzip2-*"
 
  2. Untar the main backup file.
 
@@ -155,10 +154,9 @@ any GNU/Linux system.
 
  8. Enter the decrypted directory, mount `private.img`, and access your data.
 
-        [user@restore ~]$ cd vm1/
-        [user@restore vm1]$ sudo mkdir /mnt/img
-        [user@restore vm1]$ sudo mount -o loop vm1/private.img /mnt/img/
-        [user@restore vm1]$ cat /mnt/img/home/user/your_data.txt
+        [user@restore]$ sudo mkdir /mnt/img
+        [user@restore]$ sudo mount -o loop vm1/private.img /mnt/img/
+        [user@restore]$ cat /mnt/img/home/user/your_data.txt
         This data has been successfully recovered!
 
 Success! If you wish to recover data from more than one qube in your backup,


### PR DESCRIPTION
Summary of changes:
- Update formatting and style to be consistent with the rest of the docs
- Improve language
- Clarify instructions
- Improve organization

One significant change is the removal of the portion that began with "to extract only specific VMs." There were several problems with this:

1. It was too easy to accidentally follow this part, only to realize in the following step that it wasn't necessary. "To extract only specific VMs" is not clear. Most readers probably won't realize that's something they *don't* want to do, because it sounds like something they *do* want to do.
2. It's not clear why this portion is even needed, because following the normal instructions actually only extracts a single VM at a time *anyway*! So this portion seems redundant.
3. More importantly, these mini-instructions *bypass the integrity checking step*, which is a major security risk. We should not be telling users to do that.
4. The instructions themselves are confusing and difficult to follow. Even if you try to follow them to the letter, you just end up with a `private.img.000.enc` file, and then you don't know what to do after that. If you try to pick up with next step, it makes no sense.
5. The very next step has you save your backup passphrase with `read -r`, whereas these instructions have you enter it directly. That makes no sense. At the very least, the instructions should be reorganized to be sensible.

I also changed the portion on aliasing binaries because the existing command didn't work for me on Debian 11 minimal ("command not found"). Adding a space after the asterisk caused a `scrypt` error, where it didn't recognize that I was using `dec` even though I was.