### PR TITLE
admin-api: document target=dom0 for tag-scoped qrexec policy rules

### DIFF
--- a/developer/services/admin-api.rst
+++ b/developer/services/admin-api.rst
@@ -846,6 +846,32 @@ Example device serialization:
 
    1-1.1.1 manufacturer='unknown' self_identity='0000:0000::?******' serial='unknown' ident='1-1.1.1' product='Qubes' vendor='ITL' name='Some untrusted garbage' devclass='bus' backend_domain='vm' interfaces=' ******u03**01' _additional_info='' _date='06.12.23' parent_ident='1-1.1' parent_devclass='None'
 
+Writing qrexec policy for Admin API calls
+=========================================
+
+The default Admin API policy advises adding ``target=dom0`` to every
+allow/ask entry, but does not document the reason.
+
+All ``admin.*`` calls are handled by ``qubesd`` in dom0. When writing qrexec
+policy rules for these calls, a ``@tag:`` selector in the destination column
+must be paired with ``target=dom0``. For example:
+``admin.vm.firewall.Get * source-vm @tag:some-tag allow target=dom0``.
+
+Without ``target=dom0``, the policy matches the rule on the caller-named
+destination VM (validated against the tag constraint) but routes the call to
+that VM rather than to dom0. If the VM is not running, qrexec starts it as
+part of the routing attempt. This is an unintended side effect that occurs
+even with read-only calls such as ``admin.vm.firewall.Get``. The call does
+not succeed, because ``admin.*`` calls are served by ``qubesd`` in dom0, not
+by the target VM.
+
+``target=dom0`` redirects routing to dom0 while preserving the ``@tag:``
+constraint: the call is allowed only when the caller-named VM carries the
+tag, and ``qubesd`` in dom0 handles it. This applies to any ``admin.vm.*``
+method whose destination column in the call table lists ``vm``: properties,
+features, firewall rules, volume information, device enumeration, and similar
+per-VM reads and writes.
+
 General notes
 =============
 

--- a/developer/services/admin-api.rst
+++ b/developer/services/admin-api.rst
@@ -849,28 +849,25 @@ Example device serialization:
 Writing qrexec policy for Admin API calls
 =========================================
 
-The default Admin API policy advises adding ``target=dom0`` to every
-allow/ask entry, but does not document the reason.
+All ``admin.*`` calls are served by ``qubesd`` in dom0, so every allow/ask
+rule for an ``admin.*`` call must specify ``target=dom0``, whatever the
+destination column selects (a VM name, ``@anyvm``, or a ``@tag:`` selector).
+For example::
 
-All ``admin.*`` calls are handled by ``qubesd`` in dom0. When writing qrexec
-policy rules for these calls, a ``@tag:`` selector in the destination column
-must be paired with ``target=dom0``. For example:
-``admin.vm.firewall.Get * source-vm @tag:some-tag allow target=dom0``.
+   admin.vm.firewall.Get * source-vm @tag:some-tag allow target=dom0
 
-Without ``target=dom0``, the policy matches the rule on the caller-named
-destination VM (validated against the tag constraint) but routes the call to
-that VM rather than to dom0. If the VM is not running, qrexec starts it as
-part of the routing attempt. This is an unintended side effect that occurs
-even with read-only calls such as ``admin.vm.firewall.Get``. The call does
-not succeed, because ``admin.*`` calls are served by ``qubesd`` in dom0, not
-by the target VM.
+Without ``target=dom0``, the rule still matches on the caller-named
+destination VM (validated against the destination selector) but routes the
+call to that VM rather than to dom0. If the VM is not running, qrexec starts
+it as part of the routing attempt. This is an unintended side effect that
+occurs even for read-only calls such as ``admin.vm.firewall.Get``. The call
+does not succeed, because ``admin.*`` calls are served by ``qubesd`` in dom0,
+not by the target VM.
 
-``target=dom0`` redirects routing to dom0 while preserving the ``@tag:``
-constraint: the call is allowed only when the caller-named VM carries the
-tag, and ``qubesd`` in dom0 handles it. This applies to any ``admin.vm.*``
-method whose destination column in the call table lists ``vm``: properties,
-features, firewall rules, volume information, device enumeration, and similar
-per-VM reads and writes.
+``target=dom0`` redirects routing to dom0 while preserving the destination
+constraint: the call is allowed only when the caller-named VM matches, and
+``qubesd`` in dom0 handles it. This applies to any ``admin.vm.*`` method
+whose destination column in the call table lists ``vm``.
 
 General notes
 =============


### PR DESCRIPTION
`admin.*` calls are handled by `qubesd` in dom0. When a qrexec policy rule uses a `@tag:` selector to scope which VMs a caller may act on, omitting `target=dom0` routes the call to the tagged VM instead of dom0 — starting that VM in the process, even for read-only calls such as `admin.vm.firewall.Get` — and the call then fails, because `admin.*` is served by `qubesd` in dom0, not the target VM.

The default Admin API policy header already reminds maintainers to add `target=dom0` to allow/ask entries, but doesn't explain why, or what happens if it's omitted. This adds a short "Writing qrexec policy for Admin API calls" section that:

- describes the side effect (the tagged VM is started; the call fails)
- gives the correct pattern with `target=dom0`
- notes it applies to any `admin.vm.*` method whose destination is `vm`

Found while writing tag-scoped Admin API policies for an MCP-server isolation project (qubes-mcp); raised on qubes-devel: https://groups.google.com/g/qubes-devel/c/4NuSqL64DVE