### PR TITLE
Remove mentions of wireless-tools

### DIFF
--- a/user/templates/minimal-templates.md
+++ b/user/templates/minimal-templates.md
@@ -144,7 +144,7 @@ list of packages to be installed):
   (which is normally `sys-firewall`).
 - NetVM, such as the template for `sys-net`: `qubes-core-agent-networking`
   `qubes-core-agent-network-manager` `NetworkManager-wifi`
-  `network-manager-applet` `wireless-tools` `notification-daemon`
+  `network-manager-applet` `notification-daemon`
   `gnome-keyring` `polkit` `@hardware-support`. If your network devices need
   extra packages for the template to work as a network VM, use the `lspci`
   command to identify the devices, then run `dnf search firmware` (replace
@@ -324,7 +324,7 @@ list of packages to be installed):
   if you want to use it as the `UpdateVM` (which is normally `sys-firewall`).
 - NetVM, such as the template for `sys-net`: `qubes-core-agent-networking`
   `qubes-core-agent-network-manager` `NetworkManager-wifi`
-  `network-manager-applet` `wireless-tools` `notification-daemon`
+  `network-manager-applet` `notification-daemon`
   `gnome-keyring`. If your network devices need extra packages for a network
   VM, use the `lspci` command to identify the devices, then find the package
   that provides necessary firnware and install it. If you need utilities for


### PR DESCRIPTION
Fedora removed the package back in 2021 (see https://fedoraproject.org/wiki/Changes/RemoveWirelessExtensions), and a query on pkgs.org reports that CentOS does not have any packages by that name