### PR TITLE
Initialize asyncio event loop before using it

### DIFF
--- a/developer/services/qrexec-socket-services.rst
+++ b/developer/services/qrexec-socket-services.rst
@@ -222,9 +222,7 @@ Here is the server code:
           socket_path = '/var/run/qubes/policy-agent.sock'
           service = SocketService(socket_path)
 
-          loop = asyncio.get_event_loop()
-          loop.run_until_complete(service.run())
-
+          asyncio.run(service.run())
 
       if __name__ == '__main__':
           main()


### PR DESCRIPTION
Python 3.14 (in Fedora 43) throws RunetimeError if event loop is not initialized before using it.

Resolves: QubesOS/qubes-issues#10188