### PR TITLE
Fix in-place upgrade docs to match R4.2 qubes-dist-upgrade

### DIFF
--- a/user/downloading-installing-upgrading/upgrade/4_2.md
+++ b/user/downloading-installing-upgrading/upgrade/4_2.md
@@ -48,8 +48,8 @@ can install it with the following command in the dom0 terminal:
 
     sudo qubes-dom0-update -y qubes-dist-upgrade
 
-The upgrade consists of five stages --- three before restarting the system ---
-labeled "STAGE 1" through "STAGE 3" in the options list below, and two after restarting the system --- labeled as "STAGE 4" and "STAGE 5" below.
+The upgrade consists of six stages --- three before restarting the system ---
+labeled "STAGE 1" through "STAGE 3" in the options list below, and three after restarting the system --- labeled as "STAGE 4" through "STAGE 6" below.
 
 Full list of options can be obtained with `qubes-dist-upgrade --help`:
 
@@ -59,15 +59,17 @@ Full list of options can be obtained with `qubes-dist-upgrade --help`:
     
     Options:
         --update, -t                       (STAGE 1) Update of dom0, TemplatesVM and StandaloneVM.
-        --release-upgrade, -r              (STAGE 2) Update 'qubes-release' for Qubes R4.1.
-        --dist-upgrade, -s                 (STAGE 3) Upgrade to Qubes R4.1 and Fedora 32 repositories.
-        --template-standalone-upgrade, -l  (STAGE 4) Upgrade templates and standalone VMs to R4.1 repository.
+        --release-upgrade, -r              (STAGE 2) Update 'qubes-release' for Qubes R4.2.
+        --dist-upgrade, -s                 (STAGE 3) Upgrade to Qubes R4.2 and Fedora 37 repositories.
+        --template-standalone-upgrade, -l  (STAGE 4) Upgrade templates and standalone VMs to R4.2 repository.
         --finalize, -x                     (STAGE 5) Finalize upgrade. It does:
                                              - resync applications and features
                                              - cleanup salt states
-        --all-pre-reboot                   Execute stages 1 do 3
-        --all-post-reboot                  Execute stages 4 and 5
-    
+        --convert-policy, -p               (STAGE 6) Convert qrexec policy in /etc/qubes-rpc/policy
+                                           to the new format in /etc/qubes/policy.d.
+        --all-pre-reboot                   Execute stages 1 to 3
+        --all-post-reboot                  Execute stages 4 to 6
+
         --assumeyes, -y                    Automatically answer yes for all questions.
         --usbvm, -u                        Current UsbVM defined (default 'sys-usb').
         --netvm, -n                        Current NetVM defined (default 'sys-net').


### PR DESCRIPTION
Fixes https://github.com/QubesOS/qubes-issues/issues/8776

The `qubes-dist-upgrade --help` content is copied from https://github.com/QubesOS/qubes-dist-upgrade/blob/v4.1.5/qubes-dist-upgrade.sh.