### PR TITLE
Remove Fedora 36 from supported templates (EOL)

### DIFF
--- a/user/downloading-installing-upgrading/supported-releases.md
+++ b/user/downloading-installing-upgrading/supported-releases.md
@@ -91,7 +91,7 @@ Releases](https://wiki.debian.org/DebianReleases)).
 
 | Qubes OS    | Fedora | Debian                     | Whonix |
 | ----------- | ------ | -------------------------- | ------ |
-| Release 4.1 | 36, 37 | 10 (Buster), 11 (Bullseye) | 16     |
+| Release 4.1 | 37     | 10 (Buster), 11 (Bullseye) | 16     |
 
 ### Note on Debian support
 


### PR DESCRIPTION
Waiting until EOL date (2023-05-16) to merge.