### PR TITLE
Update docs about /rw/config/rc.local* scripts

### DIFF
--- a/user/advanced-topics/config-files.md
+++ b/user/advanced-topics/config-files.md
@@ -19,7 +19,7 @@ That way, they can be used to customize a single VM instead of all VMs based on 
 The scripts here all run as root.
 
 - `/rw/config/rc.local` - script runs at VM startup.
-    Good place to change some service settings, replace config files with its copy stored in `/rw/config`, etc.
+    Good place to change some service settings, replace config files with its copy stored in `/rw/config`, etc. The script need to have the executable permission set to be executed.
     Example usage:
 
     ~~~
@@ -33,6 +33,8 @@ The scripts here all run as root.
     echo '127.0.0.1 example.com' >> /etc/hosts
     ~~~
 
+- `/rw/config/rc.local.d/*.rc` - scripts run at VM startup just before `/rw/config/rc.local`
+- `/rw/config/rc.local-early.d/*.rc`, `/rw/config/rc.local-early` - scripts similar to `/rw/config/rc.local`, but running earlier in the system startup sequence - just before `sysinit.target`, and setting up the network.
 - `/rw/config/qubes-ip-change-hook` - script runs in NetVM after every external IP change and on "hardware" link status change.
 
 - In ProxyVMs (or app qubes with `qubes-firewall` service enabled), scripts placed in the following directories will be executed in the listed order followed by `qubes-firewall-user-script` at start up.


### PR DESCRIPTION
Specify that files needs to be executable.
Add info about `/rw/config/rc.local.d/*.rc`.
Add info about `/rw/config/rc.local-early.d/*.rc` and
`/rw/config/rc.local-early`
(https://github.com/QubesOS/qubes-core-agent-linux/pull/386)