### PR TITLE
Fix wrong URLs: 404, https and typos + 308

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -116,7 +116,7 @@ html_favicon = "attachment/icons/favicon-16x16.png"
 # -- -- Options for the linkcheck builder ------------------------------------
 
 linkcheck_anchors = False
-linkcheck_ignore = [r'^https?://[^/\s]+\.onion']
+linkcheck_ignore = [r"^https?://[^/\s]+\.onion", r"https://localhost:\d+/"]
 
 # -- Extensions configuration ------------------------------------------------
 # Prefix section labels with the document name

--- a/developer/building/development-workflow.rst
+++ b/developer/building/development-workflow.rst
@@ -323,7 +323,7 @@ RPM packages - yum repo
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 
-In source VM, grab `linux-yum <https://GitHub.com/QubesOS/qubes-linux-yum>`__ repository (below is assumed you’ve made it in ``~/repo-yum-upload`` directory) and replace ``update_repo.sh`` script with:
+In source VM, grab `linux-yum <https://github.com/QubesOS/qubes-linux-yum>`__ repository (below is assumed you’ve made it in ``~/repo-yum-upload`` directory) and replace ``update_repo.sh`` script with:
 
 .. code:: bash
 
@@ -340,7 +340,7 @@ In source VM, grab `linux-yum <https://GitHub.com/QubesOS/qubes-linux-yum>`__ re
 
 
 
-In target VM, setup actual yum repository (also based on `linux-yum <https://GitHub.com/QubesOS/qubes-linux-yum>`__, this time without modifications). You will also need to setup some gpg key for signing packages (it is possible to force yum to install unsigned packages, but it isn’t possible for ``qubes-dom0-update`` tool). Fill ``~/.rpmmacros`` with key description:
+In target VM, setup actual yum repository (also based on `linux-yum <https://github.com/QubesOS/qubes-linux-yum>`__, this time without modifications). You will also need to setup some gpg key for signing packages (it is possible to force yum to install unsigned packages, but it isn’t possible for ``qubes-dom0-update`` tool). Fill ``~/.rpmmacros`` with key description:
 
 .. code:: text
 
@@ -420,7 +420,7 @@ Deb packages - Apt repo
 
 Steps are mostly the same as in the case of yum repo. The only details that differ:
 
-- use `linux-deb <https://GitHub.com/QubesOS/qubes-linux-deb>`__ instead of `linux-yum <https://GitHub.com/QubesOS/qubes-linux-yum>`__ as a base - both in source and target VM
+- use `linux-deb <https://github.com/QubesOS/qubes-linux-deb>`__ instead of `linux-yum <https://github.com/QubesOS/qubes-linux-yum>`__ as a base - both in source and target VM
 
 - use different ``update_repo.sh`` script in source VM (below)
 

--- a/developer/general/devel-books.rst
+++ b/developer/general/devel-books.rst
@@ -33,9 +33,9 @@ Below is a list of various books that might be useful in learning some basics ne
 
 - Useful books about Python:
 
-  - `Programming in Python 3 <https://www.qtrac.eu/py3book.html>`__, by Mark Summerfield
+  - `Programming in Python 3 <https://mark-summerfield.github.io/py3book.html>`__, by Mark Summerfield
 
-  - `Rapid GUI Programming with Python and Qt <https://www.qtrac.eu/pyqtbook.html>`__, by Mark Summerfield (Although note that :ref:`Qt is being replaced by GTK <developer/general/usability-ux:gnome, kde, and xfce>` in Qubes code.)
+  - `Rapid GUI Programming with Python and Qt <https://mark-summerfield.github.io/pyqtbook.html>`__, by Mark Summerfield (Although note that :ref:`Qt is being replaced by GTK <developer/general/usability-ux:gnome, kde, and xfce>` in Qubes code.)
 
 
 

--- a/developer/general/how-to-edit-the-rst-documentation.rst
+++ b/developer/general/how-to-edit-the-rst-documentation.rst
@@ -6,7 +6,7 @@ The Qubes OS documentation is stored as `reStructuredText (rST) <https://docutil
 the `qubes-doc <https://github.com/QubesOS/qubes-doc>`__ repository.
 
 We use `Sphinx <https://www.sphinx-doc.org/>`__ for building and
-`Read The Docs (RTD) <https://readthedocs.com/>`__ for hosting.
+`Read The Docs (RTD) <https://about.readthedocs.com/>`__ for hosting.
 RTD is a `continuous‑documentation deployment platform <https://docs.readthedocs.com/platform/stable/continuous-deployment.html>`__ that can automatically
 detect changes in a GitHub repository and build the latest version of a documentation.
 

--- a/developer/general/research.rst
+++ b/developer/general/research.rst
@@ -31,7 +31,7 @@ Attacks on Intel TXT
 
 - `Attacking Intel TXT® via SINIT code execution hijacking <https://invisiblethingslab.com/resources/2011/Attacking_Intel_TXT_via_SINIT_hijacking.pdf>`__ by Rafal Wojtczuk and Joanna Rutkowska, November 2011
 - `Another Way to Circumvent Intel® Trusted Execution Technology <https://invisiblethingslab.com/resources/misc09/Another%20TXT%20Attack.pdf>`__ by Rafal Wojtczuk, Joanna Rutkowska, Alex Tereshkin, December 2009
-- `ACPI: Design Principles and Concerns <https://cyber.gouv.fr/sites/default/files/IMG/pdf/article_acpi.pdf>`__ by Loic Duflot, Olivier Levillain, and Benjamin Morin, 2009
+- `ACPI: Design Principles and Concerns <https://web.archive.org/web/20251019184330/https://cyber.gouv.fr/sites/default/files/IMG/pdf/article_acpi.pdf>`__ by Loic Duflot, Olivier Levillain, and Benjamin Morin, 2009
 - `Attacking Intel® Trusted Execution Technology <https://invisiblethingslab.com/resources/bh09dc/Attacking%20Intel%20TXT%20-%20paper.pdf>`__ by Rafal Wojtczuk and Joanna Rutkowska
 
 Software Attacks Coming Through Devices
@@ -40,7 +40,7 @@ Software Attacks Coming Through Devices
 - `Following the White Rabbit: Software Attacks against Intel® VT-d <https://invisiblethingslab.com/resources/2011/Software%20Attacks%20on%20Intel%20VT-d.pdf>`__ by Rafal Wojtczuk and Joanna Rutkowska, April 2011
 - `On Formally Verified Microkernels (and on attacking them) <https://blog.invisiblethings.org/2010/05/03/on-formally-verified-microkernels-and.html>`__ by Joanna Rutkowska, May 2010
 - `Remotely Attacking Network Cards (or why we do need VT-d and TXT) <https://blog.invisiblethings.org/2010/04/30/remotely-attacking-network-cards-or-why.html>`__ by Joanna Rutkowska, April 2010
-- `Can you still trust your network card? <https://cyber.gouv.fr/sites/default/files/IMG/pdf/csw-trustnetworkcard.pdf>`__ by Loïc Duflot, Yves-Alexis Perez and others
+- `Can you still trust your network card? <https://web.archive.org/web/20251019184331/https://cyber.gouv.fr/sites/default/files/IMG/pdf/csw-trustnetworkcard.pdf>`__ by Loïc Duflot, Yves-Alexis Perez and others
 
 Application-level Security
 ==========================

--- a/developer/releases/2_0/release-notes.rst
+++ b/developer/releases/2_0/release-notes.rst
@@ -51,7 +51,7 @@ Known issues
 
 - System shutdown sometimes is very slow (#903). To mitigate the problem, shutdown all the VMs first.
 
-- For other known issues take a look at `our trac tickets <https://wiki.qubes-os.org/query?status=accepted&status=assigned&status=new&status=reopened&type=defect&milestone=Release+2.1+(post+R2)&col=id&col=summary&col=status&col=type&col=priority&col=milestone&col=component&order=priority>`__
+- For other known issues take a look at our trac tickets [dead query link towards the now defunct site `wiki.qubes-os.org <https://web.archive.org/web/20150311104801/https://wiki.qubes-os.org>`__]
 
 
 

--- a/introduction/code-of-conduct.rst
+++ b/introduction/code-of-conduct.rst
@@ -83,4 +83,4 @@ Attribution
 -----------
 
 
-The initial published version of this Code of Conduct was adapted from the `Contributor Covenant, version 1.4 <https://contributor-covenant.org/version/1/4>`__ and the `Rust Code of Conduct <https://www.rust-lang.org/en-US/conduct.html>`__.
+The initial published version of this Code of Conduct was adapted from the `Contributor Covenant, version 1.4 <https://contributor-covenant.org/version/1/4>`__ and the `Rust Code of Conduct <https://rust-lang.org/policies/code-of-conduct/>`__.

--- a/introduction/contributing.rst
+++ b/introduction/contributing.rst
@@ -35,7 +35,7 @@ Thank you for your interest in contributing to Qubes! Here are some of the many 
 
 - Engage with us on social media:
 
-  - Follow us on `Twitter <https://twitter.com/QubesOS>`__
+  - Follow us on `Twitter <https://x.com/QubesOS>`__
 
   - Join us on `Reddit <https://www.reddit.com/r/Qubes/>`__
 

--- a/introduction/faq.rst
+++ b/introduction/faq.rst
@@ -75,7 +75,7 @@ How does Qubes OS compare to using a "live CD" OS?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
-Booting your computer from a live CD (or DVD) when you need to perform sensitive activities can certainly be more secure than simply using your main OS, but this method still preserves many of the risks of conventional OSes. For example, popular live OSes (such as `Tails <https://tails.boum.org/>`__ and other Linux distributions) are still **monolithic** in the sense that all software is still running in the same OS. This means, once again, that if your session is compromised, then all the data and activities performed within that same session are also potentially compromised.
+Booting your computer from a live CD (or DVD) when you need to perform sensitive activities can certainly be more secure than simply using your main OS, but this method still preserves many of the risks of conventional OSes. For example, popular live OSes (such as `Tails <https://tails.net/>`__ and other Linux distributions) are still **monolithic** in the sense that all software is still running in the same OS. This means, once again, that if your session is compromised, then all the data and activities performed within that same session are also potentially compromised.
 
 How does Qubes OS compare to running VMs in a conventional OS?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -83,7 +83,7 @@ How does Qubes OS compare to running VMs in a conventional OS?
 
 Not all virtual machine software is equal when it comes to security. You may have used or heard of VMs in relation to software like VirtualBox or VMware Workstation. These are known as “Type 2” or “hosted” hypervisors. (The **hypervisor** is the software, firmware, or hardware that creates and runs virtual machines.) These programs are popular because they’re designed primarily to be easy to use and run under popular OSes like Windows (which is called the **host** OS, since it “hosts” the VMs). However, the fact that Type 2 hypervisors run under the host OS means that they’re really only as secure as the host OS itself. If the host OS is ever compromised, then any VMs it hosts are also effectively compromised.
 
-By contrast, Qubes uses a “Type 1” or “bare-metal” hypervisor called `Xen <https://www.xenproject.org/>`__. Instead of running inside an OS, Type 1 hypervisors run directly on the “bare metal” of the hardware. This means that an attacker must be capable of subverting the hypervisor itself in order to compromise the entire system, which is vastly more difficult.
+By contrast, Qubes uses a “Type 1” or “bare-metal” hypervisor called `Xen <https://xenproject.org/>`__. Instead of running inside an OS, Type 1 hypervisors run directly on the “bare metal” of the hardware. This means that an attacker must be capable of subverting the hypervisor itself in order to compromise the entire system, which is vastly more difficult.
 
 Qubes makes it so that multiple VMs running under a Type 1 hypervisor can be securely used as an integrated OS. For example, it puts all of your application windows on the same desktop with special colored borders indicating the trust levels of their respective VMs. It also allows for things like secure copy/paste operations between VMs, securely copying and transferring files between VMs, and secure networking between VMs and the Internet.
 
@@ -302,7 +302,7 @@ Also see :ref:`introduction/faq:is qubes os free and open-source software?` and 
 Why is the documentation hosted on ReadTheDocs as opposed to the website?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The Qubes OS documentation is written in reStructuredText and hosted on `Read The Docs <https://readsthedocs.com/>`__.
+The Qubes OS documentation is written in reStructuredText and hosted on `Read The Docs <https://about.readthedocs.com/>`__.
 The infrastructure is largely outside of our control. We don’t consider this a problem, however, since we explicitly :ref:`distrust the infrastructure <introduction/faq:what does it mean to "distrust the infrastructure"?>`.
 For this reason, we don’t think that anyone should place undue trust in the live version of this site on the Web.
 Instead, if you want to obtain your own trustworthy copy of the documentation in a secure way,

--- a/introduction/intro.rst
+++ b/introduction/intro.rst
@@ -11,7 +11,7 @@ What is Qubes OS?
 -----------------
 
 Qubes OS is a free and open-source, security-oriented operating system for
-single-user desktop computing. Qubes OS `leverages Xen-based virtualization <https://wiki.xen.org/wiki/Xen_Project_Software_Overview>`__ to allow for the creation and management of isolated compartments called :term:`qubes <qube>`.
+single-user desktop computing. Qubes OS `leverages Xen-based virtualization <https://wiki.xenproject.org/wiki/Xen_Project_Software_Overview>`__ to allow for the creation and management of isolated compartments called :term:`qubes <qube>`.
 
 These qubes, which are implemented as :term:`virtual machines (VMs) <vm>`, have specific:
 
@@ -130,8 +130,8 @@ plug in devices, and install software free from worry. It's a place where
 (See some :doc:`examples of how different types of users organize their qubes </user/how-to-guides/how-to-organize-your-qubes>`.)
 
 Qubes is also powerful. Organizations like the `Freedom of the Press Foundation <https://securedrop.org/news/piloting-securedrop-workstation-qubes-os>`__,
-`Mullvad <https://twitter.com/mullvadnet/status/631010362083643392>`__,
-and `Let's Encrypt <https://twitter.com/letsencrypt/status/1239934557710737410>`__
+`Mullvad <https://x.com/mullvadnet/status/631010362083643392>`__,
+and `Let's Encrypt <https://x.com/letsencrypt/status/1239934557710737410>`__
 rely on Qubes as they build and maintain critical privacy and
 security internet technologies that are in turn relied upon by countless
 users around the world every day. Renowned security `experts <https://qubes-os.org/endorsements/>`__ like Edward Snowden, Daniel J. Bernstein,

--- a/introduction/privacy.rst
+++ b/introduction/privacy.rst
@@ -19,7 +19,7 @@ Obviously, we don’t use any ads or trackers, but this is still a public websit
 Qubes OS documentation
 ----------------------
 
-Qubes OS documentation is hosted on `Read The Docs <https://readsthedocs.com/>`__.
+Qubes OS documentation is hosted on `Read The Docs <https://about.readthedocs.com/>`__.
 We’ve converted all of the :doc:`documentation </index>` from Markdown to reStructuredText. You can enjoy the plain text from the comfort of your terminal. Here’s the `repo <https://github.com/QubesOS/qubes-doc>`__. (By the way, Git tags on our repos are PGP-signed so you can :doc:`verify </project-security/verifying-signatures>` the authenticity of the content.) We omit the ethical ads from RTD, but this is still a public website, so man-in-the-middle attacks and such are always a possibility. Please be careful. Also see :ref:`FAQ: Why is the documentation hosted on ReadTheDocs as opposed to the website? <introduction/faq:why is the documentation hosted on readthedocs as opposed to the website?>`.
 
 Please refer to RTD's `privacy policy <https://docs.readthedocs.com/platform/stable/privacy-policy.html>`__

--- a/introduction/support.rst
+++ b/introduction/support.rst
@@ -185,7 +185,7 @@ Google Groups
 ^^^^^^^^^^^^^
 
 
-While the mailing lists are implemented as Google Group web forums, a Google account is in no way required, expected, or encouraged. Many discussants (including most members of the Qubes team) treat these lists as conventional `mailing lists <https://en.wikipedia.org/wiki/Electronic_mailing_list>`__, interacting with them solely through plain text email with `MUAs <https://en.wikipedia.org/wiki/Email_client>`__ like `Thunderbird <https://www.thunderbird.net/>`__ and `Mutt <https://www.mutt.org/>`__. The Google Groups service is just free infrastructure, and we :ref:`distrust the infrastructure <introduction/faq:what does it mean to "distrust the infrastructure"?>`. This is why, for example, we encourage discussants to use :doc:`Split GPG </user/security-in-qubes/split-gpg>` to sign all of their messages to the lists, but we do not endorse the use of these Google Groups as web forums. For that, we have a separate, dedicated :ref:`introduction/support:forum`.
+While the mailing lists are implemented as Google Group web forums, a Google account is in no way required, expected, or encouraged. Many discussants (including most members of the Qubes team) treat these lists as conventional `mailing lists <https://en.wikipedia.org/wiki/Electronic_mailing_list>`__, interacting with them solely through plain text email with `MUAs <https://en.wikipedia.org/wiki/Email_client>`__ like `Thunderbird <https://www.thunderbird.net/>`__ and `Mutt [HTTP only] <http://www.mutt.org/>`__. The Google Groups service is just free infrastructure, and we :ref:`distrust the infrastructure <introduction/faq:what does it mean to "distrust the infrastructure"?>`. This is why, for example, we encourage discussants to use :doc:`Split GPG </user/security-in-qubes/split-gpg>` to sign all of their messages to the lists, but we do not endorse the use of these Google Groups as web forums. For that, we have a separate, dedicated :ref:`introduction/support:forum`.
 
 Mailing lists
 -------------
@@ -199,7 +199,7 @@ qubes-announce
 
 This is a read-only list for those who wish to receive only very important, infrequent messages. Only the core Qubes team can post to this list. Only `Qubes Security Bulletins (QSBs) <https://www.qubes-os.org/security/qsb/>`__, new stable Qubes OS releases, and Qubes OS release end-of-life notices are announced here.
 
-To subscribe, send a blank email to ``qubes-announce+subscribe@googlegroups.com``. (**Note:** A Google account is **not** required. Any email address will work.) To unsubscribe, send a blank email to ``qubes-announce+unsubscribe@googlegroups.com``. This list also has a `traditional mail archive <https://www.mail-archive.com/qubes-announce@googlegroups.com/>`__ and an optional `Google Groups web interface <https://groups.google.com/group/qubes-announce>`__.
+To subscribe, send a blank email to ``qubes-announce+subscribe@googlegroups.com``. (**Note:** A Google account is **not** required. Any email address will work.) To unsubscribe, send a blank email to ``qubes-announce+unsubscribe@googlegroups.com``. This list also has a `traditional mail archive <https://www.mail-archive.com/qubes-announce@googlegroups.com/>`__ and an optional `Google Groups web interface <https://groups.google.com/g/qubes-announce>`__.
 
 qubes-users
 ^^^^^^^^^^^
@@ -227,7 +227,7 @@ Please try searching both the Qubes website and the archives of the mailing list
 
 
 
-You must be subscribed in order to post to this list. To subscribe, send a blank email to ``qubes-users+subscribe@googlegroups.com``. (**Note:** A Google account is **not** required. Any email address will work.) To post a message to the list, address your email to ``qubes-users@googlegroups.com``. If your post does not appear immediately, please allow time for moderation to occur. To unsubscribe, send a blank email to ``qubes-users+unsubscribe@googlegroups.com``. This list also has a `traditional mail archive <https://www.mail-archive.com/qubes-users@googlegroups.com/>`__ and an optional `Google Groups web interface <https://groups.google.com/group/qubes-users>`__.
+You must be subscribed in order to post to this list. To subscribe, send a blank email to ``qubes-users+subscribe@googlegroups.com``. (**Note:** A Google account is **not** required. Any email address will work.) To post a message to the list, address your email to ``qubes-users@googlegroups.com``. If your post does not appear immediately, please allow time for moderation to occur. To unsubscribe, send a blank email to ``qubes-users+unsubscribe@googlegroups.com``. This list also has a `traditional mail archive <https://www.mail-archive.com/qubes-users@googlegroups.com/>`__ and an optional `Google Groups web interface <https://groups.google.com/g/qubes-users>`__.
 
 qubes-devel
 ^^^^^^^^^^^
@@ -255,7 +255,7 @@ This list is primarily intended for people who are interested in contributing to
 
 
 
-You must be subscribed in order to post to this list. To subscribe, send a blank email to ``qubes-devel+subscribe@googlegroups.com``. (**Note:** A Google account is **not** required. Any email address will work.) To post a message to the list, address your email to ``qubes-devel@googlegroups.com``. If your post does not appear immediately, please allow time for moderation to occur. To unsubscribe, send a blank email to ``qubes-devel+unsubscribe@googlegroups.com``. This list also has a `traditional mail archive <https://www.mail-archive.com/qubes-devel@googlegroups.com/>`__ and an optional `Google Groups web interface <https://groups.google.com/group/qubes-devel>`__.
+You must be subscribed in order to post to this list. To subscribe, send a blank email to ``qubes-devel+subscribe@googlegroups.com``. (**Note:** A Google account is **not** required. Any email address will work.) To post a message to the list, address your email to ``qubes-devel@googlegroups.com``. If your post does not appear immediately, please allow time for moderation to occur. To unsubscribe, send a blank email to ``qubes-devel+unsubscribe@googlegroups.com``. This list also has a `traditional mail archive <https://www.mail-archive.com/qubes-devel@googlegroups.com/>`__ and an optional `Google Groups web interface <https://groups.google.com/g/qubes-devel>`__.
 
 qubes-project
 ^^^^^^^^^^^^^
@@ -275,7 +275,7 @@ Examples of topics or questions suitable for this list include:
 
 
 
-You must be subscribed in order to post to this list. To subscribe, send a blank email to ``qubes-project+subscribe@googlegroups.com``. (**Note:** A Google account is **not** required. Any email address will work.) To post a message to the list, address your email to ``qubes-project@googlegroups.com``. If your post does not appear immediately, please allow time for moderation to occur. To unsubscribe, send a blank email to ``qubes-project+unsubscribe@googlegroups.com``. This list also has a `traditional mail archive <https://www.mail-archive.com/qubes-project@googlegroups.com/>`__ and an optional `Google Groups web interface <https://groups.google.com/group/qubes-project>`__.
+You must be subscribed in order to post to this list. To subscribe, send a blank email to ``qubes-project+subscribe@googlegroups.com``. (**Note:** A Google account is **not** required. Any email address will work.) To post a message to the list, address your email to ``qubes-project@googlegroups.com``. If your post does not appear immediately, please allow time for moderation to occur. To unsubscribe, send a blank email to ``qubes-project+unsubscribe@googlegroups.com``. This list also has a `traditional mail archive <https://www.mail-archive.com/qubes-project@googlegroups.com/>`__ and an optional `Google Groups web interface <https://groups.google.com/g/qubes-project>`__.
 
 qubes-translation
 ^^^^^^^^^^^^^^^^^
@@ -293,7 +293,7 @@ Examples of topics or questions suitable for this list include:
 
 
 
-You must be subscribed in order to post to this list. To subscribe, send a blank email to ``qubes-translation+subscribe@googlegroups.com``. (**Note:** A Google account is **not** required. Any email address will work.) To post a message to the list, address your email to ``qubes-translation@googlegroups.com``. If your post does not appear immediately, please allow time for moderation to occur. To unsubscribe, send a blank email to ``qubes-translation+unsubscribe@googlegroups.com``. This list also has an optional `Google Groups web interface <https://groups.google.com/group/qubes-translation>`__.
+You must be subscribed in order to post to this list. To subscribe, send a blank email to ``qubes-translation+subscribe@googlegroups.com``. (**Note:** A Google account is **not** required. Any email address will work.) To post a message to the list, address your email to ``qubes-translation@googlegroups.com``. If your post does not appear immediately, please allow time for moderation to occur. To unsubscribe, send a blank email to ``qubes-translation+unsubscribe@googlegroups.com``. This list also has an optional `Google Groups web interface <https://groups.google.com/g/qubes-translation>`__.
 
 Forum
 -----
@@ -325,7 +325,7 @@ Social media
 
 The Qubes OS Project has a presence on the following social media platforms:
 
-- `Twitter <https://twitter.com/QubesOS>`__
+- `Twitter <https://x.com/QubesOS>`__
 
 - `Mastodon <https://mastodon.social/@QubesOS>`__
 

--- a/project-security/verifying-signatures.rst
+++ b/project-security/verifying-signatures.rst
@@ -145,9 +145,9 @@ The ``0x`` prefix is sometimes used to indicate that the string following it is 
 
 The general idea of “comparing fingerprints” is to go out into the world (whether digitally, physically, or both) and find other 40-character strings purporting to be the QMSK fingerprint, then compare them to your own purported QMSK fingerprint to ensure that the sequence of alphanumeric characters is exactly the same (again, regardless of spaces or capitalization). If any of the characters do not match or are not in the same order, then at least one of the fingerprints is a forgery. Here are some ideas to get you started:
 
-- Check the fingerprint on various websites (e.g., `mailing lists <https://groups.google.com/g/qubes-devel/c/RqR9WPxICwg/m/kaQwknZPDHkJ>`__, `discussion forums <https://forum.qubes-os.org/t/1441/9>`__, `social <https://twitter.com/rootkovska/status/496976187491876864>`__ `media <https://www.reddit.com/r/Qubes/comments/5bme9n/fingerprint_verification/>`__, `personal websites <https://andrewdavidwong.com/fingerprints.txt>`__).
+- Check the fingerprint on various websites (e.g., `mailing lists <https://groups.google.com/g/qubes-devel/c/RqR9WPxICwg/m/kaQwknZPDHkJ>`__, `discussion forums <https://forum.qubes-os.org/t/1441/9>`__, `social <https://x.com/rootkovska/status/496976187491876864>`__ `media <https://www.reddit.com/r/Qubes/comments/5bme9n/fingerprint_verification/>`__, `personal websites <https://andrewdavidwong.com/fingerprints.txt>`__).
 
-- Check against PDFs, photographs, and videos in which the fingerprint appears (e.g., `slides from a talk <https://hyperelliptic.org/PSC/slides/psc2015_qubesos.pdf>`__, on a `T-shirt <https://twitter.com/legind/status/813847907858337793/photo/2>`__, or in the `recording of a presentation <https://youtu.be/S0TVw7U3MkE?t=2563>`__).
+- Check against PDFs, photographs, and videos in which the fingerprint appears (e.g., `slides from a talk <https://hyperelliptic.org/PSC/slides/psc2015_qubesos.pdf>`__, on a `T-shirt <https://x.com/legind/status/813847907858337793/photo/2>`__, or in the `recording of a presentation <https://youtu.be/S0TVw7U3MkE?t=2563>`__).
 
 - Ask people to post the fingerprint on various mailing lists, forums, and chat rooms.
 

--- a/user/troubleshooting/debian-and-whonix-update-troubleshooting.rst
+++ b/user/troubleshooting/debian-and-whonix-update-troubleshooting.rst
@@ -3,7 +3,7 @@ Updating Debian and Whonix
 ==========================
 
 
-Despite Qubes shipping with :doc:`Debian Templates </user/templates/debian/debian>`, most of Qubes core components run on Fedora and thus our documentation has better coverage for Fedora. However, Qubes has been working closely with the `Whonix <https://whonix.org>`__ project which is based on Debian.
+Despite Qubes shipping with :doc:`Debian Templates </user/templates/debian/debian>`, most of Qubes core components run on Fedora and thus our documentation has better coverage for Fedora. However, Qubes has been working closely with the `Whonix <https://www.whonix.org>`__ project which is based on Debian.
 
 This troubleshooting guide is collection of tips about updating Whonix that also pertain to updating the normal Debian package manager. If you plan to use Debian heavily, **we highly recommend you install the Whonix templates and use them to update your normal Debian template.**
 

--- a/user/troubleshooting/pci-troubleshooting.rst
+++ b/user/troubleshooting/pci-troubleshooting.rst
@@ -25,7 +25,7 @@ PCI Passthrough Issues
 ----------------------
 
 
-Sometimes the PCI arbitrator is too strict, which may cause errors such as ``Unable to reset PCI device`` and other PCI-related errors. There is a way to enable permissive mode for it. See also: `this thread <https://groups.google.com/forum/#!topic/qubes-users/Fs94QAc3vQI>`__ and the Xen wiki’s `PCI passthrough <https://wiki.xen.org/wiki/Xen_PCI_Passthrough>`__ page. Other times, you may instead need to disable the FLR requirement on a device.
+Sometimes the PCI arbitrator is too strict, which may cause errors such as ``Unable to reset PCI device`` and other PCI-related errors. There is a way to enable permissive mode for it. See also: `this thread <https://groups.google.com/forum/#!topic/qubes-users/Fs94QAc3vQI>`__ and the Xen wiki’s `PCI passthrough <https://wiki.xenproject.org/wiki/Xen_PCI_Passthrough>`__ page. Other times, you may instead need to disable the FLR requirement on a device.
 
 Both can be achieved during attachment with ``qvm-pci`` as described :ref:`PCI Devices documentation <user/how-to-guides/how-to-use-pci-devices:additional attach options>`.
 


### PR DESCRIPTION
* remove localhost from checked links
* use Wayback machine for some links
* a link pointing to wiki.qubes-os.org has been removed