### PR TITLE
Replace all refs to template operations with qubes-dom0-update with qvm-template

### DIFF
--- a/user/how-to-guides/how-to-reinstall-a-template.md
+++ b/user/how-to-guides/how-to-reinstall-a-template.md
@@ -18,24 +18,23 @@ First, copy any files that you wish to keep from the template's `/home` and `/rw
 Then, in a dom0 terminal, run:
 
 ```
-$ sudo qubes-dom0-update --action=reinstall qubes-template-package-name
+$ qvm-template reinstall <qubes-template-name>
 ```
 
-Replace `qubes-template-package-name` with the name of the *package* of the template you wish to reinstall.
-For example, use `qubes-template-fedora-25` if you wish to reinstall the `fedora-25` template.
+Replace `qubes-template-name` with the name of the template you wish to reinstall.
 Only one template can be reinstalled at a time.
 
 Note that Qubes may initially refuse to perform the reinstall if the exact revision of the template package on your system is no longer in the Qubes online repository.
 In this case, you can specify `upgrade` as the action instead and the newer version will be used.
-The other `dnf` package actions that are supported in addition to `reinstall` and `upgrade` are `upgrade-to` and `downgrade`.
-Note that the `upgrade`, `upgrade-to`, and `downgrade` commands are only supported under Fedora based UpdateVMs.
-If you receive a message about them being unsupported, review the manual reinstallation method below.
+
+
+If you prefer to use a GUI tool, open `qvm-template-gui` from a dom0 terminal.
 
 **Reminder:** If you're trying to reinstall a template that is not in an enabled repo, you must enable that repo.
 For example:
 
 ```
-$ sudo qubes-dom0-update --enablerepo=qubes-templates-community --action=reinstall qubes-template-whonix-ws
+$ qvm-template --enablerepo=qubes-templates-community reinstall whonix-ws-16
 ```
 
 **Note:** VMs that are using the reinstalled template will not be affected until they are restarted.
@@ -60,27 +59,27 @@ If you want to reinstall more than one template, repeat these instructions for e
 3. Uninstall the target template from dom0:
 
     ```
-    $ sudo dnf remove <template-package-name>
+    $ qvm-template remove <template-name>
     ```
 
-   For example, to uninstall the `whonix-gw` template:
+   For example, to uninstall the `whonix-gw-16` template:
 
     ```
-    $ sudo dnf remove qubes-template-whonix-gw
+    $ qvm-template remove whonix-gw-16
     ```
 
 4. Reinstall the target template in dom0:
 
     ```shell_session
-    $ sudo qubes-dom0-update --enablerepo=<optional-additional-repo> \
-       <template-package-name>
+    $ qvm-template  --enablerepo=<optional-additional-repo> \
+       <template-name>
     ```
 
-   For example, to install the `whonix-gw` template:
+   For example, to install the `whonix-gw-16` template:
 
     ```shell_session
-    $ sudo qubes-dom0-update --enablerepo=qubes-templates-community \
-       qubes-template-whonix-gw
+    $ qvm-template install --enablerepo=qubes-templates-community \
+       whonix-gw-16
     ```
 
 5. If you temporarily changed all VMs based on the target template to the clone template in step 3, change them back to the new target template now.

--- a/user/templates/debian/debian.md
+++ b/user/templates/debian/debian.md
@@ -21,7 +21,7 @@ There is also a [Qubes page on the Debian Wiki](https://wiki.debian.org/Qubes).
 To [install](/doc/templates/#installing) a specific Debian template that is not currently installed in your system, use the following command in dom0:
 
 ```
-$ sudo qubes-dom0-update qubes-template-debian-XX
+$ qvm-template debian-XX
 ```
 
    (Replace `XX` with the Debian version number of the template you wish to install.)
@@ -63,13 +63,13 @@ This section contains notes about specific Debian releases.
 Debian 10 (buster) - minimal:
 
 ```
-[user@dom0 ~]$ sudo qubes-dom0-update --enablerepo=qubes-templates-itl qubes-template-debian-10-minimal
+[user@dom0 ~]$ qvm-template --enablerepo=qubes-templates-itl debian-10-minimal
 ```
 
 Debian 10 (buster) - stable:
 
 ```
-[user@dom0 ~]$ sudo qubes-dom0-update --enablerepo=qubes-templates-itl qubes-template-debian-10
+[user@dom0 ~]$ qvm-template --enablerepo=qubes-templates-itl debian-10
 ```
 
 ### Starting services

--- a/user/templates/fedora/fedora.md
+++ b/user/templates/fedora/fedora.md
@@ -13,7 +13,7 @@ The Fedora [template](/doc/templates/) is the default template in Qubes OS. This
 To [install](/doc/templates/#installing) a specific Fedora template that is not currently installed in your system, use the following command in dom0:
 
 ```
-$ sudo qubes-dom0-update qubes-template-fedora-XX
+$ qvm-template install fedora-XX
 ```
 
    (Replace `XX` with the Fedora version number of the template you wish to install.)

--- a/user/templates/minimal-templates.md
+++ b/user/templates/minimal-templates.md
@@ -65,7 +65,7 @@ A list of all available templates can also be obtained with the [Template Manage
 The minimal templates can be installed with the following type of command:
 
 ```
-[user@dom0 ~]$ sudo qubes-dom0-update qubes-template-<DISTRO_NAME>-<RELEASE_NUMBER>-minimal
+[user@dom0 ~]$ qvm-template <DISTRO_NAME>-<RELEASE_NUMBER>-minimal
 ```
 
 If your desired version is not found, it may still be in
@@ -73,14 +73,14 @@ If your desired version is not found, it may still be in
 enabled:
 
 ```
-[user@dom0 ~]$ sudo qubes-dom0-update --enablerepo=qubes-templates-itl-testing qubes-template-<DISTRO_NAME>-<RELEASE_NUMBER>-minimal
+[user@dom0 ~]$ qvm-template --enablerepo=qubes-templates-itl-testing <DISTRO_NAME>-<RELEASE_NUMBER>-minimal
 ```
 
 If you would like to install a community distribution, try the install command
 by enabling the community repository:
 
 ```
-[user@dom0 ~]$ sudo qubes-dom0-update --enablerepo=qubes-templates-community qubes-template-<DISTRO_NAME>-<RELEASE_NUMBER>-minimal
+[user@dom0 ~]$ qvm-template --enablerepo=qubes-templates-community <DISTRO_NAME>-<RELEASE_NUMBER>-minimal
 ```
 
 The download may take a while depending on your connection speed.

--- a/user/templates/xfce-templates.md
+++ b/user/templates/xfce-templates.md
@@ -20,27 +20,27 @@ you can install one of the available Xfce templates for [Fedora](/doc/templates/
 The Fedora Xfce templates can be installed with the following command (where `X` is your desired distro and version number):
 
 ```
-[user@dom0 ~]$ sudo qubes-dom0-update qubes-template-X-xfce
+[user@dom0 ~]$ qvm-template install X-xfce
 ```
 
 If your desired version is not found, it may still be in [testing](/doc/testing/).
 You may wish to try again with the testing repository enabled:
 
 ```
-[user@dom0 ~]$ sudo qubes-dom0-update --enablerepo=qubes-templates-itl-testing qubes-template-X-xfce
+[user@dom0 ~]$ qvm-template install --enablerepo=qubes-templates-itl-testing X-xfce
 ```
 
 If you would like to install a community distribution, like CentOS or Gentoo, try the install command by enabling the community repository:
 
 ```
-[user@dom0 ~]$ sudo qubes-dom0-update --enablerepo=qubes-templates-community qubes-template-X-xfce
+[user@dom0 ~]$ qvm-template --enablerepo=qubes-templates-community X-xfce
 ```
 
 If your desired version is not found, it may still be in [testing](/doc/testing/).
 You may wish to try again with the testing repository enabled:
 
 ```
-[user@dom0 ~]$ sudo qubes-dom0-update --enablerepo=qubes-templates-community-testing qubes-template-X-xfce
+[user@dom0 ~]$ qvm-template --enablerepo=qubes-templates-community-testing X-xfce
 ```
 
 The download may take a while depending on your connection speed.

--- a/user/troubleshooting/vm-troubleshooting.md
+++ b/user/troubleshooting/vm-troubleshooting.md
@@ -75,18 +75,14 @@ Common reasons that may be revealed are: too low memory, corrupted files or a VM
 
 If the error occurs as a result of too little initial memory, increase the initial memory from 200MB to 400MB by navigating to VM settings » Advanced » Initial memory.
 
-## "No match found" when trying to install a template
+## "not found" when trying to install a template
 
 For example:
 
 ```
-[user@dom0 ~]$ sudo qubes-dom0-update --enablerepo=qubes-templates-itl qubes-template-debian-10
-Using sys-whonix as UpdateVM to download updates for Dom0; this may take some time...
-No Match for argument qubes-template-debian-10
-Nothing to download
+[user@dom0 ~]$ qvm-template --enablerepo=qubes-templates-itl install debian-13
+qvm-template: error: Template 'debian-13' not found
 ```
 
-This normally means you already have the template installed.
-It may be that you have the matching package installed, but you removed or renamed the template.
-Check `rpm -q qubes-template-<name>`.
-If it lists the package, but you don't really have the template present (`qvm-ls` doesn't list it), you need to clean up leftovers of the package with `rpm -e --noscripts qubes-template-<name>`, then install it normally.
+This normally means that you have the tenmplate name wrong, or the template is in a differnet repository.
+Check the name and the repository.


### PR DESCRIPTION
As title - I think this catches all pages.
However, there is not a consistent approach to referencing the qvm-template-gui GUI tool.
Nor any screen captures of the GUI tool.
I'll leave QubesOS/qubes-issues#7837 open for now until that's resolved.
