### PR TITLE
Update 2 attachments in the "Getting started" guide

### DIFF
--- a/introduction/getting-started.md
+++ b/introduction/getting-started.md
@@ -80,7 +80,7 @@ random web surfing in a different qube, you wouldn't want to accidentally enter
 your banking password in the latter! The colored frames help to avoid such
 mistakes.
 
-[![snapshot_40.png](/attachment/doc/r4.0-snapshot_40.png)](/attachment/doc/r4.0-snapshot_40.png)
+[![snapshot_41.png](/attachment/doc/r4.1-snapshot_40.png)](/attachment/doc/r4.1-snapshot_40.png)
 
 Most Qubes users associate red with what's untrusted and dangerous (like a red
 light: stop! danger!), green with what's safe and trusted, and yellow and
@@ -142,7 +142,7 @@ To see all of your qubes at the same time, you can use the **Qube Manager** (go
 to the App Menu → Qubes Tools → Qube Manager), which displays the states of
 all the qubes in your system, even the ones that aren't running.
 
-[![r4.0-qubes-manager.png](/attachment/doc/r4.0-qubes-manager.png)](/attachment/doc/r4.0-qubes-manager.png)
+[![r4.1-qubes-manager.png](/attachment/doc/r4.1-qubes-manager.png)](/attachment/doc/r4.1-qubes-manager.png)
 
 #### Command-line interface
 


### PR DESCRIPTION
Several attachments have been already added to the qubes-attachments repository but remained unused. This change makes 2 of them be present in the "Getting started" guide.