### PR TITLE
Add Wi-Fi requirement to Debian minimal templates

### DIFF
--- a/user/templates/minimal-templates.md
+++ b/user/templates/minimal-templates.md
@@ -240,12 +240,14 @@ list of packages to be installed):
 - [FirewallVM](/doc/firewall/), such as the template for `sys-firewall`: at
   least `qubes-core-agent-networking`, and also `qubes-core-agent-dom0-updates`
   if you want to use it as the `UpdateVM` (which is normally `sys-firewall`).
-- NetVM, such as the template for `sys-net`: `qubes-core-agent-networking`
-  `qubes-core-agent-network-manager`. If your network devices need extra
-  packages for a network VM, use the `lspci` command to identify the devices,
-  then find the package that provides necessary firmware and install it. If you
-  need utilities for debugging and analyzing network connections, install the
-  following packages: `tcpdump` `telnet` `nmap` `ncat`.
+- NetVM, such as the template for `sys-net`: Ethernet requires
+  `qubes-core-agent-network-manager`, and Wi-Fi requires the previous
+  package(s) plus `wpasupplicant`, optionally `gnome-keyring` for saving the
+  Wi-Fi password. If your network devices need extra packages for a network
+  VM, use the `lspci` command to identify the devices, then find the package
+  that provides necessary firmware and install it. If you need utilities for
+  debugging and analyzing network connections, install the following packages:
+  `tcpdump` `telnet` `nmap` `ncat`.
 - [USB qube](/doc/usb-qubes/), such as the template for `sys-usb`:
   `qubes-usb-proxy` to provide USB devices to other Qubes and
   `qubes-input-proxy-sender` to provide keyboard or mouse input to dom0.


### PR DESCRIPTION
Removed:
- qubes-core-agent-networking: already a dependency of qubes-core-agent-network-manager;

Added:
- wpasupplicant: required for Wi-Fi, it is recommended by network-manager but is not installed if not installing recommends. It is required on Fedora by NetworkManager-wifi and was installed by default on Debian Minimal before https://github.com/QubesOS/qubes-builder-debian/pull/74;
- gnome-keyring: already recommended on the Fedora section, saves Wi-Fi password;

----

Tested on debian-12-minimal.