### PR TITLE
gui-troubleshooting.md: Improve the section about external screens

### DIFF
--- a/user/troubleshooting/gui-troubleshooting.md
+++ b/user/troubleshooting/gui-troubleshooting.md
@@ -6,7 +6,7 @@ ref: 233
 title: GUI troubleshooting
 ---
 
-## Can't click on parts of screens after connecting high-resolution external display
+## Can't click on parts of the screen after connecting high-resolution external display
 
 When you connect a high-resolution external display, you may be unable to click on parts of the screen.
 

--- a/user/troubleshooting/gui-troubleshooting.md
+++ b/user/troubleshooting/gui-troubleshooting.md
@@ -6,15 +6,21 @@ ref: 233
 title: GUI troubleshooting
 ---
 
-## Can't click on anything after connecting 4k external display
+## Can't click on parts of screens after connecting high-resolution external display
 
-When you connect a 4K external display, you may be unable to click on anything but a small area in the upper-right corner.
+When you connect a high-resolution external display, you may be unable to click on parts of the screen.
 
 When a qube starts, a fixed amount of RAM is allocated to the graphics buffer called video RAM.
 This buffer needs to be at least as big as the whole desktop, accounting for all displays that are or will be connected to the machine.
 By default, it is as much as needed for the current display and an additional full HD (FHD) display (1920×1080 8 bit/channel RGBA).
-This logic fails when the machine has primary display in FHD resolution and, after starting some qubes, a 4K display is connected.
+This logic fails when the machine has primary display in FHD resolution and, after starting some qubes, a high-resolution display is connected.
 If the buffer is too small, and internal desktop resize fails.
+
+To determine if this is the problem affecting you, look at the Xorg log inside the Qube at `/home/user/.local/share/xorg/Xorg.0.log` for lines like the following:
+
+~~~
+[  1623.988] (EE) DUMMYQBS(0): Unable to set up a virtual screen size of 3440x1440 with 17101 Kb of video memory available.  Please increase the video memory size.
+~~~
 
 The solution to this problem is to increase the minimum size of the video RAM buffer, as explained in [GUI Configuration](/doc/gui-configuration/#video-ram-adjustment-for-high-resolution-displays).
 


### PR DESCRIPTION
I was affected by this problem. When I saw this documentation, I didn't realize this was the problem affecting me. I don't have a 4K monitor; I have a wide monitor. I can click on most things, just not in specific sections of the screen.

Rewrite to be more generic.