### PR TITLE
Add new command for enable insecure paravirtualization

### DIFF
--- a/user/troubleshooting/installation-troubleshooting.md
+++ b/user/troubleshooting/installation-troubleshooting.md
@@ -121,5 +121,5 @@ Here are the steps to fix this. Note that this allows sys-net and sys-usb to tak
 
 1. Change the virtualization mode of sys-net and sys-usb to "PV"
 2. Add `qubes.enable_insecure_pv_passthrough` to `GRUB_CMDLINE_LINUX` in `/etc/default/grub`
-3. Run `sudo grub2-mkconfig -o /boot/efi/EFI/qubes/grub.cfg`. If you are using a non-UEFI BIOS, run `sudo grub-mkconfig -o /boot/grub2/grub.cfg`
+3. Run `sudo grub2-mkconfig -o /boot/efi/EFI/qubes/grub.cfg`. If you are using a non-UEFI BIOS (where `/boot/efi/EFI` doesn't exist), use the command `sudo grub-mkconfig -o /boot/grub2/grub.cfg` instead.
 4. Reboot

--- a/user/troubleshooting/installation-troubleshooting.md
+++ b/user/troubleshooting/installation-troubleshooting.md
@@ -121,5 +121,5 @@ Here are the steps to fix this. Note that this allows sys-net and sys-usb to tak
 
 1. Change the virtualization mode of sys-net and sys-usb to "PV"
 2. Add `qubes.enable_insecure_pv_passthrough` to `GRUB_CMDLINE_LINUX` in `/etc/default/grub`
-3. Run `sudo grub2-mkconfig -o /boot/efi/EFI/qubes/grub.cfg`
+3. Run `sudo grub2-mkconfig -o /boot/efi/EFI/qubes/grub.cfg`. If you are using a non-UEFI BIOS, run `sudo grub-mkconfig -o /boot/grub2/grub.cfg`
 4. Reboot


### PR DESCRIPTION
following up [QubesOS/qubes-issues#7334](https://github.com/QubesOS/qubes-issues/issues/7334) 

* Even following the recommendations, I was struggling enable insecure paravirtualization passthrough in a Qubes v4.1.2 VM running under KVM hypervisor.  (Note: My system hasn't IOMMU working)
* Thanks to [this answer](https://unix.stackexchange.com/questions/703107/qubes-post-install-problem/704283#704283), changing the output path of the grub config to `/boot/grub2/grub.cfg` made it works fine.
 