### PR TITLE
Remove Fedora 37 from supported templates (EOL)

### DIFF
--- a/user/downloading-installing-upgrading/supported-releases.md
+++ b/user/downloading-installing-upgrading/supported-releases.md
@@ -93,8 +93,8 @@ Releases](https://wiki.debian.org/DebianReleases)).
 
 | Qubes OS    | Fedora | Debian | Whonix |
 | ----------- | ------ | ------ | ------ |
-| Release 4.1 | 37, 38 | 11, 12 | 16     |
-| Release 4.2 | 37, 38 | 11, 12 | 17     |
+| Release 4.1 | 38     | 11, 12 | 16     |
+| Release 4.2 | 38     | 11, 12 | 17     |
 
 ### Note on Debian support
 


### PR DESCRIPTION
To be merged when Fedora 37 reaches EOL, which is currently scheduled for 2023-11-21 (see https://github.com/QubesOS/qubes-posts/commit/7b084fbace06c7f015c569ebc339186db6bdf6fc).