### PR TITLE
Revert 918eaa47 partially to fix links markup

### DIFF
--- a/_dev/index.rst
+++ b/_dev/index.rst
@@ -2,28 +2,13 @@
 Welcome to Qubes OS developer's documentation!
 ==============================================
 
-
 This is documentation for the source code. Please choose specific repostitory:
 
 .. toctree::
    :maxdepth: 1
 
-   core-admin <>
-.. _core-admin: /projects/core-admin
+   core-admin <https://dev.qubes-os.org/projects/core-admin>
+   core-admin-client <https://dev.qubes-os.org/projects/core-admin-client>
+   qubes-core-qrexec <https://dev.qubes-os.org/projects/qubes-core-qrexec>
 
-
-
-   core-admin-client <>
-.. _core-admin-client: /projects/core-admin-client
-
-
-
-   qubes-core-qrexec <>
-.. _qubes-core-qrexec: /projects/qubes-core-qrexec
-
-
-
-Or see the main Qubes OS documentation <https://www.qubes-os.org/doc/>
-.. _the main qubes os documentation: https://www.qubes-os.org/doc/
-
-.
+Or see `the main Qubes OS documentation <https://www.qubes-os.org/doc/>`_.


### PR DESCRIPTION
The index of dev.qubes-os.org ended up with a weird markup during the convertion, this is now correct.

Might be related to QubesOS/qubes-issues#10220