### PR TITLE
Remove Fedora 42 from supported templates (EOL)

### DIFF
--- a/user/downloading-installing-upgrading/supported-releases.rst
+++ b/user/downloading-installing-upgrading/supported-releases.rst
@@ -120,10 +120,10 @@ It is the responsibility of each distribution to clearly notify its users in adv
      - Fedora
      - Debian
    * - Release 4.2
-     - 42, 43
+     - 43
      - 12, 13
    * - Release 4.3
-     - 42, 43
+     - 43
      - 12, 13
 
 


### PR DESCRIPTION
https://www.qubes-os.org/news/2026/03/13/fedora-42-approaching-end-of-life/