### PR TITLE
Adding missing link to qubes-core-qrexec

### DIFF
--- a/_dev/index.rst
+++ b/_dev/index.rst
@@ -5,5 +5,6 @@ This is documentation for the source code. Please choose specific repostitory:
 
 * `core-admin </projects/core-admin>`_
 * `core-admin-client </projects/core-admin-client>`_
+* `qubes-core-qrexec </projects/qubes-core-qrexec>`_
 
 Or see `the main Qubes OS documentation <https://www.qubes-os.org/doc/>`_.


### PR DESCRIPTION
Once again, a valuable piece of documentation lost in the internet...

See also: QubesOS/qubes-core-qrexec#214