### PR TITLE
Replace gnome-terminal with Xfce Terminal

### DIFF
--- a/user/how-to-guides/how-to-install-software.rst
+++ b/user/how-to-guides/how-to-install-software.rst
@@ -16,7 +16,7 @@ Installing software from default repositories
 
 1. Start the template.
 
-2. Start either a terminal (e.g. ``gnome-terminal``) or a dedicated software management application, such as ``gpk-application``.
+2. Start either a terminal (e.g. ``Xfce Terminal``) or a dedicated software management application, such as ``gpk-application``.
 
 3. Install software as normally instructed inside that operating system, e.g.:
 


### PR DESCRIPTION
As Xfce templates are now default, it may be best to use it as example.