### PR TITLE
Fix: avoid indefinite Sphinx build freeze from unbounded git log call

### DIFF
--- a/_ext/last_edition.py
+++ b/_ext/last_edition.py
@@ -8,7 +8,7 @@ import subprocess
 MIGRATION_DATETIME = datetime.datetime.fromisoformat("2025-08-06 02:20:01+02:00")
 
 _DEFAULT_TIMEOUT = 1
-_GIT_TIMEOUT = int(os.environ.get("QUBES_LAST_EDITION_TIMEOUT", _DEFAULT_TIMEOUT))
+_GIT_TIMEOUT = int(os.environ.get("QUBES_DOC_LAST_EDITION_TIMEOUT", _DEFAULT_TIMEOUT))
 
 
 def html_page_context(app, pagename, templatename, context, doctree):

--- a/_ext/last_edition.py
+++ b/_ext/last_edition.py
@@ -35,9 +35,10 @@ def html_page_context(app, pagename, templatename, context, doctree):
                 "--pretty=format:%ci",
                 "--",
                 f"{pagename}{context['page_source_suffix']}",
-            )
+            ),
+            timeout=5,
         ).decode()
-    except subprocess.CalledProcessError:
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
         return
 
     try:

--- a/_ext/last_edition.py
+++ b/_ext/last_edition.py
@@ -2,9 +2,13 @@
 """Add last_edition_datetime to the html context"""
 
 import datetime
+import os
 import subprocess
 
 MIGRATION_DATETIME = datetime.datetime.fromisoformat("2025-08-06 02:20:01+02:00")
+
+_DEFAULT_TIMEOUT = 1
+_GIT_TIMEOUT = int(os.environ.get("QUBES_LAST_EDITION_TIMEOUT", _DEFAULT_TIMEOUT))
 
 
 def html_page_context(app, pagename, templatename, context, doctree):
@@ -36,9 +40,15 @@ def html_page_context(app, pagename, templatename, context, doctree):
                 "--",
                 f"{pagename}{context['page_source_suffix']}",
             ),
-            timeout=5,
+            timeout=_GIT_TIMEOUT,
         ).decode()
-    except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
+    except (
+        subprocess.CalledProcessError,
+        subprocess.TimeoutExpired,
+        FileNotFoundError,
+        PermissionError,
+        OSError,
+    ):
         return
 
     try:

--- a/conf.py
+++ b/conf.py
@@ -38,8 +38,10 @@ extensions = [
   'youtube_frame', # Embed YouTube videos
 ]
 
-if os.environ.get('READTHEDOCS') or os.environ.get('QUBES_DOC_FULL_BUILD'):
-    extensions.append('last_edition')
+if os.environ.get("READTHEDOCS") or os.environ.get(
+    "QUBES_DOC_FULL_BUILD", ""
+).lower() in ("true", "on", "1"):
+    extensions.append("last_edition")
 
 # Redirects for specific URLs as fall back
 redirects = {

--- a/conf.py
+++ b/conf.py
@@ -36,8 +36,10 @@ extensions = [
   'sphinx_reredirects', # Manage redirects in the documentation
   'sphinxext.opengraph', # Add Open Graph meta tags for social media sharing
   'youtube_frame', # Embed YouTube videos
-  'last_edition',
 ]
+
+if os.environ.get('READTHEDOCS') or os.environ.get('QUBES_DOC_FULL_BUILD'):
+    extensions.append('last_edition')
 
 # Redirects for specific URLs as fall back
 redirects = {

--- a/developer/general/how-to-edit-the-rst-documentation.rst
+++ b/developer/general/how-to-edit-the-rst-documentation.rst
@@ -290,6 +290,44 @@ as defined in :file:`conf.py`, as well a simple custom one to embed YouTube vide
 which can be found `here <https://github.com/QubesOS/qubes-doc/tree/main/_ext>`__.
 
 
+.. _last_edition_configuration:
+
+``last_edition`` timeout configuration
+---------------------------------------
+
+The ``last_edition`` extension runs ``git log`` once per page during a full
+build to determine when each page was last edited. To avoid accumulating
+delays across many pages, the subprocess call uses a short timeout and the
+extension is only loaded when explicitly requested via an environment variable.
+
+``QUBES_DOC_FULL_BUILD``
+   When set to any non-empty value, the ``last_edition`` extension is loaded.
+   On `Read The Docs <https://readthedocs.com/>`__ the ``READTHEDOCS``
+   environment variable fulfils the same role and is set automatically.
+   In a plain local build neither variable is set by default, so the extension
+   is skipped and per-page ``git`` invocations are not performed.
+
+``QUBES_LAST_EDITION_TIMEOUT``
+   Maximum time in seconds allowed for each ``git log`` subprocess call.
+   Defaults to ``1``. Increase this value only if the extension is timing out
+   on a slow build machine.
+
+Example — enabling the extension for a local build:
+
+.. code-block:: console
+
+   $ export QUBES_DOC_FULL_BUILD=1
+   $ sphinx-build -b html . _build/html
+
+To also override the per-page timeout:
+
+.. code-block:: console
+
+   $ export QUBES_DOC_FULL_BUILD=1
+   $ export QUBES_LAST_EDITION_TIMEOUT=2
+   $ sphinx-build -b html . _build/html
+
+
 .. _build_locally:
 
 Building the rST documentation locally

--- a/developer/general/how-to-edit-the-rst-documentation.rst
+++ b/developer/general/how-to-edit-the-rst-documentation.rst
@@ -289,44 +289,31 @@ We use several Sphinx `extensions <https://www.sphinx-doc.org/en/master/usage/ex
 as defined in :file:`conf.py`, as well a simple custom one to embed YouTube videos,
 which can be found `here <https://github.com/QubesOS/qubes-doc/tree/main/_ext>`__.
 
+.. _last-edition-extension:
 
-.. _last_edition_configuration:
+``last_edition`` extension
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-``last_edition`` timeout configuration
----------------------------------------
+The ``last_edition`` adds the "Last edition of the current page" in the footer. The extension runs ``git log`` once per page during a full build to determine when each page was last edited. To avoid accumulating delays across many pages, the build process uses a short timeout and the extension is only loaded when explicitly requested via an environment variable.
 
-The ``last_edition`` extension runs ``git log`` once per page during a full
-build to determine when each page was last edited. To avoid accumulating
-delays across many pages, the subprocess call uses a short timeout and the
-extension is only loaded when explicitly requested via an environment variable.
+.. envvar:: QUBES_DOC_FULL_BUILD
 
-``QUBES_DOC_FULL_BUILD``
-   When set to any non-empty value, the ``last_edition`` extension is loaded.
-   On `Read The Docs <https://readthedocs.com/>`__ the ``READTHEDOCS``
-   environment variable fulfils the same role and is set automatically.
-   In a plain local build neither variable is set by default, so the extension
-   is skipped and per-page ``git`` invocations are not performed.
+   :Default value: empty
+   :Allowed values: ``True``, ``on``, ``1``
+   :Case sensitive: no
 
-``QUBES_LAST_EDITION_TIMEOUT``
-   Maximum time in seconds allowed for each ``git log`` subprocess call.
-   Defaults to ``1``. Increase this value only if the extension is timing out
-   on a slow build machine.
+   Build the documentation with full features: if any of the allowed values is set, "last edition" will be displayed in the footer. On `Read the Docs <https://readthedocs.com/>`__ the ``READTHEDOCS`` environment variable fulfills the same role and is set automatically. In a plain local build, neither variable is set by default, so the extension is skipped and per-page ``git`` invocations are not performed.
 
-Example — enabling the extension for a local build:
+.. envvar:: QUBES_DOC_LAST_EDITION_TIMEOUT
 
-.. code-block:: console
+   :Default value: ``1``
+   :Allowed values: any integer
 
-   $ export QUBES_DOC_FULL_BUILD=1
-   $ sphinx-build -b html . _build/html
+   Maximum time in seconds allowed for each program:`git` call. Increase this value only if the extension is timing out on a slow build machine.
 
-To also override the per-page timeout:
+.. admonition:: See also
 
-.. code-block:: console
-
-   $ export QUBES_DOC_FULL_BUILD=1
-   $ export QUBES_LAST_EDITION_TIMEOUT=2
-   $ sphinx-build -b html . _build/html
-
+   :ref:`build-environment-variables`
 
 .. _build_locally:
 
@@ -471,9 +458,9 @@ Creating a Python environment with poetry
 
    .. hint::
 
-      If you would like to avoid prefixing commands with :program:`poetry run`, you can source the virtual environment with ``eval $(poetry env activate)`` on every new shell session. Note that when enabling ``virtualenvs.in-project``, you will find the virtual environment in the project root directory undre ``.venv``, same place the ``venv`` instructions uses.
+      If you would like to avoid prefixing commands with :program:`poetry run`, you can source the virtual environment with ``eval $(poetry env activate)`` on every new shell session. Note that when enabling ``virtualenvs.in-project``, you will find the virtual environment in the project root directory under ``.venv``, same place the ``venv`` instructions uses.
 
-Linting the documentation with peotry
+Linting the documentation with poetry
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
@@ -529,6 +516,38 @@ Building the documentation with poetry
 
       $ poetry run sphinx-autobuild . _build/html
 
+.. _build-environment-variables:
+
+Build environment variables
+---------------------------
+
+Part of the build process is not triggered by the default build, to speed up the local builds. You might want to define some environment variables in order to get something closer to the official documentation website.
+
+Display the "last edition" in the footer
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you want to build the documentation and print the :ref:`last edition datetime <last-edition-extension>` in the footer, set :envvar:`QUBES_DOC_FULL_BUILD` to `True`. A :program:`git` command will be issued for each page. A timeout is set, in case :program:`git` takes too much time. The following is an example of enabling the extension for a local build:
+
+.. code-block:: console
+
+   $ export QUBES_DOC_FULL_BUILD=True
+   $ sphinx-build -b html . _build/html
+
+To also change the value of the timeout, use :envvar:`QUBES_DOC_LAST_EDITION_TIMEOUT`.
+
+.. code-block:: console
+
+   $ export QUBES_DOC_FULL_BUILD=True
+   $ export QUBES_DOC_LAST_EDITION_TIMEOUT=2
+   $ sphinx-build -b html . _build/html
+
+Display the ".onion available" button in Tor Browser
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+By default, the documentation only tells Tor Browser that an .onion alternative is available when building the ``latest`` branch and ``en`` language on ReadTheDocs. You can force this behavior by setting:
+
+* `READTHEDOCS_VERSION <https://docs.readthedocs.com/platform/stable/reference/environment-variables.html#envvar-READTHEDOCS_VERSION>`__ to ``latest``
+* and `READTHEDOCS_LANGUAGE <https://docs.readthedocs.com/platform/stable/reference/environment-variables.html#envvar-READTHEDOCS_LANGUAGE>`__ to ``en``
 
 Editor
 ------


### PR DESCRIPTION
**Summary**

This PR fixes a blocking issue in `_ext/last_edition.py` where a `git log` subprocess is executed without a timeout inside the `html_page_context` hook.

Since `html_page_context` runs once per page during Sphinx builds, the following code path is executed repeatedly:

```python
last_datetime_raw = subprocess.check_output(
    (
        "git",
        "--git-dir",
        git_dir,
        "log",
        "-1",
        "--pretty=format:%ci",
        "--",
        f"{pagename}{context['page_source_suffix']}",
    )
).decode()
```

Without a timeout, any delay/hang in `git` (repo lock, concurrent git operations, slow filesystem, etc.) can block the **entire** Sphinx build indefinitely. This is especially noticeable with `sphinx-autobuild`, where one stuck build prevents subsequent rebuilds.

**Fix**

The subprocess call is now bounded with a timeout and handles timeout failures gracefully:

```python
last_datetime_raw = subprocess.check_output(
    (...),
    timeout=5,
).decode()
except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
    return
```

**Key improvements**

* Prevents indefinite blocking of Sphinx builds
* Ensures builds continue even if `git` is slow/unavailable
* Gracefully skips `last_edition` metadata for affected pages
* Minimal, localized change; normal fast-path remains unchanged

**Verification**

* Ran `sphinx-autobuild` locally and confirmed rebuilds continue under simulated `git` delays (e.g., temporary repo lock / slow response)
* Confirmed normal behavior is unchanged when `git log` executes quickly
