### PR TITLE
Refactor glossary: clarifications, new section and more consistent markup

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -132,6 +132,8 @@ gettext_uuid = True
 
 # Define a block of reusable reStructuredText (reST) snippets, warnings etc. that Sphinx automatically appends to every source file before it is parsed
 rst_epilog = """
+.. |fedora-version| replace:: 42
 .. |debian-codename| replace:: bookworm
 .. |debian-version| replace:: 12
+.. |whonix-version| replace:: 17
 """

--- a/introduction/intro.rst
+++ b/introduction/intro.rst
@@ -14,7 +14,7 @@ Qubes OS is a free and open-source, security-oriented operating system for
 single-user desktop computing. Qubes OS `leverages Xen-based virtualization <https://wiki.xen.org/wiki/Xen_Project_Software_Overview>`__ to allow for the creation and management of isolated compartments called :term:`qubes <qube>`.
 
 
-These qubes, which are implemented as :ref:`virtual machines (VMs)<user/reference/glossary:vm>`, have specific:
+These qubes, which are implemented as :term:`virtual machines (VMs) <vm>`, have specific:
                
 - **Purposes:** with a predefined set of one or many isolated
   applications, for personal or professional projects, to manage the

--- a/introduction/screenshots.rst
+++ b/introduction/screenshots.rst
@@ -37,7 +37,7 @@ Qubes Release 2 can also run Windows AppVMs in seamless mode, integrated onto th
 
 |r2b3-windows-seamless-filecopy.png|
 
-Windows AppVMs are fully integrated with the rest of the Qubes OS system, which includes things such as secure, policy governed, inter-VM file copy, clipboard, and generally our whole elastic qrexec infrastructure for secure inter-VM RPC! Starting with Qubes R2 Beta 3 we also support HVM-based templates allowing to instantly create many Windows AppVMs with shared “root filesystem” from the Template VM (but one should ensure their license allows for such instantiation of the OS in the template). Just like with Linux AppVMs!
+Windows AppVMs are fully integrated with the rest of the Qubes OS system, which includes things such as secure, :term:`policy` governed, inter-VM file copy, clipboard, and generally our whole elastic qrexec infrastructure for secure inter-VM RPC! Starting with Qubes R2 Beta 3 we also support HVM-based templates allowing to instantly create many Windows AppVMs with shared “root filesystem” from the Template VM (but one should ensure their license allows for such instantiation of the OS in the template). Just like with Linux AppVMs!
 
 
 ----

--- a/user/how-to-guides/how-to-edit-a-policy.rst
+++ b/user/how-to-guides/how-to-edit-a-policy.rst
@@ -2,7 +2,7 @@
 How to edit a policy
 ====================
 
-There are three ways to edit a :ref:`policy <user/reference/glossary:policies>`:
+There are three ways to edit a :term:`policy`:
 
 * with :program:`Qubes OS Global Config`, the **recommended way** for the most common policies
 

--- a/user/reference/glossary.rst
+++ b/user/reference/glossary.rst
@@ -7,55 +7,53 @@ Glossary
    admin qube
       A type of :term:`qube` used for administering Qubes OS.
 
-      - Currently, the only admin qube is :term:`dom0`.
+      :Note: Currently, the only admin qube is :term:`dom0`.
 
    app qube
       Any :term:`qube` that does not have a root filesystem of its own. Every app qube is based on a :term:`template` from which it borrows the root filesystem.
 
+      :See: :ref:`inheritance-and-persistence`
+      :Example: *personal*, *untrusted* or *vault* qubes with the default installation
       :Previously known as: ``AppVM``, ``TemplateBasedVM``.
       :Historical note: This term originally meant “a qube intended for running user software applications” (hence the name “app”).
 
    disposable
-      A type of temporary :term:`app qube` that self-destructs when its originating window closes. Each disposable is based on a :term:`disposable template`.
+      A type of temporary :term:`app qube` that self-destructs when closed. Each disposable is based on a :term:`disposable template`.
 
-      :See: :doc:`/user/how-to-guides/how-to-use-disposables`.
-
+      :See: :doc:`/user/how-to-guides/how-to-use-disposables`, :ref:`inheritance-and-persistence`
+      :Example: *dispXXXX* qubes when a new disposable is created
       :Previously known as: ``DisposableVM``, ``DispVM``.
 
    disposable template
       Any :term:`app qube` on which :term:`disposable` are based. A disposable template shares its user directories (and, indirectly, the root filesystem of the regular :term:`template` on which it is based) with all :term:`disposable` based on it.
 
-      - Not to be confused with the concept of a regular :term:`template` that is itself disposable, which does not exist in Qubes OS.
+      Every :term:`disposable` is based on a disposable template, which is in turn based on a regular :term:`template`. Disposable templates must be app qubes. They cannot be regular :term:`template`. A *disposable template* should not be confused with the concept of a regular :term:`template`. Unlike :term:`disposable`, disposable templates have the persistence properties of normal :term:`app qube`.
 
-      - Disposable templates must be app qubes. They cannot be regular :term:`template`.
-
-      - Every :term:`disposable` is based on a disposable template, which is in turn based on a regular :term:`template`.
-
-      - Unlike :term:`disposable`, disposable templates have the persistence properties of normal :term:`app qube`.
-
+      :See: :ref:`user/how-to-guides/how-to-use-disposables:How to create disposable templates`, :ref:`inheritance-and-persistence`
+      :Example: *default-dvm* qube
       :Previously known as: ``DisposableVM Template``, ``DVM Template``, ``DVM``.
 
    dom0
       :term:`domain` zero. A type of :term:`admin qube`. Also known as the **host** domain, dom0 is the initial qube started by the Xen hypervisor on boot. Dom0 runs the Xen management toolstack and has special privileges relative to other domains, such as direct access to most hardware.
 
-      - The term “dom0” is a common noun and should follow the capitalization rules of common nouns.
+      :Note: The term “dom0” is a common noun and should follow the capitalization rules of common nouns.
 
    domain
       In Xen, a synonym for :term:`vm`.
 
       :See: `“domain” on the Xen Wiki <https://wiki.xenproject.org/wiki/Domain>`__.
-
-      - This term has no official meaning in Qubes OS.
+      :Note: This term has no official meaning in Qubes OS.
 
    domU
       Unprivileged :term:`domain`. Also known as **guest** domains, domUs are the counterparts to dom0. In Xen, all VMs except dom0 are domUs. By default, most domUs lack direct hardware access.
 
-      - The term “domU” is a common noun and should follow the capitalization rules of common nouns.
-
-      - Sometimes the term :term:`vm` is used as a synonym for domU. This is technically inaccurate, as :term:`dom0` is also a VM in Xen.
+      :Usage: The term “domU” is a common noun and should follow the capitalization rules of common nouns.
+      :Note: Sometimes the term :term:`vm` is used as a synonym for domU. This is technically inaccurate, as :term:`dom0` is also a VM in Xen.
 
    firmware
       Software that runs outside the control of the operating system. Some firmware executes on the same CPU cores as Qubes OS does, but all computers have many additional processors that the operating system does not run on, and these computers also run firmware.
+
+      :See: :ref:`user/how-to-guides/how-to-update:firmware updates`
 
    HVM
       Hardware-assisted Virtual Machine. Any fully virtualized, or hardware-assisted, :term:`vm` utilizing the virtualization extensions of the host CPU. Although HVMs are typically slower than paravirtualized qubes due to the required emulation, HVMs allow the user to create domains based on any operating system.
@@ -65,38 +63,47 @@ Glossary
    management qube
       A :term:`qube` used for automated management of a Qubes OS installation via :doc:`/user/advanced-topics/salt`.
 
+      :Example: *disp-mgmt-...* qubes
+
    named disposable
-      A type of :term:`disposable` given a permanent name that continues to exist even after it is shut down and can be restarted again. Like a regular :term:`disposable`, a named disposable has no persistent state: Any changes made are lost when it is shut down.
+      A type of :term:`disposable` given a permanent name that continues to exist even after it is shut down and can be restarted again. Like a regular :term:`disposable`, a named disposable has no persistent state: any changes made are lost when it is shut down.
+
+      **Notes:**
 
       - Only one instance of a named disposable can run at a time.
 
       - Like a regular :term:`disposable`, a named disposable always has the same state when it starts, namely that of the :term:`disposable template` on which it is based.
 
+      :See: :ref:`user/how-to-guides/how-to-use-disposables:How to create named disposables`, :ref:`inheritance-and-persistence`
+      :Example: *sys-net*, *sys-usb* or *sys-firewall* could be named disposables (depending on the options selected during installation)
       :Technical note: Named disposables are useful for certain :term:`service qube`, where the combination of persistent device assignment and ephemeral qube state is desirable.
 
    net qube
       Internally known as :term:`qube` that specifies from which qube, if any, it receives network access. Despite the name, “net qube” (or :term:`app qube` to be the :term:`service qube` ``sys-firewall``, which in turn uses ``sys-net`` as its net qube.
 
-      - If a qube does not have a net qube (i.e., its ``netvm`` is set to ``None``), then that qube is offline. It is disconnected from all networking.
+      If a qube does not have a net qube (i.e., its ``netvm`` property is set to ``None``), then **that qube is offline**. It is disconnected from all networking.
 
-      - The name :term:`service qube` called a “NetVM.” The name of the ``netvm`` property is a holdover from that era.
+      :Example: *sys-firewall*
+      :Previously known as: ``NetVM`` (The name of the ``netvm`` property is a holdover from that era)
 
-   policies
+   policy
       In Qubes OS, “policies” govern interactions between qubes, powered by :doc:`Qubes’ qrexec system </developer/services/qrexec>`. A single policy is a rule applied to a qube or set of qubes, that governs how and when information or assets may be shared with other qubes.
-      An example is the rules governing how files can be copied between qubes.
-      Policy rules are grouped together in files under ``/etc/qubes/policy.d``
-      Policies are an important part of what makes Qubes OS special.
+
+      :See: :doc:`/user/how-to-guides/how-to-edit-a-policy`
+      :Example: the rules governing how files can be copied between qubes.
 
    qube
       A secure compartment in Qubes OS. Currently, qubes are implemented as Xen :term:`vm`, but Qubes OS is independent of its underlying compartmentalization technology. VMs could be replaced with a different technology, and qubes would still be called “qubes.”
 
       .. important:: The term “qube” is a common noun and should follow the capitalization rules of common nouns. For example, “I have three qubes” is correct, while “I have three Qubes” is incorrect.
 
+      **About the use of the term:**
+
       - Note that starting a sentence with the plural of “qube” (i.e., “Qubes…”) can be ambiguous, since it may not be clear whether the referent is a plurality of qubes or :term:`Qubes OS`.
 
-      - Example usage: “In Qubes OS, you do your banking in your ‘banking’ qube and your web surfing in your ‘untrusted’ qube. That way, if your ‘untrusted’ qube is compromised, your banking activities will remain secure.”
+      - **Example usage:** “In Qubes OS, you do your banking in your ‘banking’ qube and your web surfing in your ‘untrusted’ qube. That way, if your ‘untrusted’ qube is compromised, your banking activities will remain secure.”
 
-      - Historical note: The term “qube” was originally invented as an alternative to “VM” intended to make it easier for less technical users to understand Qubes OS and learn how to use it.
+      - **Historical note:** The term “qube” was originally invented as an alternative to “VM” intended to make it easier for less technical users to understand Qubes OS and learn how to use it.
 
    Qubes OS
       A security-oriented operating system (OS). The main principle of Qubes OS is security by compartmentalization (or isolation), in which activities are compartmentalized (or isolated) in separate :term:`qube`.
@@ -109,7 +116,9 @@ Glossary
       :See: :doc:`/user/templates/windows/qubes-windows-tools` and :doc:`/user/templates/windows/qubes-windows`.
 
    service qube
-      Any :term:`app qube` the primary purpose of which is to provide services to other qubes. ``sys-net`` and ``sys-firewall`` are examples of service qubes.
+      Any :term:`app qube` or :term:`named disposable`, the primary purpose of which is to provide services to other qubes.
+
+      :Example: *sys-net* and *sys-firewall*
 
    standalone
       Any :term:`qube` that has its own root filesystem and does not share it with another qube. Distinct from both :term:`template` and :term:`app qube`.
@@ -120,16 +129,77 @@ Glossary
    template
       Any :term:`qube` that shares its root filesystem with another qube. A qube that is borrowing a template’s root filesystem is known as an :term:`app qube` and is said to be “based on” the template. Templates are intended for installing and updating software applications, but not for running them.
 
-      :See: :doc:`/user/templates/templates`.
-
       - No template is an :term:`app qube`.
 
       - A template cannot be based on another template.
 
       - Regular templates cannot function as :term:`disposable template`. (Disposable templates must be app qubes.)
 
-      :See: :doc:`/user/templates/templates`.
-      :Previously known as: ``TemplateVM``.
+      :See: :doc:`/user/templates/templates`
+      :Example: fedora-|fedora-version|-xfce, debian-|debian-version|-xfce or whonix-workstation-|whonix-version|
+      :Previously known as: ``TemplateVM``
 
    VM
       An abbreviation for “virtual machine.” A software implementation of a computer that provides the functionality of a physical machine.
+
+      :Note: if possible, the term :term:`qube` is encouraged instead of *VM*
+
+Confusions between qube types
+-----------------------------
+
+.. list-table::
+   :header-rows: 1
+   :stub-columns: 1
+   :width: 100%
+
+   * - Term
+     - Is also
+     - Is not
+     - Could be
+
+   * - a :term:`template`
+     -
+     - a :term:`disposable template`
+     -
+
+   * - a :term:`qube`
+     -
+     - a :term:`disposable`
+     - a :term:`service qube`, a :term:`net qube` or a :term:`disposable template`
+
+   * - a :term:`disposable`
+     -
+     - a :term:`disposable template` or an :term:`app qube`
+     - a :term:`named disposable`
+
+   * - a :term:`disposable template`
+     - an :term:`app qube`
+     - a :term:`template` or a :term:`disposable`
+     -
+
+   * - a :term:`named disposable`
+     - a :term:`disposable`
+     - a :term:`disposable template` or an :term:`app qube`
+     - a :term:`service qube` or a :term:`net qube`
+
+   * - a :term:`service qube`
+     - a :term:`named disposable` or an :term:`app qube`
+     -
+     - a :term:`net qube`
+
+   * - a :term:`net qube`
+     - a :term:`service qube`
+     -
+     -
+
+   * - a :term:`standalone`
+     -
+     - a :term:`template` or an :term:`app qube`
+     - a :term:`service qube`
+
+   * - :term:`dom0`
+     - an :term:`admin qube`
+     - or an :term:`app qube`
+     -
+
+Each term is also called a :term:`qube` and, except for :term:`dom0`, is also a :term:`domU`. None of those terms are also a :term:`template`, except for the first one.

--- a/user/reference/glossary.rst
+++ b/user/reference/glossary.rst
@@ -9,25 +9,18 @@ Glossary
 
       - Currently, the only admin qube is :term:`dom0`.
 
-
-
    app qube
       Any :term:`qube` that does not have a root filesystem of its own. Every app qube is based on a :term:`template` from which it borrows the root filesystem.
 
-      - Previously known as: ``AppVM``, ``TemplateBasedVM``.
-
-      - Historical note: This term originally meant “a qube intended for running user software applications” (hence the name “app”).
-
-
+      :Previously known as: ``AppVM``, ``TemplateBasedVM``.
+      :Historical note: This term originally meant “a qube intended for running user software applications” (hence the name “app”).
 
    disposable
       A type of temporary :term:`app qube` that self-destructs when its originating window closes. Each disposable is based on a :term:`disposable template`.
 
-      See :doc:`/user/how-to-guides/how-to-use-disposables`.
+      :See: :doc:`/user/how-to-guides/how-to-use-disposables`.
 
-      - Previously known as: ``DisposableVM``, ``DispVM``.
-
-
+      :Previously known as: ``DisposableVM``, ``DispVM``.
 
    disposable template
       Any :term:`app qube` on which :term:`disposable` are based. A disposable template shares its user directories (and, indirectly, the root filesystem of the regular :term:`template` on which it is based) with all :term:`disposable` based on it.
@@ -40,25 +33,19 @@ Glossary
 
       - Unlike :term:`disposable`, disposable templates have the persistence properties of normal :term:`app qube`.
 
-      - Previously known as: ``DisposableVM Template``, ``DVM Template``, ``DVM``.
-
-
+      :Previously known as: ``DisposableVM Template``, ``DVM Template``, ``DVM``.
 
    dom0
       :term:`domain` zero. A type of :term:`admin qube`. Also known as the **host** domain, dom0 is the initial qube started by the Xen hypervisor on boot. Dom0 runs the Xen management toolstack and has special privileges relative to other domains, such as direct access to most hardware.
 
       - The term “dom0” is a common noun and should follow the capitalization rules of common nouns.
 
-
-
    domain
       In Xen, a synonym for :term:`vm`.
 
-      See `“domain” on the Xen Wiki <https://wiki.xenproject.org/wiki/Domain>`__.
+      :See: `“domain” on the Xen Wiki <https://wiki.xenproject.org/wiki/Domain>`__.
 
       - This term has no official meaning in Qubes OS.
-
-
 
    domU
       Unprivileged :term:`domain`. Also known as **guest** domains, domUs are the counterparts to dom0. In Xen, all VMs except dom0 are domUs. By default, most domUs lack direct hardware access.
@@ -67,15 +54,13 @@ Glossary
 
       - Sometimes the term :term:`vm` is used as a synonym for domU. This is technically inaccurate, as :term:`dom0` is also a VM in Xen.
 
-
-
    firmware
       Software that runs outside the control of the operating system. Some firmware executes on the same CPU cores as Qubes OS does, but all computers have many additional processors that the operating system does not run on, and these computers also run firmware.
 
    HVM
       Hardware-assisted Virtual Machine. Any fully virtualized, or hardware-assisted, :term:`vm` utilizing the virtualization extensions of the host CPU. Although HVMs are typically slower than paravirtualized qubes due to the required emulation, HVMs allow the user to create domains based on any operating system.
 
-      See :doc:`/user/advanced-topics/standalones-and-hvms`.
+      :See: :doc:`/user/advanced-topics/standalones-and-hvms`.
 
    management qube
       A :term:`qube` used for automated management of a Qubes OS installation via :doc:`/user/advanced-topics/salt`.
@@ -87,9 +72,7 @@ Glossary
 
       - Like a regular :term:`disposable`, a named disposable always has the same state when it starts, namely that of the :term:`disposable template` on which it is based.
 
-      - Technical note: Named disposables are useful for certain :term:`service qube`, where the combination of persistent device assignment and ephemeral qube state is desirable.
-
-
+      :Technical note: Named disposables are useful for certain :term:`service qube`, where the combination of persistent device assignment and ephemeral qube state is desirable.
 
    net qube
       Internally known as :term:`qube` that specifies from which qube, if any, it receives network access. Despite the name, “net qube” (or :term:`app qube` to be the :term:`service qube` ``sys-firewall``, which in turn uses ``sys-net`` as its net qube.
@@ -98,19 +81,16 @@ Glossary
 
       - The name :term:`service qube` called a “NetVM.” The name of the ``netvm`` property is a holdover from that era.
 
-
-
    policies
       In Qubes OS, “policies” govern interactions between qubes, powered by :doc:`Qubes’ qrexec system </developer/services/qrexec>`. A single policy is a rule applied to a qube or set of qubes, that governs how and when information or assets may be shared with other qubes.
       An example is the rules governing how files can be copied between qubes.
       Policy rules are grouped together in files under ``/etc/qubes/policy.d``
       Policies are an important part of what makes Qubes OS special.
 
-
    qube
       A secure compartment in Qubes OS. Currently, qubes are implemented as Xen :term:`vm`, but Qubes OS is independent of its underlying compartmentalization technology. VMs could be replaced with a different technology, and qubes would still be called “qubes.”
 
-      - **Important:** The term “qube” is a common noun and should follow the capitalization rules of common nouns. For example, “I have three qubes” is correct, while “I have three Qubes” is incorrect.
+      .. important:: The term “qube” is a common noun and should follow the capitalization rules of common nouns. For example, “I have three qubes” is correct, while “I have three Qubes” is incorrect.
 
       - Note that starting a sentence with the plural of “qube” (i.e., “Qubes…”) can be ambiguous, since it may not be clear whether the referent is a plurality of qubes or :term:`Qubes OS`.
 
@@ -118,19 +98,15 @@ Glossary
 
       - Historical note: The term “qube” was originally invented as an alternative to “VM” intended to make it easier for less technical users to understand Qubes OS and learn how to use it.
 
-
-
    Qubes OS
       A security-oriented operating system (OS). The main principle of Qubes OS is security by compartmentalization (or isolation), in which activities are compartmentalized (or isolated) in separate :term:`qube`.
 
-      - **Important:** The official name is “Qubes OS” (note the capitalization and the space between “Qubes” and “OS”). In casual conversation, this is often shortened to “Qubes.” Only in technical contexts where spaces are not permitted (e.g., in usernames) may the space be omitted, as in ``@QubesOS``.
-
-
+      .. important:: The official name is “Qubes OS” (note the capitalization and the space between “Qubes” and “OS”). In casual conversation, this is often shortened to “Qubes.” Only in technical contexts where spaces are not permitted (e.g., in usernames) may the space be omitted, as in ``@QubesOS``.
 
    Qubes Windows Tools (QWT)
       A set of programs and drivers that provide integration of Windows qubes with the rest of the Qubes OS system.
 
-      See :doc:`/user/templates/windows/qubes-windows-tools` and :doc:`/user/templates/windows/qubes-windows`.
+      :See: :doc:`/user/templates/windows/qubes-windows-tools` and :doc:`/user/templates/windows/qubes-windows`.
 
    service qube
       Any :term:`app qube` the primary purpose of which is to provide services to other qubes. ``sys-net`` and ``sys-firewall`` are examples of service qubes.
@@ -138,16 +114,13 @@ Glossary
    standalone
       Any :term:`qube` that has its own root filesystem and does not share it with another qube. Distinct from both :term:`template` and :term:`app qube`.
 
-      See :doc:`/user/advanced-topics/standalones-and-hvms`.
-
-      - Previously known as: ``StandaloneVM``.
-
-
+      :See: :doc:`/user/advanced-topics/standalones-and-hvms`.
+      :Previously known as: ``StandaloneVM``.
 
    template
       Any :term:`qube` that shares its root filesystem with another qube. A qube that is borrowing a template’s root filesystem is known as an :term:`app qube` and is said to be “based on” the template. Templates are intended for installing and updating software applications, but not for running them.
 
-      See :doc:`/user/templates/templates`.
+      :See: :doc:`/user/templates/templates`.
 
       - No template is an :term:`app qube`.
 
@@ -155,9 +128,8 @@ Glossary
 
       - Regular templates cannot function as :term:`disposable template`. (Disposable templates must be app qubes.)
 
-      - Previously known as: ``TemplateVM``.
-
-
+      :See: :doc:`/user/templates/templates`.
+      :Previously known as: ``TemplateVM``.
 
    VM
       An abbreviation for “virtual machine.” A software implementation of a computer that provides the functionality of a physical machine.

--- a/user/templates/templates.rst
+++ b/user/templates/templates.rst
@@ -3,7 +3,7 @@ Templates
 =========
 
 
-In :doc:`Getting Started </introduction/getting-started>`, we covered the distinction in Qubes OS between where you *install* your software and where you *run* your software. Software that you use in most everyday tasks, is installed within :term:`templates <template>`. When using Qubes OS, you normally work in :term:`app qubes <app qube>`. App qubes are based on a *template* qube (or more simply, just *a template*). They inherit most of the `“root filesystem” <https://opensource.com/life/16/10/introduction-linux-filesystems>`__, from the template. Changes you make to the root filesystem are not written back to the template: if you install an application in an app qube it will disappear when you shut down the qube. (You may be able to work round this by using Flatpak or snap packages, which install to the user’s home directory.) The user home directory *is* specific to the app qube, and changes there are kept. There is a full explanation of this `below <#inheritance-and-persistence>`__.
+In :doc:`Getting Started </introduction/getting-started>`, we covered the distinction in Qubes OS between where you *install* your software and where you *run* your software. Software that you use in most everyday tasks, is installed within :term:`templates <template>`. When using Qubes OS, you normally work in :term:`app qubes <app qube>`. :term:`App qubes <app qube>` are based on a *template* qube (or more simply, just *a template*). They inherit most of the `“root filesystem” <https://opensource.com/life/16/10/introduction-linux-filesystems>`__, from the template. Changes you make to the root filesystem are not written back to the template: if you install an application here in an app qube it will disappear when you shut down the qube. The user home directory *is* specific to the app qube, and changes there are kept. This is called :ref:`inheritance-and-persistence`.
 
 If you use a :term:`Standalone <standalone>`, the **whole filesystem** is specific to the standalone, and every change you make will be kept after shutdown.
 
@@ -17,7 +17,7 @@ The template system has significant benefits:
 
 - **Updates:** Updates are naturally centralized, since updating a template means that all qubes based on it will automatically use those updates after they’re restarted.
 
-An important side effect of this system is that any software installed in an app qube (rather than in the template on which it is based) will disappear when the app qube shuts down (see `Inheritance and Persistence <#inheritance-and-persistence>`__). For this reason, we recommend installing most of your software in templates, not app qubes.
+An important side effect of this system is that any software installed in the root filesystem of an app qube (rather than in the template on which it is based) will disappear when the app qube shuts down (see `Inheritance and Persistence <#inheritance-and-persistence>`__). For this reason, we recommend installing most of your software in templates, not app qubes. You may be able to work around this by using Flatpak or snap packages, which install to the user’s home directory.
 
 The default template in Qubes is based on Fedora, but there are additional templates based on other Linux distributions. There are also templates available with or without certain software preinstalled. You may find it useful to have multiple templates installed in order to provide:
 
@@ -191,6 +191,8 @@ Advanced
 --------
 
 The following sections cover advanced topics pertaining to templates.
+
+.. _inheritance-and-persistence:
 
 Inheritance and persistence
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This PR is trying to clarify the glossary by using the field markup for recurring fields like "Previously known as". Some examples are provided.

Some inaccuracies are corrected and some sentences are reorganized to try to make more sense.

A new section "Confusions between qube types" is trying to provide another way to understand the terminology.