### PR TITLE
Remove reference to nonexisting Split SSH GUI

### DIFF
--- a/developer/releases/4_2/release-notes.md
+++ b/developer/releases/4_2/release-notes.md
@@ -23,7 +23,7 @@ _**Please note:** This page is still an unfinished draft in progress. It is bein
 - fwupd integration for firmware updates ([#4855](https://github.com/QubesOS/qubes-issues/issues/4855))
 - Optional automatic clipboard clearing ([#3415](https://github.com/QubesOS/qubes-issues/issues/3415))
 - Official packages built using Qubes Builder v2 ([#6486](https://github.com/QubesOS/qubes-issues/issues/6486))
-- Split GPG and Split SSH management in Qubes Global Settings
+- Split GPG management in Qubes Global Settings
 - Qrexec services use new qrexec policy format by default (but old format is still supported) ([#8000](https://github.com/QubesOS/qubes-issues/issues/8000))
 
 For a full list, including more detailed descriptions, please see


### PR DESCRIPTION
https://github.com/search?q=org%3AQubesOS+qubes.SshAgent&type=code
https://forum.qubes-os.org/t/qubes-os-4-2-where-is-split-ssh-in-gui/22148