### PR TITLE
docs: fixed missing "is" for correct sentence structure

### DIFF
--- a/developer/services/qrexec-internals.md
+++ b/developer/services/qrexec-internals.md
@@ -124,7 +124,7 @@ Details of all possible use cases and the messages involved are described below.
 
   (If `local_program` is set, `qrexec-client` executes it and uses that child's stdin/stdout in place of its own when exchanging data with `qrexec-agent` later.)
 
-  `qrexec-client` translates that request into a `MSG_EXEC_CMDLINE` message sent to `qrexec-daemon`, with `connect_domain` set to 0 (connect to **dom0**) and `connect_port also set to 0 (allocate a port).
+  `qrexec-client` translates that request into a `MSG_EXEC_CMDLINE` message sent to `qrexec-daemon`, with `connect_domain` set to 0 (connect to **dom0**) and `connect_port is also set to 0 (allocate a port).
 
 - **dom0**: `qrexec-daemon` allocates a free port (in this case 513), and sends a `MSG_EXEC_CMDLINE` back to the client with connection parameters (**domX** and 513) and with command field empty.
 


### PR DESCRIPTION
fixed the issue where the sentence was missing the word "is," which is necessary for proper grammar and clarity.