### PR TITLE
guivm: fix a typo in a command

### DIFF
--- a/user/advanced-topics/gui-domain.md
+++ b/user/advanced-topics/gui-domain.md
@@ -147,7 +147,7 @@ qvm-prefs personal guivm dom0
 You are now able to delete the GUI domain, for example `sys-gui-gpu`:
 
 ```bash
-qvm-remove -y sys-gui-gpu
+qvm-remove -f sys-gui-gpu
 ```
 
 #### General issues


### PR DESCRIPTION
`qvm-remove -y` doesn't exist, I suppose it's to automatically approve the deletion, the correct usage is `qvm-remove -f`