### PR TITLE
firewall: replace ifconfig with ip

### DIFF
--- a/user/security-in-qubes/firewall.md
+++ b/user/security-in-qubes/firewall.md
@@ -262,7 +262,7 @@ As an example we can take the use case of a web server listening on port 443 tha
 **1. Identify the IP addresses you will need to use for sys-net, sys-firewall and the destination qube.**
 
 You can get this information from the Settings Window for the qube, or by running this command in each qube:
-`ifconfig | grep -i cast `
+`ip -4 -br a | grep UP`
 Note the IP addresses you will need.
 > Note: The vifx.0 interface is the one used by qubes connected to this netvm so it is _not_ an outside world interface.
 


### PR DESCRIPTION
ifconfig isn't available anymore in debian-11 and fedora-38 templates, it's time to use ip instead.

The output on sys-net looks like this:

```
[user@sys-net ~]$ ip -4 -br a | grep UP
ens6             UP             10.42.42.101/24 
vif5.0           UP             10.138.4.171/32 
```