### PR TITLE
Revamp certified hardware documentation

### DIFF
--- a/user/hardware/certified-hardware/certified-hardware.md
+++ b/user/hardware/certified-hardware/certified-hardware.md
@@ -25,71 +25,19 @@ Qubes-certified computers are certified for a [major release](/doc/version-schem
 
 The current Qubes-certified models are listed below in reverse chronological order of certification.
 
-### NovaCustom V54 Series 14.0 inch coreboot laptop
-
-[![Photo of the NovaCustom V54 Series 14.0 inch coreboot laptop](/attachment/site/novacustom-v54-series.png)](https://novacustom.com/product/v54-series/)
-
-The [NovaCustom V54 Series 14.0 inch coreboot laptop](https://novacustom.com/product/v54-series/) is certified for Qubes OS Release 4.
-
-### NitroPad V56
-
-[![Photo of the NitroPad V56](/attachment/site/nitropad-v56.png)](https://shop.nitrokey.com/shop/nitropad-v56-684)
-
-The [NitroPad V56](https://shop.nitrokey.com/shop/nitropad-v56-684) is certified for Qubes OS Release 4.
-
-### NovaCustom V56 Series 16.0 inch coreboot laptop
-
-[![Photo of the NovaCustom V56 Series 16.0 inch coreboot laptop](/attachment/site/novacustom-v56-series.png)](https://novacustom.com/product/v56-series/)
-
-The [NovaCustom V56 Series 16.0 inch coreboot laptop](https://novacustom.com/product/v56-series/) is certified for Qubes OS Release 4.
-
-### NitroPC Pro 2
-
-[![Photo of the NitroPC Pro 2](/attachment/posts/nitropc-pro.jpg)](https://shop.nitrokey.com/shop/nitropc-pro-2-523)
-
-The [NitroPC Pro 2](https://shop.nitrokey.com/shop/nitropc-pro-2-523) is a desktop based on the MSI PRO Z790-P DDR5 motherboard. It is certified for Qubes OS Release 4.
-
-### Star Labs StarBook
-
-[![Photo of the Star Labs StarBook](/attachment/site/starlabs-starbook.png)](https://starlabs.systems/pages/starbook)
-
-The [Star Labs StarBook](https://starlabs.systems/pages/starbook) is a 14-inch laptop. It is certified for Qubes OS Release 4.
-
-### NitroPC Pro
-
-[![Photo of the NitroPC Pro](/attachment/posts/nitropc-pro.jpg)](https://shop.nitrokey.com/shop/product/nitropc-pro-523)
-
-The [NitroPC Pro](https://shop.nitrokey.com/shop/product/nitropc-pro-523) is a desktop based on the MSI PRO Z690-A DDR5 motherboard. It is certified for Qubes OS Release 4.
-
-### NovaCustom NV41 Series
-
-[![Photo of the NovaCustom NV41 Series](/attachment/site/novacustom-nv41-series.png)](https://novacustom.com/product/nv41-series/)
-
-The [NovaCustom NV41 Series](https://novacustom.com/product/nv41-series/) is a 14-inch custom laptop. It is certified for Qubes OS Release 4.
-
-### Dasharo FidelisGuard Z690
-
-[![Photo of the Dasharo FidelisGuard Z690](/attachment/site/dasharo-fidelisguard-z690.jpg)](https://3mdeb.com/shop/open-source-hardware/dasharo-fidelisguard-z690-qubes-os-certified/)
-
-The [Dasharo FidelisGuard Z690](https://3mdeb.com/shop/open-source-hardware/dasharo-fidelisguard-z690-qubes-os-certified/) is a desktop based on the MSI PRO Z690-A DDR4 motherboard. It is certified for Qubes OS Release 4.
-
-### NitroPad T430
-
-[![Photo of the NitroPad T430](/attachment/site/nitropad-t430.jpg)](https://shop.nitrokey.com/shop/product/nitropad-t430-119)
-
-The [NitroPad T430](https://shop.nitrokey.com/shop/product/nitropad-t430-119) is a laptop based on the ThinkPad T430. It is certified for Qubes OS Release 4.
-
-### NitroPad X230
-
-[![Photo of the NitroPad X230](/attachment/site/nitropad-x230.jpg)](https://shop.nitrokey.com/shop/product/nitropad-x230-67)
-
-The [NitroPad X230](https://shop.nitrokey.com/shop/product/nitropad-x230-67) is a laptop based on the ThinkPad X230. It is certified for Qubes OS Release 4.
-
-### Insurgo PrivacyBeast X230
-
-[![Photo of the Insurgo PrivacyBeast X230](/attachment/site/insurgo-privacybeast-x230.png)](https://insurgo.ca/produit/qubesos-certified-privacybeast_x230-reasonably-secured-laptop/)
-
-The [Insurgo PrivacyBeast X230](https://insurgo.ca/produit/qubesos-certified-privacybeast_x230-reasonably-secured-laptop/) is a laptop based on the ThinkPad X230. It is certified for Qubes OS Release 4.
+| Brand                                  | Model                                                                                                                  | Certification details                                                       |
+| -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| [NovaCustom](https://novacustom.com/)  | [V54 Series](https://novacustom.com/product/v54-series/)                                                               | [Certification details](/doc/certified-hardware/novacustom-v54-series/)     |
+| [Nitrokey](https://www.nitrokey.com/)  | [NitroPad V56](https://shop.nitrokey.com/shop/nitropad-v56-684)                                                        | [Certification details](/doc/certified-hardware/nitropad-v56/)              |
+| [NovaCustom](https://novacustom.com/)  | [V56 Series](https://novacustom.com/product/v56-series/)                                                               | [Certification details](/doc/certified-hardware/novacustom-v56-series/)     |
+| [Nitrokey](https://www.nitrokey.com/)  | [NitroPC Pro 2](https://shop.nitrokey.com/shop/nitropc-pro-2-523)                                                      | [Certification details](/doc/certified-hardware/nitropc-pro-2/)             |
+| [Star Labs](https://starlabs.systems/) | [StarBook](https://starlabs.systems/pages/starbook)                                                                    | [Certification details](/doc/certified-hardware/starlabs-starbook/)         |
+| [Nitrokey](https://www.nitrokey.com/)  | [NitroPC Pro](https://shop.nitrokey.com/shop/product/nitropc-pro-523)                                                  | [Certification details](/doc/certified-hardware/nitropc-pro/)               |
+| [NovaCustom](https://novacustom.com/)  | [NV41 Series](https://novacustom.com/product/nv41-series/)                                                             | [Certification details](/doc/certified-hardware/novacustom-nv41-series/)    |
+| [3mdeb](https://3mdeb.com/)            | [Dasharo FidelisGuard Z690](https://3mdeb.com/shop/open-source-hardware/dasharo-fidelisguard-z690-qubes-os-certified/) | [Certification details](/doc/certified-hardware/dasharo-fidelisguard-z690/) |
+| [Nitrokey](https://www.nitrokey.com/)  | [NitroPad T430](https://shop.nitrokey.com/shop/product/nitropad-t430-119)                                              | [Certification details](/doc/certified-hardware/nitropad-t430/)             |
+| [Nitrokey](https://www.nitrokey.com/)  | [NitroPad X230](https://shop.nitrokey.com/shop/product/nitropad-x230-67)                                               | [Certification details](/doc/certified-hardware/nitropad-x230/)             |
+| [Insurgo](https://insurgo.ca/)         | [PrivacyBeast X230](https://insurgo.ca/produit/qubesos-certified-privacybeast_x230-reasonably-secured-laptop/)         | [Certification details](/doc/certified-hardware/insurgo-privacybeast-x230/) |
 
 ## Become hardware certified
 

--- a/user/hardware/certified-hardware/dasharo-fidelisguard-z690.md
+++ b/user/hardware/certified-hardware/dasharo-fidelisguard-z690.md
@@ -1,0 +1,38 @@
+---
+lang: en
+layout: doc
+permalink: /doc/certified-hardware/dasharo-fidelisguard-z690/
+title: Dasharo FidelisGuard Z690
+image: /attachment/posts/dasharo-fidelisguard-z690_2.jpg
+---
+
+The [Dasharo FidelisGuard Z690](https://3mdeb.com/shop/open-source-hardware/dasharo-fidelisguard-z690-qubes-os-certified/) is [officially certified](/doc/certified-hardware/) for Qubes OS Release 4.
+
+[![Photo of MSI PRO Z690-A DDR4 motherboard](/attachment/posts/dasharo-fidelisguard-z690_1.jpg)](https://3mdeb.com/shop/open-source-hardware/dasharo-fidelisguard-z690-qubes-os-certified/)
+
+The [Dasharo FidelisGuard Z690](https://3mdeb.com/shop/open-source-hardware/dasharo-fidelisguard-z690-qubes-os-certified/) is a full desktop PC build that brings the [Dasharo](https://dasharo.com/) open-source firmware distribution to the MSI PRO Z690-A DDR4 motherboard with Qubes OS preinstalled. The full configuration includes:
+
+| Part         | Model Name                                                     |
+|------------- | -------------------------------------------------------------- |
+| CPU	         | Intel Core i5-12600K, 3.7GHz                                   |
+| Cooling	     | Noctua CPU NH-U12S Redux                                       |
+| RAM	         | Kingston Fury Beast, DDR4, 4x8GB (32 GB Total), 3600 MHz, CL17 |
+| Power Supply | Seasonic Focus PX 750W 80 Plus Platinum                        |
+| Storage      | SSD Intel 670p 512 GB M.2 2280 PCI-E x4 Gen3 NVMe              |
+| Enclosure	   | SilentiumPC Armis AR1                                          |
+
+[![Photo of Dasharo FidelisGuard Z690 with open case](/attachment/posts/dasharo-fidelisguard-z690_2.jpg)](https://3mdeb.com/shop/open-source-hardware/dasharo-fidelisguard-z690-qubes-os-certified/)
+
+This computer comes with a "Dasharo Supporters Entrance Subscription," which includes the following:
+
+- Full access to [Dasharo Tools Suite (DTS)](https://docs.dasharo.com/dasharo-tools-suite/overview/)
+- The latest Dasharo releases issued by the Dasharo Team
+- Special Dasharo updates for supporters
+- Dasharo Premier Support through an invite-only Matrix channel
+- Influence on the Dasharo feature roadmap
+
+[![Photo of Dasharo FidelisGuard Z690 with open case](/attachment/posts/dasharo-fidelisguard-z690_3.jpg)](https://3mdeb.com/shop/open-source-hardware/dasharo-fidelisguard-z690-qubes-os-certified/)
+
+For further details, please see the [Dasharo FidelisGuard Z690](https://3mdeb.com/shop/open-source-hardware/dasharo-fidelisguard-z690-qubes-os-certified/) product page.
+
+[![Photo of the outside of the Dasharo FidelisGuard Z690](/attachment/posts/dasharo-fidelisguard-z690_4.jpg)](https://3mdeb.com/shop/open-source-hardware/dasharo-fidelisguard-z690-qubes-os-certified/)

--- a/user/hardware/certified-hardware/insurgo-privacybeast-x230.md
+++ b/user/hardware/certified-hardware/insurgo-privacybeast-x230.md
@@ -1,0 +1,26 @@
+---
+lang: en
+layout: doc
+permalink: /doc/certified-hardware/insurgo-privacybeast-x230/
+title: Insurgo PrivacyBeast X230
+image: /attachment/site/insurgo-privacybeast-x230.png
+---
+
+<div class="alert alert-danger" role="alert">
+  <i class="fa fa-exclamation-triangle"></i>
+  <b>Warning:</b> The CPU in this computer no longer receives microcode updates from Intel. Without microcode updates, Qubes OS cannot ensure that this computer is secure against CPU vulnerabilities. While this computer remains certified for Qubes OS Release 4, we recommend that prospective buyers consider a newer Qubes-certified computer instead.
+</div>
+
+The [Insurgo PrivacyBeast X230](https://insurgo.ca/produit/qubesos-certified-privacybeast_x230-reasonably-secured-laptop/) is [officially certified](/doc/certified-hardware/) for Qubes OS Release 4.
+
+[![Photo of the Insurgo PrivacyBeast X230](/attachment/site/insurgo-privacybeast-x230.png)](https://insurgo.ca/produit/qubesos-certified-privacybeast_x230-reasonably-secured-laptop/)
+
+The [Insurgo PrivacyBeast X230](https://insurgo.ca/produit/qubesos-certified-privacybeast_x230-reasonably-secured-laptop/) is a custom refurbished [ThinkPad X230](https://www.thinkwiki.org/wiki/Category:X230) that includes the following features:
+
+- [coreboot](https://www.coreboot.org/) initialization for the x230 is binary-blob-free, including native graphic initialization. Built with the [Heads](https://github.com/osresearch/heads/) payload, it delivers an [Anti Evil Maid (AEM)](/doc/anti-evil-maid/)-like solution built into the firmware. (Even though our [requirements](/doc/certified-hardware/#hardware-certification-requirements) provide an exception for CPU-vendor-provided blobs for silicon and memory initialization, Insurgo exceeds our requirements by insisting that these be absent from its machines.)
+
+- [Intel ME](https://libreboot.org/faq.html#intelme) is neutered through the AltMeDisable bit, while all modules other than ROMP and BUP, which are required to initialize main CPU, have been [deleted](https://github.com/osresearch/heads-wiki/blob/master/Clean-the-ME-firmware.md#how-to-disabledeactive-most-of-it).
+
+- A re-ownership process that allows it to ship pre-installed with Qubes OS, including full-disk encryption already in place, but where the final disk encryption key is regenerated only when the machine is first powered on by the user, so that the OEM doesn't know it.
+
+- [Heads](https://github.com/osresearch/heads/) provisioned pre-delivery to protect against malicious [interdiction](https://en.wikipedia.org/wiki/Interdiction).

--- a/user/hardware/certified-hardware/nitropad-t430.md
+++ b/user/hardware/certified-hardware/nitropad-t430.md
@@ -1,0 +1,30 @@
+---
+lang: en
+layout: doc
+permalink: /doc/certified-hardware/nitropad-t430/
+title: NitroPad T430
+image: /attachment/site/nitropad-t430.jpg
+---
+
+<div class="alert alert-danger" role="alert">
+  <i class="fa fa-exclamation-triangle"></i>
+  <b>Warning:</b> The CPU in this computer no longer receives microcode updates from Intel. Without microcode updates, Qubes OS cannot ensure that this computer is secure against CPU vulnerabilities. While this computer remains certified for Qubes OS Release 4, we recommend that prospective buyers consider a newer Qubes-certified computer instead.
+</div>
+
+<div class="alert alert-warning" role="alert">
+  <i class="fa fa-exclamation-circle"></i>
+  <b>Note:</b> Please be advised that the i7-3632QM option is <b>not</b> compatible with Qubes OS, as it does not support VT-d. The option specifically tested by the Qubes team is the i5-3320M.
+</div>
+
+The [NitroPad T430](https://shop.nitrokey.com/shop/product/nitropad-t430-119) is [officially certified](/doc/certified-hardware/) for Qubes OS Release 4.
+
+[![Photo of the NitroPad T430](/attachment/site/nitropad-t430.jpg)](https://shop.nitrokey.com/shop/product/nitropad-t430-119)
+
+Key features of the [NitroPad T430](https://shop.nitrokey.com/shop/product/nitropad-t430-119) include:
+
+- Tamper detection through measured boot with [coreboot](https://www.coreboot.org/), [Heads](https://github.com/osresearch/heads/), and Nitrokey USB hardware, including support for [Anti Evil Maid (AEM)](/doc/anti-evil-maid/)
+- Deactivated [Intel Management Engine](https://libreboot.org/faq.html#intelme)
+- User-replaceable cryptographic keys
+- Included Nitrokey USB key
+- Professional ThinkPad hardware based on the [ThinkPad T430](https://www.thinkwiki.org/wiki/Category:T430)
+- Security-conscious shipping to mitigate against third-party [interdiction](https://en.wikipedia.org/wiki/Interdiction)

--- a/user/hardware/certified-hardware/nitropad-v56.md
+++ b/user/hardware/certified-hardware/nitropad-v56.md
@@ -1,0 +1,82 @@
+---
+lang: en
+layout: doc
+permalink: /doc/certified-hardware/nitropad-v56/
+title: NitroPad V56
+image: /attachment/site/nitropad-v56.png
+---
+
+The [NitroPad V56](https://shop.nitrokey.com/shop/nitropad-v56-684) is [officially certified](/doc/certified-hardware/) for Qubes OS Release 4.
+
+[![Photo of the NitroPad V56](/attachment/site/nitropad-v56.png)](https://shop.nitrokey.com/shop/nitropad-v56-684)
+
+## Qubes-certified options
+
+The configuration options required for Qubes certification are detailed below.
+
+### Processor and graphics card
+
+- Certified: Intel Core Ultra 5 Processor 125H, Intel Arc iGPU with AI Boost
+- Certified: Intel Core Ultra 7 Processor 155H, Intel Arc iGPU with AI Boost
+- The Nvidia GPU options are not currently certified.
+
+### Memory (RAM) DDR5, 5600 MHz
+
+- Certified: All options 16 GB (2x8 GB) and higher
+
+
+### 1st Hard Disk SSD NVMe PCIe 4.0 x4
+
+- Certified: Any of the available options in this section
+
+### 2nd Hard Disk SSD NVMe PCIe 4.0 x4
+
+- Certified: Any of the available options in this section
+
+### Keyboard
+
+- Certified: Any of the available options in this section
+
+### Wireless interfaces
+
+- Certified: Wi-Fi 6E + Bluetooth 5.3, Intel AX-210/211 (non vPro) WLAN module 2.4 Gbps, 802.11ax
+- Certified: Wi-Fi 7 + Bluetooth 5.42, Intel BE200 (non vPro) WLAN module 5.8 Gbps, 802.11be
+- Certified: No wireless
+
+### Webcam and microphone
+
+- Certified: Any of the available options in this section
+
+### Type
+
+- Certified: Any of the available options in this section
+
+### Firmware
+
+- Certified: Dasharo TianoCore UEFI without Measured boot, without Nitrokey
+- The option "Dasharo HEADS with Measured Boot, requires Nitrokey!" is not yet certified.
+
+### Operating system
+
+- Certified: Qubes OS 4.2.3 or newer (within Release 4).
+- Releases older than 4.2.3 are not certified.
+- You may choose either to have Nitrokey preinstall Qubes OS for you, or you may choose to install Qubes OS yourself. This choice does not affect certification.
+
+### Nitrokey
+
+- Certified: None -- for TianoCore only!
+- The Nitrokey options are currently not applicable to Qubes hardware certification. (See the Firmware section above.)
+
+### Shipment of Nitrokey
+
+- This section does not affect Qubes hardware certification.
+
+### Tamper-evident packaging
+
+- This section does not affect Qubes hardware certification.
+
+## Disclaimers
+
+- In order for Wi-Fi to function properly, `sys-net` must currently be based on a Fedora template. The firmware package in Debian templates is currently too old for the certified Wi-Fi cards.
+- Currently requires `kernel-latest`: If you install Qubes OS yourself, you must select the `Install Qubes OS RX using kernel-latest` option on the GRUB menu when booting the installer. This non-default kernel option is currently required for the NitroPad V56 to function properly.
+- Due to a [known bug](https://github.com/Dasharo/dasharo-issues/issues/976), the bottom-right USB-C port is currently limited to USB 2.0 speeds.

--- a/user/hardware/certified-hardware/nitropad-x230.md
+++ b/user/hardware/certified-hardware/nitropad-x230.md
@@ -1,0 +1,25 @@
+---
+lang: en
+layout: doc
+permalink: /doc/certified-hardware/nitropad-x230/
+title: NitroPad X230
+image: /attachment/site/nitropad-x230.jpg
+---
+
+<div class="alert alert-danger" role="alert">
+  <i class="fa fa-exclamation-triangle"></i>
+  <b>Warning:</b> The CPU in this computer no longer receives microcode updates from Intel. Without microcode updates, Qubes OS cannot ensure that this computer is secure against CPU vulnerabilities. While this computer remains certified for Qubes OS Release 4, we recommend that prospective buyers consider a newer Qubes-certified computer instead.
+</div>
+
+The [NitroPad X230](https://shop.nitrokey.com/shop/product/nitropad-x230-67) is [officially certified](/doc/certified-hardware/) for Qubes OS Release 4.
+
+[![Photo of the NitroPad X230](/attachment/site/nitropad-x230.jpg)](https://shop.nitrokey.com/shop/product/nitropad-x230-67)
+
+The [NitroPad X230](https://shop.nitrokey.com/shop/product/nitropad-x230-67) offers users unprecedented control over the security of their hardware. Key features include:
+
+- Tamper detection through measured boot with [coreboot](https://www.coreboot.org/), [Heads](https://github.com/osresearch/heads/), and Nitrokey USB hardware, including support for [Anti Evil Maid (AEM)](/doc/anti-evil-maid/)
+- Deactivated [Intel Management Engine](https://libreboot.org/faq.html#intelme)
+- User-replaceable cryptographic keys
+- Included Nitrokey USB key
+- Professional ThinkPad hardware based on the [ThinkPad X230](https://www.thinkwiki.org/wiki/Category:X230)
+- Security-conscious shipping to mitigate against third-party [interdiction](https://en.wikipedia.org/wiki/Interdiction)

--- a/user/hardware/certified-hardware/nitropc-pro-2.md
+++ b/user/hardware/certified-hardware/nitropc-pro-2.md
@@ -1,0 +1,47 @@
+---
+lang: en
+layout: doc
+permalink: /doc/certified-hardware/nitropc-pro-2/
+title: NitroPC Pro 2
+image: /attachment/posts/nitropc-pro.jpg
+---
+
+<div class="alert alert-warning" role="alert">
+  <i class="fa fa-exclamation-circle"></i>
+  <b>Note:</b> When configuring your NitroPC Pro 2 on the Nitrokey website, there is an option for a discrete graphics card (e.g., Nvidia GeForce RTX 4070 or 4090) in addition to integrated graphics (e.g., Intel UHD 770, which is always included because it is physically built into the CPU). NitroPC Pro 2 configurations that include discrete graphics cards are <em>not</em> Qubes-certified. The only NitroPC Pro 2 configurations that are Qubes-certified are those that contain <em>only</em> integrated graphics.
+</div>
+
+<div class="alert alert-warning" role="alert">
+  <i class="fa fa-exclamation-circle"></i>
+  <b>Note:</b> Only the "Dasharo TianoCore UEFI without Measured Boot, without Nitrokey" firmware option is certified. The "HEADS with Measured Boot, requires Nitrokey!" firmware option is <em>not</em> certified.
+</div>
+
+The [NitroPC Pro 2](https://shop.nitrokey.com/shop/nitropc-pro-2-523) is [officially certified](/doc/certified-hardware/) for Qubes OS Release 4.
+
+[![Photo of NitroPC Pro 2](/attachment/posts/nitropc-pro.jpg)](https://shop.nitrokey.com/shop/nitropc-pro-2-523)
+
+Here's a summary of the main component options available for this mid-tower desktop PC:
+
+| Component                    | Options                                                  |
+|----------------------------- | -------------------------------------------------------- |
+| Motherboard                  | MSI PRO Z790-P DDR5 (Wi-Fi optional)                     |
+| Processor                    | 14th Generation Intel Core i5-14600K or i9-14900K        |
+| Memory                       | 16 GB to 128 GB DDR5                                     |
+| NVMe storage (optional)      | Up to two NVMe PCIe 4.0 x4 SSDs, up to 2 TB each         |
+| SATA storage (optional)      | Up to two SATA SSDs, up to 7.68 TB each                  |
+| Wireless (optional)          | Wi-Fi 6E, 2400 Mbps, 802.11/a/b/g/n/ac/ax, Bluetooth 5.2 |
+| Operating system (optional)  | Qubes OS 4.2 or Ubuntu 22.04 LTS                         |
+
+Of special note for Qubes users, the NitroPC Pro 2 features a combined PS/2 port that supports both a PS/2 keyboard and a PS/2 mouse simultaneously with a Y-cable (not included). This allows for full control of dom0 without the need for USB keyboard or mouse passthrough. Nitrokey also offers a special tamper-evident shipping method for an additional fee. With this option, the case screws will be individually sealed and photographed, and the NitroPC Pro 2 will be packed inside a sealed bag. Photographs of the seals will be sent to you by email, which you can use to determine whether the case was opened during transit.
+
+The NitroPC Pro 2 also comes with a "Dasharo Entry Subscription," which includes the following:
+
+- Accesses to the latest firmware releases
+- Exclusive newsletter
+- Special updates, including early access to updates enhancing privacy, security, performance, and compatibility
+- Early access to new firmware releases for [newly-supported desktop platforms](https://docs.dasharo.com/variants/overview/#desktop) (please see the [roadmap](https://github.com/Dasharo/presentations/blob/main/dasharo_roadmap.md#dasharo-desktop-roadmap))
+- Access to the Dasharo Premier Support invite-only live chat channel on the Matrix network, allowing direct access to the Dasharo Team and fellow subscribers with personalized and priority assistance
+- Insider's view and influence on the Dasharo feature roadmap for a real impact on Dasharo development
+- [Dasharo Tools Suite Entry Subscription](https://docs.dasharo.com/osf-trivia-list/dts/#what-is-dasharo-tools-suite-supporters-entrance) keys
+
+For further product details, please see the official [NitroPC Pro 2](https://shop.nitrokey.com/shop/nitropc-pro-2-523) page.

--- a/user/hardware/certified-hardware/nitropc-pro.md
+++ b/user/hardware/certified-hardware/nitropc-pro.md
@@ -1,0 +1,47 @@
+---
+lang: en
+layout: doc
+permalink: /doc/certified-hardware/nitropc-pro/
+title: NitroPC Pro
+image: /attachment/posts/nitropc-pro.jpg
+---
+
+<div class="alert alert-warning" role="alert">
+  <i class="fa fa-exclamation-circle"></i>
+  <b>Note:</b> When configuring your NitroPC Pro 2 on the Nitrokey website, there is an option for a discrete graphics card (e.g., Nvidia GeForce RTX 4070 or 4090) in addition to integrated graphics (e.g., Intel UHD 770, which is always included because it is physically built into the CPU). NitroPC Pro 2 configurations that include discrete graphics cards are <em>not</em> Qubes-certified. The only NitroPC Pro 2 configurations that are Qubes-certified are those that contain <em>only</em> integrated graphics.
+</div>
+
+<div class="alert alert-warning" role="alert">
+  <i class="fa fa-exclamation-circle"></i>
+  <b>Note:</b> Only the "Dasharo TianoCore UEFI without Measured Boot, without Nitrokey" firmware option is certified. The "HEADS with Measured Boot, requires Nitrokey!" firmware option is <em>not</em> certified.
+</div>
+
+The [NitroPC Pro](https://shop.nitrokey.com/shop/product/nitropc-pro-523) is [officially certified](/doc/certified-hardware/) for Qubes OS Release 4.
+
+[![Photo of NitroPC Pro](/attachment/posts/nitropc-pro.jpg)](https://shop.nitrokey.com/shop/product/nitropc-pro-523)
+
+Here's a summary of the main component options available for this mid-tower desktop PC:
+
+| Component                    | Options                                                  |
+|----------------------------- | -------------------------------------------------------- |
+| Motherboard                  | MSI PRO Z690-A DDR5 (Wi-Fi optional)                     |
+| Processor                    | 12th Generation Intel Core i5-12600K or i9-12900K        |
+| Memory                       | 16 GB to 128 GB DDR5                                     |
+| NVMe storage (optional)      | Up to two NVMe PCIe 4.0 x4 SSDs, up to 2 TB each         |
+| SATA storage (optional)      | Up to two SATA SSDs, up to 7.68 TB each                  |
+| Wireless (optional)          | Wi-Fi 6E, 2400 Mbps, 802.11/a/b/g/n/ac/ax, Bluetooth 5.2 |
+| Operating system (optional)  | Qubes OS 4.1 or Ubuntu 22.04 LTS                         |
+
+Of special note for Qubes users, the NitroPC Pro features a combined PS/2 port that supports both a PS/2 keyboard and a PS/2 mouse simultaneously with a Y-cable (not included). This allows for full control of dom0 without the need for USB keyboard or mouse passthrough. Nitrokey also offers a special tamper-evident shipping method for an additional fee. With this option, the case screws will be individually sealed and photographed, and the NitroPC Pro will be packed inside a sealed bag. Photographs of the seals will be sent to you by email, which you can use to determine whether the case was opened during transit.
+
+The NitroPC Pro also comes with a "Dasharo Entry Subscription," which includes the following:
+
+- Accesses to the latest firmware releases
+- Exclusive newsletter
+- Special firmware updates, including early access to updates enhancing privacy, security, performance, and compatibility
+- Early access to new firmware releases for [newly-supported desktop platforms](https://docs.dasharo.com/variants/overview/#desktop) (please see the [roadmap](https://github.com/Dasharo/presentations/blob/main/dug2_dasharo_roadmap.md#dasharo-desktop-roadmap))
+- Access to the Dasharo Premier Support invite-only live chat channel on the Matrix network, allowing direct access to the Dasharo Team and fellow subscribers with personalized and priority assistance
+- Insider's view and influence on the Dasharo feature roadmap for a real impact on Dasharo development
+- [Dasharo Tools Suite Entry Subscription](https://docs.dasharo.com/osf-trivia-list/dts/#what-is-dasharo-tools-suite-supporters-entrance) keys
+
+For further product details, please see the official [NitroPC Pro](https://shop.nitrokey.com/shop/product/nitropc-pro-523) page.

--- a/user/hardware/certified-hardware/novacustom-nv41-series.md
+++ b/user/hardware/certified-hardware/novacustom-nv41-series.md
@@ -1,0 +1,42 @@
+---
+lang: en
+layout: doc
+permalink: /doc/certified-hardware/novacustom-nv41-series/
+title: NovaCustom NV41 Series
+image: /attachment/site/novacustom-nv41-series.png
+---
+
+The [NovaCustom NV41 Series](https://novacustom.com/product/nv41-series/) is [officially certified](/doc/certified-hardware/) for Qubes OS Release 4.
+
+[![Photo of the NovaCustom NV41 Series](/attachment/site/novacustom-nv41-series.png)](https://novacustom.com/product/nv41-series/)
+
+## Qubes-certified configurations
+
+The following configuration options are certified for Qubes OS Release 4:
+
+Processor:
+- Intel Core i5-1240P processor
+- Intel Core i7-1260P processor
+
+Memory:
+- 2 x 16 GB Kingston DDR4 SODIMM 3200 MHz (32 GB total)
+- 1 x 32 GB Kingston DDR4 SODIMM 3200 MHz (32 GB total)
+- 2 x 32 GB Kingston DDR4 SODIMM 3200 MHz (64 GB total)
+
+M.2 storage chip:
+- Samsung 980 SSD (all capacities)
+- Samsung 980 Pro SSD (all capacities)
+
+Wi-Fi and Bluetooth:
+- Intel AX-200/201 Wi-Fi module 2976 Mbps, 802.11ax/Wi-Fi 6 + Bluetooth 5.2
+- Killer (Intel) Wireless-AX 1675x M.2 Wi-Fi module 802.11ax/Wi-Fi 6E + Bluetooth 5.3
+- Blob-free: Qualcomm Atheros QCNFA222 Wi-Fi 802.11a/b/g/n + Bluetooth 4.0
+- No Wi-Fi/Bluetooth chip
+
+### Notes on Wi-Fi and Bluetooth options
+
+- When viewed in a Linux environment with `lspci`, the "Killer (Intel) Wireless-AX 1675x M.2 Wi-Fi module 802.11ax/Wi-Fi 6E + Bluetooth 5.3" device displays the model number "AX210." However, according to its [Intel Ark entry](https://ark.intel.com/content/www/us/en/ark/products/211485/intel-killer-wifi-6e-ax1675-xw.html) (in the "Product Brief" file), they are actually the same Wi-Fi module.
+
+- Similarly, when viewed in a Linux environment with `lspci`, the "Blob-free: Qualcomm Atheros QCNFA222 Wi-Fi 802.11a/b/g/n + Bluetooth 4.0" device displays the model number "AR9462," which seems to be just the Wi-Fi chip model number, whereas "QCNFA222" seems to be the model number of the whole device (which include Bluetooth). Meanwhile, the Bluetooth device presents itself as "IMC Networks Device 3487."
+
+- The term "blob-free" is used in different ways. In practice, being "blob-free" generally does *not* mean that the device does not use any closed-source firmware "blobs." Rather, it means that the device comes with firmware *preinstalled* so that it does not have to be loaded from the operating system. In theory, the preinstalled firmware could be open-source, but as far as we know, that is not the case with this particular Atheros Wi-Fi/Bluetooth module. (Qualcomm has published firmware source code in the past, but only for other device models, as far as we are aware.) Meanwhile, the Free Software Foundation (FSF) [considers](https://www.gnu.org/philosophy/free-hardware-designs.en.html#boundary) unmodifiable preinstalled firmware to be part of the hardware, hence they regard such hardware as "blob-free" from a software perspective. While common usage of the term "blob-free" often follows the FSF's interpretation, it is worthwhile for Qubes users who are concerned about closed-source firmware to understand the nuance.

--- a/user/hardware/certified-hardware/novacustom-v54-series.md
+++ b/user/hardware/certified-hardware/novacustom-v54-series.md
@@ -1,0 +1,69 @@
+---
+lang: en
+layout: doc
+permalink: /doc/certified-hardware/novacustom-v54-series/
+title: NovaCustom V54 Series
+image: /attachment/site/novacustom-v54-series.png
+---
+
+The [NovaCustom V54 Series 14.0 inch coreboot laptop](https://novacustom.com/product/v54-series/) is [officially certified](/doc/certified-hardware/) for Qubes OS Release 4.
+
+[![Photo of the NovaCustom V54 Series 14.0 inch coreboot laptop](/attachment/site/novacustom-v54-series.png)](https://novacustom.com/product/v54-series/)
+
+## Qubes-certified options
+
+The configuration options required for Qubes certification are detailed below.
+
+### Screen size
+
+- Certified: 14 inch
+
+**Note:** The 14-inch model (V540TU) and the 16-inch model (V560TU) are two separate products. [The 16-inch model is also certified.](/doc/certified-hardware/novacustom-v56-series/)
+
+### Screen resolution
+
+- Certified: Full HD+ (1920 x 1200)
+- Certified: 2.8K (2880 x 1800)
+
+### Processor and graphics
+
+- Certified: Intel Core Ultra 5 Processor 125H, Intel Arc iGPU with AI Boost
+- Certified: Intel Core Ultra 7 Processor 155H, Intel Arc iGPU with AI Boost
+- The Nvidia discrete GPU options are not currently certified.
+
+### Memory
+
+- Certified: Any configuration with at least 16 GB of memory
+
+### Storage
+
+- Certified: All of the available options in these sections
+
+### Personalization
+
+- This section is merely cosmetic and therefore does not affect certification.
+
+### Firmware options
+
+- Qubes OS does not currently support UEFI secure boot.
+- The option to be kept up to date with firmware updates is merely an email notification service and therefore does not affect certification.
+- The coreboot+Heads option is not currently certified. This option is a separate firmware variant. As such, it requires a separate certification process, which we expect to occur in the future.
+- Disabling Intel Management Engine (HAP disabling) does not affect certification.
+
+### Operating system
+
+- Certified: Qubes OS 4.2.4 or newer (within Release 4).
+- Releases older than 4.2.4 are not certified.
+- You may choose either to have NovaCustom preinstall Qubes OS for you, or you may choose to install Qubes OS yourself. This choice does not affect certification.
+
+### Wi-Fi and Bluetooth
+
+- Certified: Intel AX-210/211 (non vPro) Wi-Fi module 2.4 Gbps, 802.11AX/Wi-Fi6E + Bluetooth 5.3
+- Certified: Intel BE200 (non vPro) Wi-Fi module 5.8 Gbps, 802.11BE/Wi-Fi7 + Bluetooth 5.42
+- Certified: No Wi-Fi chip -- no Bluetooth and Wi-Fi connection possible (only with USB adapter)
+
+## Disclaimers
+
+- In order for Wi-Fi to function properly, `sys-net` must currently be based on a Fedora template. The firmware package in Debian templates is currently too old for the certified Wi-Fi cards.
+- Currently requires `kernel-latest`: If you install Qubes OS yourself, you must select the `Install Qubes OS RX using kernel-latest` option on the GRUB menu when booting the installer. This non-default kernel option is currently required for the NovaCustom V54 Series to function properly.
+- Due to a [known bug](https://github.com/Dasharo/dasharo-issues/issues/976), the bottom-right USB-C port is currently limited to USB 2.0 speeds.

--- a/user/hardware/certified-hardware/novacustom-v56-series.md
+++ b/user/hardware/certified-hardware/novacustom-v56-series.md
@@ -1,0 +1,69 @@
+---
+lang: en
+layout: doc
+permalink: /doc/certified-hardware/novacustom-v56-series/
+title: NovaCustom V56 Series
+image: /attachment/site/novacustom-v56-series.png
+---
+
+The [NovaCustom V56 Series 16.0 inch coreboot laptop](https://novacustom.com/product/v56-series/) is [officially certified](/doc/certified-hardware/) for Qubes OS Release 4.
+
+[![Photo of the NovaCustom V56 Series 16.0 inch coreboot laptop](/attachment/site/novacustom-v56-series.png)](https://novacustom.com/product/v56-series/)
+
+## Qubes-certified options
+
+The configuration options required for Qubes certification are detailed below.
+
+### Screen size
+
+- Certified: 16 inch
+
+**Note:** The 16-inch model (V560TU) and the 14-inch model (V540TU) are two separate products. [The 14-inch model is also certified.](/doc/certified-hardware/novacustom-v54-series/)
+
+### Screen resolution
+
+- Certified: Full HD+ (1920 x 1200)
+- Certified: Q-HD+ (2560 x 1600)
+
+### Processor and graphics
+
+- Certified: Intel Core Ultra 5 Processor 125H + Intel Arc iGPU with AI Boost
+- Certified: Intel Core Ultra 7 Processor 155H + Intel Arc iGPU with AI Boost
+- The Nvidia discrete GPU options are not currently certified.
+
+### Memory
+
+- Certified: Any configuration with at least 16 GB of memory
+
+### Storage
+
+- Certified: Any of the available options in this section
+
+### Personalization
+
+- This section is merely cosmetic and therefore does not affect certification.
+
+### Firmware options
+
+- Qubes OS does not currently support UEFI secure boot.
+- Keeping up-to-date with firmware updates is merely an email notification service and therefore does not affect certification.
+- The coreboot+Heads option is not currently certified. This option is a separate firmware variant. As such, it requires a separate certification process, which we expect to occur in the future.
+- Disabling Intel Management Engine (HAP disabling) does not affect certification.
+
+### Operating system
+
+- Certified: Qubes OS 4.2.3 or newer (within Release 4).
+- Releases older than 4.2.3 are not certified.
+- You may choose either to have NovaCustom preinstall Qubes OS for you, or you may choose to install Qubes OS yourself. This choice does not affect certification.
+
+### Wi-Fi and Bluetooth
+
+- Certified: Intel AX-210/211 (non vPro) Wi-Fi module 2.4 Gbps, 802.11AX/Wi-Fi6E + Bluetooth 5.3
+- Certified: Intel BE200 (non vPro) Wi-Fi module 5.8 Gbps, 802.11BE/Wi-Fi7 + Bluetooth 5.42
+- Certified: No Wi-Fi chip - no Bluetooth and Wi-Fi connection possible (only with USB adapter)
+
+## Disclaimers
+
+- In order for Wi-Fi to function properly, `sys-net` must currently be based on a Fedora template. The firmware package in Debian templates is currently too old for the certified Wi-Fi cards.
+- Currently requires `kernel-latest`: If you install Qubes OS yourself, you must select the `Install Qubes OS RX using kernel-latest` option on the GRUB menu when booting the installer. This non-default kernel option is currently required for the NovaCustom V56 Series to function properly.
+- Due to a [known bug](https://github.com/Dasharo/dasharo-issues/issues/976), the bottom-right USB-C port is currently limited to USB 2.0 speeds.

--- a/user/hardware/certified-hardware/starlabs-starbook.md
+++ b/user/hardware/certified-hardware/starlabs-starbook.md
@@ -1,0 +1,35 @@
+---
+lang: en
+layout: doc
+permalink: /doc/certified-hardware/starlabs-starbook/
+title: Star Labs StarBook
+image: /attachment/site/starlabs-starbook.png
+---
+
+The [Star Labs StarBook](https://starlabs.systems/pages/starbook) is [officially certified](/doc/certified-hardware/) for Qubes OS Release 4.
+
+The [Star Labs StarBook](https://starlabs.systems/pages/starbook) is a 14-inch laptop featuring open-source coreboot and EDK II firmware. 
+
+[![Photo of Star Labs StarBook](/attachment/site/starlabs-starbook.png)](https://starlabs.systems/pages/starbook)
+
+The Qubes developers have tested and certified the following StarBook configuration options for Qubes OS Release 4:
+
+| Component        | Qubes-certified options                          |
+| ---------------- | ------------------------------------------------ |
+| Processor        | 13th Generation Intel Core i3-1315U or i7-1360P  |
+| Memory           | 8 GB, 16 GB, 32 GB, or 64 GB RAM                 |
+| Storage          | 512 GB, 1 TB, or 2 TB SSD                        |
+| Graphics         | Intel (integrated graphics)                      |
+| Networking       | Intel Wi-Fi 6 AX210 (no built-in wired Ethernet) |
+| Firmware         | coreboot 8.97 (2023-10-03)                       |
+| Operating system | Qubes OS (pre-installation optional)             |
+
+[![Photo of Star Labs StarBook](/attachment/posts/starlabs-starbook_top.png)](https://starlabs.systems/pages/starbook)
+
+The StarBook features a true matte 14-inch IPS display at 1920x1080 full HD resolution with 400cd/m² of brightness, 178° viewing angles, and a 180° hinge. The backlit keyboard is available in US English, UK English, French, German, Nordic, and Spanish layouts.
+
+[![Photo of Star Labs StarBook](/attachment/posts/starlabs-starbook_side.png)](https://starlabs.systems/pages/starbook)
+
+The StarBook includes four USB ports (1x USB-C with Thunderbolt 4, 2x USB 3.0, and 1x USB 2.0), one HDMI port, a microSD slot, an audio input/output combo jack, and a DC jack for charging. For more information, see the official [Star Labs StarBook](https://starlabs.systems/pages/starbook) page.
+
+[![Photo of Star Labs StarBook](/attachment/posts/starlabs-starbook_back.png)](https://starlabs.systems/pages/starbook)


### PR DESCRIPTION
- Replace list of certified models with table
- Create page for each certified model
- Organize certified hardware files in subdirectory
- Update certification details of individual model pages
- Add warnings for X230- and T430-based models (QubesOS/qubes-issues#9782)