### PR TITLE
Filter out issues that have assignee or linked PR

### DIFF
--- a/introduction/contributing.rst
+++ b/introduction/contributing.rst
@@ -55,17 +55,19 @@ Contributing code
 
 If you’re interested in contributing code, the best starting point is to have a look at our `GitHub issues <https://github.com/QubesOS/qubes-issues/issues>`__ to see which tasks are the most urgent. You can filter issues depending on your interest and experience. For example, here are some common issue labels:
 
-- `Help wanted <https://github.com/QubesOS/qubes-issues/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22help%20wanted%22&utf8=%E2%9C%93>`__
+- `Good first issue that nobody is working on yet <https://github.com/qubesos/qubes-issues/issues?q=is%3Aissue%20state%3Aopen%20no%3Aassignee%20-linked%3Apr%20label%3A%22good%20first%20issue%22>`__
 
-- `UX and usability <https://github.com/QubesOS/qubes-issues/issues?q=is%3Aissue%20is%3Aopen%20label%3AUX>`__
+- `Help wanted <https://github.com/qubesos/qubes-issues/issues?q=is%3Aissue%20state%3Aopen%20no%3Aassignee%20-linked%3Apr%20label%3A%22help%20wanted%22>`__
 
-- `Windows tools <https://github.com/QubesOS/qubes-issues/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22C%3A%20windows-tools%22>`__
+- `UX and usability <https://github.com/qubesos/qubes-issues/issues?q=is%3Aissue%20state%3Aopen%20no%3Aassignee%20-linked%3Apr%20label%3Aux>`__
 
-- `Documentation <https://github.com/QubesOS/qubes-issues/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22C%3A%20doc%22>`__
+- `Windows tools <https://github.com/qubesos/qubes-issues/issues?q=is%3Aissue%20state%3Aopen%20no%3Aassignee%20-linked%3Apr%20label%3A%22C%3A%20windows-vm%22%20OR%20label%3A%22C%3A%20windows-tools%22>`__
 
-- `Privacy <https://github.com/QubesOS/qubes-issues/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3A%22privacy%22%20>`__
+- `Documentation <https://github.com/qubesos/qubes-issues/issues?q=is%3Aissue%20state%3Aopen%20no%3Aassignee%20-linked%3Apr%20label%3A%22C%3A%20windows-vm%22%20OR%20label%3A%22C%3A%20windows-tools%22>`__
 
-- `Debian/Ubuntu <https://github.com/QubesOS/qubes-issues/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22C%3A%20Debian%2FUbuntu%22>`__
+- `Privacy <https://github.com/qubesos/qubes-issues/issues?q=is%3Aissue%20state%3Aopen%20no%3Aassignee%20-linked%3Apr%20label%3A%22C%3A%20windows-vm%22%20OR%20label%3A%22C%3A%20windows-tools%22>`__
+
+- `Debian/Ubuntu <https://github.com/qubesos/qubes-issues/issues?q=is%3Aissue%20state%3Aopen%20no%3Aassignee%20-linked%3Apr%20label%3A%22C%3A%20Debian%2FUbuntu%22>`__
 
 
 


### PR DESCRIPTION
New contributors shouldn't spend time on issues somebody else is currently working on.

---

@andrewdavidwong 

I don't think the label `pr submitted` is required anymore, since `linked:pr` exists.

I understand there are some cases of a contributor being assigned, submitting a PR and abandoning it, but for the most part, I think that the filter helps. Let's suppose a PR is abandoned, what can be done to make it appear in the filter again?

- Can't remove linked PR from issue
- Can remove the assignee, but the filter is `no:assignee -linked:pr`, so both conditions needs to match. A bit of a problem as there is a lot of issues [with PR submitted that have no assignee](https://github.com/qubesos/qubes-issues/issues?q=is%3Aissue%20state%3Aopen%20sort%3Aupdated-desc%20linked%3Apr%20no%3Aassignee), and they aren't for the most part, abandoned

I propose that every issue that has `linked:pr` to have an assignee, so that I can make the filter: `no:assignee -linked:pr` become just `no:assignee`, then we drop assignee when the PR is abandoned.