### PR TITLE
Fix outdated link in insurgo-privacybeast-x230.md

### DIFF
--- a/user/hardware/certified-hardware/insurgo-privacybeast-x230.md
+++ b/user/hardware/certified-hardware/insurgo-privacybeast-x230.md
@@ -19,7 +19,7 @@ The [Insurgo PrivacyBeast X230](https://insurgo.ca/produit/qubesos-certified-pri
 
 - [coreboot](https://www.coreboot.org/) initialization for the x230 is binary-blob-free, including native graphic initialization. Built with the [Heads](https://github.com/osresearch/heads/) payload, it delivers an [Anti Evil Maid (AEM)](/doc/anti-evil-maid/)-like solution built into the firmware. (Even though our [requirements](/doc/certified-hardware/#hardware-certification-requirements) provide an exception for CPU-vendor-provided blobs for silicon and memory initialization, Insurgo exceeds our requirements by insisting that these be absent from its machines.)
 
-- [Intel ME](https://libreboot.org/faq.html#intelme) is neutered through the AltMeDisable bit, while all modules other than ROMP and BUP, which are required to initialize main CPU, have been [deleted](https://github.com/osresearch/heads-wiki/blob/master/Clean-the-ME-firmware.md#how-to-disabledeactive-most-of-it).
+- [Intel ME](https://libreboot.org/faq.html#intelme) is neutered through the AltMeDisable bit, while all modules other than ROMP and BUP, which are required to initialize main CPU, have been [deleted](https://github.com/linuxboot/heads-wiki/blob/master/Installing-and-Configuring/Flashing-Guides/Clean-the-ME-firmware.md#how-to-disabledeactive-most-of-it).
 
 - A re-ownership process that allows it to ship pre-installed with Qubes OS, including full-disk encryption already in place, but where the final disk encryption key is regenerated only when the machine is first powered on by the user, so that the OEM doesn't know it.
 


### PR DESCRIPTION
The previous link pointed to a section that no longer exists in the osresearch/heads-wiki repository. The updated link reflects the current valid path to the same documentation within the linuxboot/heads-wiki repository where the guide has been moved.

If maintainers have a preferred canonical link, I’d be happy to revise.