### PR TITLE
qubes-builderv1 still support 4.2 builds

### DIFF
--- a/developer/building/qubes-builder.md
+++ b/developer/building/qubes-builder.md
@@ -13,7 +13,7 @@ title: Qubes builder
 <div class="alert alert-warning" role="alert">
   <i class="fa fa-exclamation-circle"></i>
   <b>Note:</b> These instructions concern the older Qubes builder (v1). It supports
-  only building Qubes 4.1 or earlier.<br>The build process has been completely rewritten in <a href="https://github.com/QubesOS/qubes-builderv2/">qubes-builder v2</a>. This can be used for building Qubes R4.1 and later, and all related components.
+  only building Qubes 4.2 or earlier.<br>The build process has been completely rewritten in <a href="https://github.com/QubesOS/qubes-builderv2/">qubes-builder v2</a>. This can be used for building Qubes R4.2 and later, and all related components.
 </div>
 
 **Note: See [ISO building instructions](/doc/qubes-iso-building/) for a streamlined overview on how to use the build system.**


### PR DESCRIPTION
Not sure why when I contributed that string it said 4.1 was the last supported. It is in fact 4.2, [according to Marek](https://www.mail-archive.com/qubes-devel@googlegroups.com/msg05364.html).