### PR TITLE
change sphinx output format to dirhtml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,7 +10,7 @@ submodules:
   recursive: true
 
 sphinx:
-  builder: html
+  builder: dirhtml
   configuration: conf.py
   fail_on_warning: false
 


### PR DESCRIPTION
this produces prettier urls without '.html' at the end