### PR TITLE
dnf5 command syntax update

### DIFF
--- a/user/how-to-guides/how-to-install-software.md
+++ b/user/how-to-guides/how-to-install-software.md
@@ -227,10 +227,10 @@ depending on which RPM Fusion repositories you wish to enable (see [RPM
 Fusion](https://rpmfusion.org/) for details):
 
 ~~~
-sudo dnf config-manager --set-enabled rpmfusion-free
-sudo dnf config-manager --set-enabled rpmfusion-free-updates
-sudo dnf config-manager --set-enabled rpmfusion-nonfree
-sudo dnf config-manager --set-enabled rpmfusion-nonfree-updates
+dnf config-manager setopt rpmfusion-free.enabled=1
+dnf config-manager setopt rpmfusion-free-updates.enabled=1
+dnf config-manager setopt rpmfusion-nonfree.enabled=1
+dnf config-manager setopt rpmfusion-nonfree-updates.enabled=1
 sudo dnf upgrade --refresh
 ~~~
 


### PR DESCRIPTION
Fedora 41 uses dnf5 which has updated syntax on new dnf

dnf config-manager --set-enabled
changed to 
dnf config-manager setopt

First time doing this. So hope it's correct.