### PR TITLE
Remove Debian 12 from supported releases (EOL)

### DIFF
--- a/user/downloading-installing-upgrading/supported-releases.rst
+++ b/user/downloading-installing-upgrading/supported-releases.rst
@@ -121,10 +121,10 @@ It is the responsibility of each distribution to clearly notify its users in adv
      - Debian
    * - Release 4.2
      - 43
-     - 12, 13
+     - 13
    * - Release 4.3
      - 43
-     - 12, 13
+     - 13
 
 
 Note on Debian support


### PR DESCRIPTION
https://www.qubes-os.org/news/2026/05/06/debian-12-bookworm-approaching-end-of-life/