### PR TITLE
Remove duplicated template versions

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -168,7 +168,6 @@ gettext_uuid = True
 # Define a block of reusable reStructuredText (reST) snippets, warnings etc. that Sphinx automatically appends to every source file before it is parsed
 rst_epilog = """
 .. |debian-codename| replace:: trixie
-.. |debian-version| replace:: 13
 .. |qubes-logo-icon| image:: /attachment/icons/128x128/apps/qubes-logo-icon.png
    :height: 1em
    :class: no-scaled-link

--- a/user/templates/debian/debian.rst
+++ b/user/templates/debian/debian.rst
@@ -3,7 +3,7 @@ Debian templates
 ================
 
 
-The Debian :term:`template` is an officially :ref:`supported <user/downloading-installing-upgrading/supported-releases:templates>` template in Qubes OS. The Current version is Debian |debian-version| (“|debian-codename|”). It is available in 3 versions - ``debian-13-xfce``, the default Debian template with the Xfce desktop environment; ``debian-13``, an alternative Debian template with the GNOME desktop environment; and ``debian-13-minimal``. This page is about the “full” templates. For the minimal version, please see the :doc:`Minimal templates </user/templates/minimal-templates>` page.
+The Debian :term:`template` is an officially :ref:`supported <user/downloading-installing-upgrading/supported-releases:templates>` template in Qubes OS. The current version is listed in the :ref:`Templates section of Supported releases <user/downloading-installing-upgrading/supported-releases:Templates>`. It is available in 3 versions - ``debian-13-xfce``, the default Debian template with the Xfce desktop environment; ``debian-13``, an alternative Debian template with the GNOME desktop environment; and ``debian-13-minimal``. This page is about the “full” templates. For the minimal version, please see the :doc:`Minimal templates </user/templates/minimal-templates>` page.
 
 Installing
 ----------

--- a/user/templates/fedora/fedora.rst
+++ b/user/templates/fedora/fedora.rst
@@ -3,7 +3,7 @@ Fedora templates
 ================
 
 
-The Fedora :doc:`template </user/templates/templates>` is the default template in Qubes OS. The current version is Fedora 42. This page is about the “full” Fedora templates. For the minimal version, please see the :doc:`Minimal templates </user/templates/minimal-templates>` page.
+The Fedora :doc:`template </user/templates/templates>` is the default template in Qubes OS. The current version is listed in the :ref:`Templates section of Supported releases <user/downloading-installing-upgrading/supported-releases:Templates>`. This page is about the “full” Fedora templates. For the minimal version, please see the :doc:`Minimal templates </user/templates/minimal-templates>` page.
 
 Installing
 ----------


### PR DESCRIPTION
The current version of the templates in `user/templates` now refers to the Supported releases page, to avoid forgetting to update it.

The unused `|debian-version|` substitution is removed.