### PR TITLE
Update managing-vm-kernels.md, initramfs is needed with Qubes 4.2

### DIFF
--- a/user/advanced-topics/managing-vm-kernels.md
+++ b/user/advanced-topics/managing-vm-kernels.md
@@ -224,7 +224,7 @@ Kernel for a VM is stored in `/var/lib/qubes/vm-kernels/KERNEL_VERSION` director
 * `modules.img` - ext4 filesystem image containing Linux kernel modules (to be mounted at `/lib/modules`); additionally it should contain a copy of `vmlinuz` and `initramfs` in its root directory (for loading by qemu inside stubdomain)
 * `default-kernelopts-common.txt` - default kernel options, in addition to those specified with `kernelopts` qube property (can be disabled with `no-default-kernelopts` feature)
 
-All the files besides `vmlinuz` are optional in Qubes R4.1 or newer. In Qubes R4.0, `vmlinuz` and `initramfs` are both required to be present.
+All the files besides `vmlinuz` and `initramfs` are optional in Qubes R4.0 or newer.
 
 ## Using kernel installed in the VM
 


### PR DESCRIPTION
The presence of initramfs is checked with Qubes 4.2 in the current head of qubes-core-admin (https://github.com/QubesOS/qubes-core-admin/blob/49c9fc95a26fbc866efe731b94cef543de67cb07/qubes/storage/kernels.py#L140).