### PR TITLE
Fix broken link to qrexec-policy-agent documentation

### DIFF
--- a/developer/services/qrexec-internals.md
+++ b/developer/services/qrexec-internals.md
@@ -253,4 +253,4 @@ There are two endpoints:
 - `policy.Ask` - ask the user about whether to execute a given action
 - `policy.Notify` - notify the user about an action.
 
-See [qrexec-policy-agent.rst](https://github.com/QubesOS/qubes-core-qrexec/blob/master/Documentation/qrexec-policy-agent.rst) for protocol details.
+See [qrexec-policy-agent.md](https://github.com/QubesOS/qubes-core-qrexec/blob/master/doc/qrexec-policy-agent.md) for protocol details.


### PR DESCRIPTION
This PR updates a broken link in qrexec-internals.md that previously pointed to a removed .rst file:

Old:
Documentation/qrexec-policy-agent.rst → returns 404

New:
doc/qrexec-policy-agent.md → correct and up-to-date documentation

This ensures developers are directed to the correct Qrexec policy agent protocol reference.