### PR TITLE
Add redirections for the old windows pages

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -47,6 +47,18 @@ redirects = {
         "https://www.qubes-os.org/doc/visual-style-guide/",
     "user/downloading-installing-upgrading/downloads":
         "https://www.qubes-os.org/downloads/",
+
+    # user/templates/windows URLs
+    "user/templates/windows/windows-qubes-4-1":
+        "qubes-windows.html",
+    "user/templates/windows/windows-qubes-4-0":
+        "qubes-windows.html",
+    "user/templates/windows/qubes-windows-tools-4-1":
+        "qubes-windows-tools.html",
+    "user/templates/windows/qubes-windows-tools-4-0":
+        "qubes-windows-tools.html",
+    "user/templates/windows/migrate-to-4-1":
+        "qubes-windows-migrate.html",
 }
 
 


### PR DESCRIPTION
* windows-qubes-4-X redirect to qubes-windows
* qubes-windows-tools-4-X redirect to qubes-windows-tools
* migrate-to-4-1 redirect to qubes-windows-migrate

Should fix QubesOS/qubes-issues#10234