### PR TITLE
Update instructions to install KDE on R4.1

### DIFF
--- a/user/advanced-topics/kde.md
+++ b/user/advanced-topics/kde.md
@@ -18,6 +18,11 @@ still possible to install KDE by issuing this command in dom0:
 ```shell_session
 $ sudo qubes-dom0-update @kde-desktop-qubes
 ```
+In Qubes R4.1, install KDE by issuing this command in dom0:
+```shell_session
+$ sudo qubes-dom0-update kde-settings-qubes
+```
+
 
 You can also change your default login manager (lightdm) to the new KDE default: sddm
 

--- a/user/advanced-topics/kde.md
+++ b/user/advanced-topics/kde.md
@@ -16,13 +16,8 @@ R3.2, however, [XFCE is the new default desktop environment](/doc/releases/3.2/r
 still possible to install KDE by issuing this command in dom0:
 
 ```shell_session
-$ sudo qubes-dom0-update @kde-desktop-qubes
-```
-In Qubes R4.1, install KDE by issuing this command in dom0:
-```shell_session
 $ sudo qubes-dom0-update kde-settings-qubes
 ```
-
 
 You can also change your default login manager (lightdm) to the new KDE default: sddm
 


### PR DESCRIPTION
Running “sudo qubes-dom0-update @kde-desktop-qubes” in R4.1 downloads all (at least 276 of them) the packages, but then exits with the message "Module or Group ‘kde-desktop-qubes’ is not available.

Unman suggested  $ sudo qubes-dom0-update kde-settings-qubes in the response below, this seems to work properly. https://forum.qubes-os.org/t/installing-and-running-kde-as-desktop-environment/1513/31