### PR TITLE
Issue tracking: Fix component label link

### DIFF
--- a/introduction/issue-tracking.md
+++ b/introduction/issue-tracking.md
@@ -75,7 +75,7 @@ There are several issue **priority** levels ranging from `P: minor` to `P: block
 
 #### Component
 
-There are many **component** labels, each beginning with `C:` (see [here](https://github.com/QubesOS/qubes-issues/labels?page=2&q=C%3A) for the full list). Every open issue should have **at least one** component. An open issue may have more than one component, but it should not lack a component entirely. When no other component applies, use `C: other`.
+There are many **component** labels, each beginning with `C:` (see [here](https://github.com/QubesOS/qubes-issues/labels?q=C%3A) for the full list). Every open issue should have **at least one** component. An open issue may have more than one component, but it should not lack a component entirely. When no other component applies, use `C: other`.
 
 #### Affected release
 


### PR DESCRIPTION
The "Issue tracking" page links to per-class lists of labels. The link to Component C: labels starts from page 2. The most common components seem to be on page 1.

This patch updates the link to point to page 1.