### PR TITLE
R4.2 Clean Install: Change Qubes Sources to 4.2 in Imported Templates

### DIFF
--- a/user/downloading-installing-upgrading/upgrade/4_2.md
+++ b/user/downloading-installing-upgrading/upgrade/4_2.md
@@ -22,37 +22,26 @@ data.
 If you would prefer to perform a clean installation rather than upgrading
 in-place:
 
-1. Create a
+1. (optional) Run the updater to ensure all of your templates are in their latest version.
+2. Install the `qubes-dist-upgrade` tool. This is the inplace upgrade tool, which is not what we're doing. However it will needed in order to prepare the templates for the 4.2 version. You install it with the following command in the dom0 terminal:
+
+       sudo qubes-dom0-update -y qubes-dist-upgrade
+
+3. Change your templates to use the 4.2 repositories instead of the 4.1 ones. You do this with the following command in the dom0 terminal:
+
+       qubes-dist-upgrade --template-standalone-upgrade
+
+    **Note**: This step is critical to ensure the templates will receive updates once Qubes 4.1 reaches end-of-life (EOL) and was missing in previous clean installation instructions.
+
+4. Create a
    [backup](/doc/how-to-back-up-restore-and-migrate/#creating-a-backup) of your
    current installation.
-2. [Download](/downloads/) the latest 4.2 release.
-3. Follow the [installation guide](/doc/installation-guide/) to install Qubes
+5. [Download](/downloads/) the latest 4.2 release.
+6. Follow the [installation guide](/doc/installation-guide/) to install Qubes
    4.1.
-4. [Restore from your
+7. [Restore from your
    backup](/doc/how-to-back-up-restore-and-migrate/#restoring-from-a-backup) on
    your new 4.2 installation.
-5. In each old the old templates update the Qubes software sources from 4.1 to Qubes 4.2.
-   > **Note**: If the templates were first installed on a version older than
-   > Qubes 4.1, you should reinstall them. For example, your first Qubes install
-   > was 4.0 and you've been upgrading to Qubes 4.2 via clean install ever since,
-   > then this affects you and you should instead use the templates that come
-   > preinstalled in 4.2.
-
-   If the above note does not apply, you should open a teminal in each of the
-   imported templates and running the following commands:
-   - **Debian-based templates**:
-     ```
-     sudo sed -i 's/r4.1/r4.2/g' /etc/apt/sources.list.d/qubes-r4.list
-     sudo sed -i 's|\[arch=amd64\]|\[arch=amd64 signed-by=/usr/share/keyrings/qubes-archive-keyring-4.2.gpg \]|g' /etc/apt/sources.list.d/qubes-r4.list
-     sudo apt update
-     sudo apt upgrade
-     ```
-   - **Fedora-based templates**:
-     ```
-     sudo sed -i 's/r4.1/r4.2/g' /etc/yum.repos.d/qubes-r4.repo
-     sudo sed -i 's/RPM-GPG-KEY-qubes-4.1-/RPM-GPG-KEY-qubes-4.2-/g' /etc/yum.repos.d/qubes-r4.repo
-     sudo dnf update
-     ```
 
 ## In-place upgrade
 

--- a/user/downloading-installing-upgrading/upgrade/4_2.md
+++ b/user/downloading-installing-upgrading/upgrade/4_2.md
@@ -23,7 +23,7 @@ If you would prefer to perform a clean installation rather than upgrading
 in-place:
 
 1. (optional) Run the updater to ensure all of your templates are in their latest version.
-2. Install the `qubes-dist-upgrade` tool. This is the inplace upgrade tool, which is not what we're doing. However it will needed in order to prepare the templates for the 4.2 version. You install it with the following command in the dom0 terminal:
+2. Install the `qubes-dist-upgrade` tool. This is the inplace upgrade tool, which is not what we're doing. However it will be needed in order to prepare the templates for the 4.2 version. You install it with the following command in the dom0 terminal:
 
        sudo qubes-dom0-update -y qubes-dist-upgrade
 

--- a/user/downloading-installing-upgrading/upgrade/4_2.md
+++ b/user/downloading-installing-upgrading/upgrade/4_2.md
@@ -34,7 +34,8 @@ in-place:
 5. In each old the old templates update the Qubes software sources from 4.1 to Qubes 4.2. Do this by opening a teminal in each of the imported templates and running the following commands:
    - **Debian-based templates**:
      ```
-     sudo sed -i 's/r4.[01]/r4.2/g' /etc/apt/sources.list.d/qubes-r4.list`
+     sudo sed -i 's/r4.[01]/r4.2/g' /etc/apt/sources.list.d/qubes-r4.list
+     sudo sed -i 's|\[arch=amd64\]|\[arch=amd64 signed-by=/usr/share/keyrings/qubes-archive-keyring-4.2.gpg \]|g' /etc/apt/sources.list.d/qubes-r4.list
      ```
    - **Fedora-based templates**: 
      ```

--- a/user/downloading-installing-upgrading/upgrade/4_2.md
+++ b/user/downloading-installing-upgrading/upgrade/4_2.md
@@ -39,7 +39,7 @@ in-place:
    - **Fedora-based templates**: 
      ```
      sudo sed -i 's/r4.[01]/r4.2/g' /etc/yum.repos.d/qubes-r4.repo
-     sudo sed -i 's/RPM-GPG-KEY-qubes-4\(\.1\)\{0,1\}-primary/RPM-GPG-KEY-qubes-4.2-primary/g' /etc/yum.repos.d/qubes-r4.repo
+     sudo sed -i 's/RPM-GPG-KEY-qubes-4\(\.1\)\{0,1\}-/RPM-GPG-KEY-qubes-4.2-/g' /etc/yum.repos.d/qubes-r4.repo
      ```
 
 ## In-place upgrade

--- a/user/downloading-installing-upgrading/upgrade/4_2.md
+++ b/user/downloading-installing-upgrading/upgrade/4_2.md
@@ -31,16 +31,27 @@ in-place:
 4. [Restore from your
    backup](/doc/how-to-back-up-restore-and-migrate/#restoring-from-a-backup) on
    your new 4.2 installation.
-5. In each old the old templates update the Qubes software sources from 4.1 to Qubes 4.2. Do this by opening a teminal in each of the imported templates and running the following commands:
+5. In each old the old templates update the Qubes software sources from 4.1 to Qubes 4.2.
+   > **Note**: If the templates were first installed on a version older than
+   > Qubes 4.1, you should reinstall them. For example, your first Qubes install
+   > was 4.0 and you've been upgrading to Qubes 4.2 via clean install ever since,
+   > then this affects you and you should instead use the templates that come
+   > preinstalled in 4.2.
+
+   If the above note does not apply, you should open a teminal in each of the
+   imported templates and running the following commands:
    - **Debian-based templates**:
      ```
-     sudo sed -i 's/r4.[01]/r4.2/g' /etc/apt/sources.list.d/qubes-r4.list
+     sudo sed -i 's/r4.1/r4.2/g' /etc/apt/sources.list.d/qubes-r4.list
      sudo sed -i 's|\[arch=amd64\]|\[arch=amd64 signed-by=/usr/share/keyrings/qubes-archive-keyring-4.2.gpg \]|g' /etc/apt/sources.list.d/qubes-r4.list
+     sudo apt update
+     sudo apt upgrade
      ```
-   - **Fedora-based templates**: 
+   - **Fedora-based templates**:
      ```
-     sudo sed -i 's/r4.[01]/r4.2/g' /etc/yum.repos.d/qubes-r4.repo
-     sudo sed -i 's/RPM-GPG-KEY-qubes-4\(\.1\)\{0,1\}-/RPM-GPG-KEY-qubes-4.2-/g' /etc/yum.repos.d/qubes-r4.repo
+     sudo sed -i 's/r4.1/r4.2/g' /etc/yum.repos.d/qubes-r4.repo
+     sudo sed -i 's/RPM-GPG-KEY-qubes-4.1-/RPM-GPG-KEY-qubes-4.2-/g' /etc/yum.repos.d/qubes-r4.repo
+     sudo dnf update
      ```
 
 ## In-place upgrade

--- a/user/downloading-installing-upgrading/upgrade/4_2.md
+++ b/user/downloading-installing-upgrading/upgrade/4_2.md
@@ -31,6 +31,16 @@ in-place:
 4. [Restore from your
    backup](/doc/how-to-back-up-restore-and-migrate/#restoring-from-a-backup) on
    your new 4.2 installation.
+5. In each old the old templates update the Qubes software sources from 4.1 to Qubes 4.2. Do this by opening a teminal in each of the imported templates and running the following commands:
+   - **Debian-based templates**:
+     ```
+     sudo sed -i 's/r4.[01]/r4.2/g' /etc/apt/sources.list.d/qubes-r4.list`
+     ```
+   - **Fedora-based templates**: 
+     ```
+     sudo sed -i 's/r4.[01]/r4.2/g' /etc/yum.repos.d/qubes-r4.repo
+     sudo sed -i 's/RPM-GPG-KEY-qubes-4\(\.1\)\{0,1\}-primary/RPM-GPG-KEY-qubes-4.2-primary/g' /etc/yum.repos.d/qubes-r4.repo
+     ```
 
 ## In-place upgrade
 


### PR DESCRIPTION
Tell users to upgrade the software sources when doing a 4.2 clean install. Otherwise they may miss on critical integrations for 4.2 like VMExec (for the updater to work) and most importantly, after 4.1 is EOL, it'll silently stop resolving Qubes package upgrades even though the template is not yet EOL.

## User story
I have a (rarely used) minimal template which I had been migrating ever since 4.0 through clean installs which was still targeting Qubes 4.0 repos :grimacing:. And the updates seemed to be working so I never assumed something was wrong.

I only detected this issue when after migrating to 4.2 updates stopped failed to udpate this template since `/etc/qubes-rpc/qubes.VMExec` was missing.

These instructions are also missing in the [4.1 clean install](https://www.qubes-os.org/doc/upgrade/4.1/#clean-installation) instructions.

## Unsolved issue: Missing Keyring (Debian only)
One thing I didn't manage to solve yet is the keyrings on Debian. On Fedora this was easy since the 4.2 signing keyring was already available and explicit in the `.repo` file. But for Debian not only was it not explicit in the `.list` file (unlike a 4.2 template), but the keyring wasn't available as far as I can tell in `/usr/share/keyrings/qubes-archive-keyring-4.2.gpg`.

This gives the users a chicken and egg situation. If the user doesn't add the new 4.2 key, they'll get an error:
```
GPG error: https://deb.qubes-os.org/r4.2/vm bullseye InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 5BB71C441BCB1OFE
```

However, the user won't get that key from any keyring unless they explicitly import it, which would add more complexity to the instructions. `qubes-core-agent` is the package providing the keyring file in 4.2 templates. Maybe this keyring could be backported to 4.1 template updates so the user doesn't run into this issue? :thinking:

## Ideally this would be solved by software

In an ideal situation the user would not need to do anything special. I see two ways of going about this:

### Option A

If the 4.1 -> 4.2 upgrade tool already does this, then tell the user doing a clean install to run this specific stage of the upgrade tool (in case that's possible)

### Option B

Integrate this template upgrade thing into the updater:

1. the updater would check if a template has 4.1 (or older) qubes repo sources
2. update the repo configuration accordingly

**Note**: to make this work the upgrade tool would probably need to make use of the old `qubes.VMShell` since in older templates `qubes.VMExec` isn't available.