### PR TITLE
Autostart troubleshooting: Make clear that kernel options must go on the kernel line.

### DIFF
--- a/user/troubleshooting/autostart-troubleshooting.rst
+++ b/user/troubleshooting/autostart-troubleshooting.rst
@@ -14,7 +14,7 @@ To address this, there is a ``qubes.skip_autostart`` option for the kernel comma
 
 |grub1.png|
 
-Press the ``E`` key on the first prompt (or your custom prompt). Then, press the down arrow key multiple times to reach the line starting with ``module2``.
+Press the ``E`` key on the first prompt (or your custom prompt). Then, press the down arrow key multiple times to reach the line starting with ``module2 /vmlinuz``.
 
 |grub2.png|
 


### PR DESCRIPTION
User on forum was appending to initrd line..

[ edited for broken forum link]
https://forum.qubes-os.org/t/major-qubes-malfunction-pci-device-not-available-wont-boot-on-certain-laptop-backup-vms/40038