### PR TITLE
fixed libera.chat irc address

### DIFF
--- a/introduction/support.md
+++ b/introduction/support.md
@@ -527,4 +527,4 @@ For example, here are some **unofficial** chat channels we know about that are
 maintained by the community:
 
 * Matrix, Qubes-related: <https://matrix.to/#/#cybersec-qubes_os:matrix.org>
-* `#qubes` channel on libera.chat via traditional IRC clients
+* `#qubes` channel on irc.libera.chat via traditional IRC clients


### PR DESCRIPTION
line :: 530 :: * `#qubes` channel on irc.libera.chat via traditional IRC clients