### PR TITLE
Added ntp package hint

### DIFF
--- a/user/templates/minimal-templates.md
+++ b/user/templates/minimal-templates.md
@@ -241,8 +241,8 @@ list of packages to be installed):
   least `qubes-core-agent-networking`, and also `qubes-core-agent-dom0-updates`
   if you want to use it as the `UpdateVM` (which is normally `sys-firewall`).
 - NetVM, such as the template for `sys-net`: `qubes-core-agent-networking`
-  `qubes-core-agent-network-manager`. If your network devices need extra
-  packages for a network VM, use the `lspci` command to identify the devices,
+  `qubes-core-agent-network-manager` `systemd-timesyncd`(or other NTP Service).
+  If your network devices need extra packages for a network VM, use the `lspci` command to identify the devices,
   then find the package that provides necessary firmware and install it. If you
   need utilities for debugging and analyzing network connections, install the
   following packages: `tcpdump` `telnet` `nmap` `ncat`.


### PR DESCRIPTION
As also discussed in the QubesOS Forum[0], here the hint for systemd-timesyncd (or other NTP package) is added.

[0]https://forum.qubes-os.org/t/definitive-guide-to-time-setting-sync-in-qubes-os/17641/13