### PR TITLE
Remove gentoo mention in minimal-templates.rst

### DIFF
--- a/user/templates/minimal-templates.rst
+++ b/user/templates/minimal-templates.rst
@@ -32,8 +32,6 @@ Minimal templates of the following distros are available:
 
 - Debian
 
-- Gentoo
-
 
 
 A list of all available templates can also be obtained with the :doc:`Template Manager </developer/system/template-manager>` tool.


### PR DESCRIPTION
There don't seem to be any gentoo templates available anymore.