### PR TITLE
Issue tracking: Pluralize word

### DIFF
--- a/introduction/issue-tracking.md
+++ b/introduction/issue-tracking.md
@@ -105,7 +105,7 @@ This guideline is important for keeping issues focused on *actionable informatio
 
 ### Do not submit questions
 
-[qubes-issues](https://github.com/QubesOS/qubes-issues/issues) is not the place to ask questions. This includes, but is not limited to, troubleshooting questions and questions about how to do things with Qubes. Instead, see [Help, Support, Mailing Lists, and Forum](/support/) for appropriate place to ask questions. By contrast, [qubes-issues](https://github.com/QubesOS/qubes-issues/issues) is meant for tracking more general bugs, enhancements, and tasks that affect a broad range of Qubes users.
+[qubes-issues](https://github.com/QubesOS/qubes-issues/issues) is not the place to ask questions. This includes, but is not limited to, troubleshooting questions and questions about how to do things with Qubes. Instead, see [Help, Support, Mailing Lists, and Forum](/support/) for appropriate places to ask questions. By contrast, [qubes-issues](https://github.com/QubesOS/qubes-issues/issues) is meant for tracking more general bugs, enhancements, and tasks that affect a broad range of Qubes users.
 
 ### Use the issue template
 


### PR DESCRIPTION
Small grammar correction. Changes this:

>.. for appropriate place to ask questions.

To the plural noun:

>.. for appropriate places to ask questions.

I pluralized because there are multiple venues, but an alternative might be:

>.. for the appropriate place to ask questions.