### PR TITLE
Add note to bind-dirs when dir does not exist yet

### DIFF
--- a/user/advanced-topics/bind-dirs.md
+++ b/user/advanced-topics/bind-dirs.md
@@ -44,6 +44,14 @@ Inside the app qube.
 
 4. Save.
 
+> **Note**: If the directory you are trying to persist doesn't already exist in the app qube, you'll need to create the directory with its full path, under `/rw/bind-dirs`. In this case you would do:
+>
+>    ```
+>    sudo mkdir -p /rw/bind-dirs/var/lib/tor
+>    ```
+>
+> This case happens only when the template on which this app qube is based does have this directory.
+
 5. Reboot the app qube.
 
 6. Done.


### PR DESCRIPTION
The doc on bind-dirs only provided an example where `/var/lib/tor` was made persistent in sys-whonix. However, if one tries to make persistent any directory that wasn't already present in the template qube, it would not persist as expected. The issue QubesOS/qubes-issues#5862 demonstrates this exact confusion.

This commit adds a note about this situation.

Fixes QubesOS/qubes-issues#5862