### PR TITLE
Additional instructions for creating Win11 instance without internet access

### DIFF
--- a/user/templates/windows/windows-qubes-4-1.md
+++ b/user/templates/windows/windows-qubes-4-1.md
@@ -172,6 +172,13 @@ These parameters are set for the following reasons:
     - Click `Next`. A screen appears saying "Who's going to use this device?" This is the local account creation screen.
     - Enter the username you want to use and click `Next`.
     - Enter a password and click `Next`. You can leave the field blank but it's not recommended.
+   
+   Alternative instructions have been published for when those two methods do not work:
+
+    - Type Shift-F10 to open a console window.
+    - Here, type `oobe\bypassnro`
+    - Close the console window and continue setup normally
+    - When prompted to connect to a network, select "I don't have internet" - it will let you create local credentials
 
 - On systems shipped with a Windows license, the product key may be read from flash via root in dom0:
 


### PR DESCRIPTION
By modifying a bypass variable in oobe, users can setup a Windows 11 machine without access to the internet (and without a valid Microsoft account)

- [This article](https://www.qubes-os.org/doc/templates/windows/windows-qubes-4-1/)  is no longer up-to-date: Windows 11 version 22H2 refuses to let users create a local account after failing to sign-in, and killing "Network Connection Flow" just produced an impassable error page
- I found [this helpful](https://www.windowscentral.com/how-set-windows-11-without-microsoft-account)
	- just type `oobe\bypassnro` in a console (`shift+F10`) 
	- this solution is also posted on the [msft forums](https://answers.microsoft.com/en-us/insider/forum/all/set-up-windows-11-without-internet-oobebypassnro/4fc44554-b416-4ecb-8961-6f79fd55ae0f) so i dunno, how long will it last?
	- I don't see "oobe" nor "bypassnro" in any of the PR's on GitHub
- Admittedly I'm no Windows expert, and don't know all of the implications of such an approach
	- There may be some obvious security drawbacks, e.g., not installing critical security updates during the setup that compromise the VM
	- From light research I would assume this is a faster backdoor to disable "Network Connection Flow" than the task manager approach, and may have similar implications to that approach