### PR TITLE
migration to fido2: proxy setup clarification to avoid confusing errors

### DIFF
--- a/user/security-in-qubes/ctap-proxy.md
+++ b/user/security-in-qubes/ctap-proxy.md
@@ -85,7 +85,7 @@ $ sudo qubes-dom0-update qubes-ctap-dom0
 $ qvm-service --enable work qubes-ctap-proxy
 ```
 
-The above assumes a `work` qube in which you would like to enable ctap. Repeat the `qvm-service` command for all qubes that should have the proxy enabled.  Alternatively, you can add `qubes-ctap-proxy` in VM settings -> Services in the Qube Manager of each qube you would like to enable the service.
+The above assumes a `work` qube in which you would like to enable ctap. Repeat the `qvm-service` command for all qubes that should have the client proxy enabled.  Alternatively, you can add `qubes-ctap-proxy` in VM settings -> Services in the Qube Manager of each qube you would like to enable the service. Attempting to start the `qubes-ctap-proxy` service in the device-hosting qube (`sys-usb`) will fail.
 
 In Fedora templates:
 


### PR DESCRIPTION
solves QubesOS/qubes-issues/issues/9064