### PR TITLE
Remove outdated commands to run grub2-mkconfig

### DIFF
--- a/user/advanced-topics/usb-qubes.rst
+++ b/user/advanced-topics/usb-qubes.rst
@@ -92,7 +92,7 @@ When using a USB keyboard on a system with multiple USB controllers, we recommen
 
 5. Save and close the file.
 
-6. Run the command ``grub2-mkconfig -o /boot/grub2/grub.cfg`` (legacy boot) or ``grub2-mkconfig -o /boot/efi/EFI/qubes/grub.cfg`` (EFI) in dom0.
+6. Run the command ``grub2-mkconfig -o /boot/grub2/grub.cfg``
 
 7. Reboot.
 
@@ -202,7 +202,7 @@ GRUB2 (legacy boot or EFI)
 
 4. Save and close the file.
 
-5. Run the command ``grub2-mkconfig -o /boot/grub2/grub.cfg`` (legacy boot) or ``grub2-mkconfig -o /boot/efi/EFI/qubes/grub.cfg`` (EFI) in dom0.
+5. Run the command ``grub2-mkconfig -o /boot/grub2/grub.cfg``
 
 6. Reboot.
 
@@ -233,25 +233,3 @@ GRUB2
 7. Run the command ``grub2-mkconfig -o /boot/grub2/grub.cfg`` in dom0.
 
 8. Reboot.
-
-
-
-Qubes 4.0: EFI
-^^^^^^^^^^^^^^
-
-
-1. Shut down the USB qube.
-
-2. In Qubes Manager, right-click on the USB qube and select “Remove VM.”
-
-3. Open the file ``/boot/efi/EFI/qubes/xen.cfg`` in dom0.
-
-4. Find the line(s) that begins with ``kernel=``.
-
-5. If ``rd.qubes.hide_all_usb`` appears anywhere in those lines, remove it.
-
-6. Save and close the file.
-
-7. Reboot.
-
-

--- a/user/troubleshooting/installation-troubleshooting.rst
+++ b/user/troubleshooting/installation-troubleshooting.rst
@@ -125,7 +125,7 @@ Here are the steps to fix this. Note that this allows sys-net and sys-usb to tak
 
 2. Add ``qubes.enable_insecure_pv_passthrough`` to ``GRUB_CMDLINE_LINUX`` in ``/etc/default/grub``
 
-3. Run ``sudo grub2-mkconfig -o /boot/efi/EFI/qubes/grub.cfg``. If you are using a non-UEFI BIOS (where ``/boot/efi/EFI`` doesn’t exist), use the command ``sudo grub-mkconfig -o /boot/grub2/grub.cfg`` instead.
+3. Run ``sudo grub-mkconfig -o /boot/grub2/grub.cfg``
 
 4. Reboot
 

--- a/user/troubleshooting/resume-suspend-troubleshooting.rst
+++ b/user/troubleshooting/resume-suspend-troubleshooting.rst
@@ -160,4 +160,4 @@ Suspend turns off the screen and gets stuck
 -------------------------------------------
 
 
-On some devices suspend-to-RAM does not work and a hard power-off is needed to recover, because the system does not go into deep sleep. To get suspend to work, you need to add ``mem_sleep_default=deep`` kernel option. For legacy boot, or UEFI/legacy in R4.1+, add it to the ``GRUB_CMDLINE_LINUX`` setting in ``/etc/default/grub``, update the grub config, and reboot. In R4.0 with UEFI boot, you need to add it to every ``kernel=`` line in ``/boot/efi/EFI/qubes/xen.cfg`` and reboot.
+On some devices suspend-to-RAM does not work and a hard power-off is needed to recover, because the system does not go into deep sleep. To get suspend to work, you need to add ``mem_sleep_default=deep`` kernel option. Add it to the ``GRUB_CMDLINE_LINUX`` setting in ``/etc/default/grub``, update the grub config, and reboot.


### PR DESCRIPTION
Following a [forum
topic](https://forum.qubes-os.org/t/how-to-change-boot-options-for-usb-boot/36387/2), it seems that the documentation still referenced some outdated way of running `grub2-mkconfig` command.