### PR TITLE
Syntax changed for enabling repositories due to dnf5/Fedora41

### DIFF
--- a/user/how-to-guides/how-to-install-software.md
+++ b/user/how-to-guides/how-to-install-software.md
@@ -227,10 +227,10 @@ depending on which RPM Fusion repositories you wish to enable (see [RPM
 Fusion](https://rpmfusion.org/) for details):
 
 ~~~
-sudo dnf config-manager --set-enabled rpmfusion-free
-sudo dnf config-manager --set-enabled rpmfusion-free-updates
-sudo dnf config-manager --set-enabled rpmfusion-nonfree
-sudo dnf config-manager --set-enabled rpmfusion-nonfree-updates
+sudo dnf config-manager setopt rpmfusion-free.enabled=1
+sudo dnf config-manager setopt rpmfusion-free-updates.enabled=1
+sudo dnf config-manager setopt rpmfusion-nonfree.enabled=1
+sudo dnf config-manager setopt rpmfusion-nonfree-updates.enabled=1
 sudo dnf upgrade --refresh
 ~~~
 


### PR DESCRIPTION
Syntax changed for enabling repositories with dnf5 which is used by default from Fedora 41 on.

https://dnf5.readthedocs.io/en/latest/changes_from_dnf4.7.html