### PR TITLE
Show the link to the onion site on r4.3, not latest

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -149,8 +149,9 @@ html_context = {
     "conf_py_path": "/",
 }
 
-# The onion site only mirrors the content of the documentation built as /en/latest/
-if os.environ.get('READTHEDOCS_LANGUAGE') == 'en' and os.environ.get('READTHEDOCS_VERSION') == 'latest':
+# The onion site mirrors the content of the documentation of the latest stable release
+# This is the default view in RTD
+if os.environ.get('READTHEDOCS_LANGUAGE') == 'en' and os.environ.get('READTHEDOCS_VERSION') == 'r4.3':
     html_context["onion_location"] = "http://doc.qubesosfasa4zl44o4tws22di6kepyzfeqv3tg4e3ztknltfxqrymdad.onion"
 
 # -- -- Options for internationalisation -------------------------------------


### PR DESCRIPTION
The onion site mirrors the content of the documentation of the latest stable release
This is r4.3, the default RTD view
