### PR TITLE
Generalize YubiKey guide by adding TOTP MFA

### DIFF
--- a/user/security-in-qubes/mfa.md
+++ b/user/security-in-qubes/mfa.md
@@ -12,7 +12,7 @@ title: Multi-factor Login
 ---
 
 
-## Multi-factor authentication within in particular qubes
+## Multi-factor authentication within particular qubes
 
 Most use cases for the hardware tokens can be achieved exactly as described by the
 manufacturer or other instructions found online. One usually just needs to


### PR DESCRIPTION
Not every user will have a hardware token. This adds instructions for setting up multi-factor with TOTP. This was inspired / based on [work](https://forum.qubes-os.org/t/otp-for-xscreensaver-guide/23988) by @kennethrrosen.

Everything about the YubiKey guide is kept but moved to a lower heading level to acommodate for the two MFA options: YubiKey or TOTP.

**NOTE** I am no expert on MFA on Linux, so (as expected) I'd recommend especially careful review.

References that helped me build this guide:
 - https://forum.qubes-os.org/t/otp-for-xscreensaver-guide/23988
 - https://michaelpesa.com/posts/creating-custom-authselect-profiles/
 - https://www.redhat.com/sysadmin/mfa-linux
 - [Authselect man page](https://www.mankier.com/8/authselect)