### PR TITLE
Mention existence of Qubes Builder V2

### DIFF
--- a/developer/building/qubes-builder-details.md
+++ b/developer/building/qubes-builder-details.md
@@ -10,6 +10,14 @@ ref: 65
 title: Qubes builder details
 ---
 
+
+<div class="alert alert-warning" role="alert">
+  <i class="fa fa-exclamation-circle"></i>
+  <b>Note:</b> This information concern the older Qubes builder (v1). It supports
+  only building Qubes 4.1 or earlier. For building Qubes R4.2 or later and related
+  components, please see instead [qubes-builderv2](https://github.com/QubesOS/qubes-builderv2/).
+</div>
+
 Components Makefile.builder file
 --------------------------------
 

--- a/developer/building/qubes-builder.md
+++ b/developer/building/qubes-builder.md
@@ -10,6 +10,13 @@ ref: 64
 title: Qubes builder
 ---
 
+<div class="alert alert-warning" role="alert">
+  <i class="fa fa-exclamation-circle"></i>
+  <b>Note:</b> These instructions concern the older Qubes builder (v1). It supports
+  only building Qubes 4.1 or earlier. For building Qubes R4.2 or later and related
+  components, please see instead [qubes-builderv2](https://github.com/QubesOS/qubes-builderv2/).
+</div>
+
 **Note: See [ISO building instructions](/doc/qubes-iso-building/) for a streamlined overview on how to use the build system.**
 
 

--- a/developer/building/qubes-iso-building.md
+++ b/developer/building/qubes-iso-building.md
@@ -12,6 +12,13 @@ ref: 63
 title: Qubes ISO building
 ---
 
+<div class="alert alert-warning" role="alert">
+  <i class="fa fa-exclamation-circle"></i>
+  <b>Note:</b> These instructions concern the older Qubes builder (v1). It supports
+  only building Qubes 4.1 or earlier. For building Qubes R4.2 or later and related
+  components, please see instead [qubes-builderv2](https://github.com/QubesOS/qubes-builderv2/).
+</div>
+
 Build Environment
 -----------------
 


### PR DESCRIPTION
Qubes Builder V1 is still supported at least until Qubes 4.1 reaches EOL. However the docs don't mention at all the existance of version 2 of the builder. The ideal solution would be to document builder v2, while that doesn't happen, at least having a warning is better than nothing.