### PR TITLE
Add link to raw HCL data to the HCL documentation

### DIFF
--- a/user/hardware/how-to-use-the-hcl.rst
+++ b/user/hardware/how-to-use-the-hcl.rst
@@ -5,7 +5,11 @@ How to use the hardware compatibility list (HCL)
 
 The `HCL <https://www.qubes-os.org/hcl/>`__ is a compilation of reports generated and submitted by users across various Qubes versions about their hardware’s compatibility with Qubes.
 
-**Note:** Except in the case of developer-reported entries, the Qubes team has not independently verified the accuracy of these reports. Please first consult the data sheets (CPU, chipset, motherboard) prior to buying new hardware for Qubes. Make sure it meets the :doc:`System Requirements </user/hardware/system-requirements>` and search in particular for support of:
+.. hint::
+Raw HCL data is available here: https://github.com/QubesOS/qubes-hcl
+
+.. note::
+Except in the case of developer-reported entries, the Qubes team has not independently verified the accuracy of these reports. Please first consult the data sheets (CPU, chipset, motherboard) prior to buying new hardware for Qubes. Make sure it meets the :doc:`System Requirements </user/hardware/system-requirements>` and search in particular for support of:
 
 - HVM (“AMD virtualization (AMD-V)”, “Intel virtualization (VT-x)”, “VIA virtualization (VIA VT)”)
 
@@ -35,4 +39,5 @@ You are encouraged to submit your HCL report for the benefit of further Qubes de
 
 Please include any useful information about any Qubes features you may have tested (see the legend below), as well as general machine compatibility (video, networking, sleep, etc.). Please consider sending the **HCL Support Files** ``.cpio.gz`` file as well. To generate these add the ``-s`` or ``--support`` command line option.
 
-**Please note:** The **HCL Support Files** may contain numerous hardware details, including serial numbers. If, for privacy or security reasons, you do not wish to make this information public, please **do not** post the ``.cpio.gz`` file on a public mailing list or forum.
+.. warning::
+The **HCL Support Files** may contain numerous hardware details, including serial numbers. If, for privacy or security reasons, you do not wish to make this information public, please **do not** post the ``.cpio.gz`` file on a public mailing list or forum.

--- a/user/hardware/how-to-use-the-hcl.rst
+++ b/user/hardware/how-to-use-the-hcl.rst
@@ -6,7 +6,7 @@ How to use the hardware compatibility list (HCL)
 The `HCL <https://www.qubes-os.org/hcl/>`__ is a compilation of reports generated and submitted by users across various Qubes versions about their hardware’s compatibility with Qubes.
 
 .. hint::
-  Raw HCL data is available here: https://github.com/QubesOS/qubes-hcl
+  Raw HCL data is available on `github <https://github.com/QubesOS/qubes-hcl>`__
 
 .. note::
   Except in the case of developer-reported entries, the Qubes team has not independently verified the accuracy of these reports. Please first consult the data sheets (CPU, chipset, motherboard) prior to buying new hardware for Qubes. Make sure it meets the :doc:`System Requirements </user/hardware/system-requirements>` and search in particular for support of:

--- a/user/hardware/how-to-use-the-hcl.rst
+++ b/user/hardware/how-to-use-the-hcl.rst
@@ -6,10 +6,10 @@ How to use the hardware compatibility list (HCL)
 The `HCL <https://www.qubes-os.org/hcl/>`__ is a compilation of reports generated and submitted by users across various Qubes versions about their hardware’s compatibility with Qubes.
 
 .. hint::
-Raw HCL data is available here: https://github.com/QubesOS/qubes-hcl
+  Raw HCL data is available here: https://github.com/QubesOS/qubes-hcl
 
 .. note::
-Except in the case of developer-reported entries, the Qubes team has not independently verified the accuracy of these reports. Please first consult the data sheets (CPU, chipset, motherboard) prior to buying new hardware for Qubes. Make sure it meets the :doc:`System Requirements </user/hardware/system-requirements>` and search in particular for support of:
+  Except in the case of developer-reported entries, the Qubes team has not independently verified the accuracy of these reports. Please first consult the data sheets (CPU, chipset, motherboard) prior to buying new hardware for Qubes. Make sure it meets the :doc:`System Requirements </user/hardware/system-requirements>` and search in particular for support of:
 
 - HVM (“AMD virtualization (AMD-V)”, “Intel virtualization (VT-x)”, “VIA virtualization (VIA VT)”)
 
@@ -40,4 +40,4 @@ You are encouraged to submit your HCL report for the benefit of further Qubes de
 Please include any useful information about any Qubes features you may have tested (see the legend below), as well as general machine compatibility (video, networking, sleep, etc.). Please consider sending the **HCL Support Files** ``.cpio.gz`` file as well. To generate these add the ``-s`` or ``--support`` command line option.
 
 .. warning::
-The **HCL Support Files** may contain numerous hardware details, including serial numbers. If, for privacy or security reasons, you do not wish to make this information public, please **do not** post the ``.cpio.gz`` file on a public mailing list or forum.
+  The **HCL Support Files** may contain numerous hardware details, including serial numbers. If, for privacy or security reasons, you do not wish to make this information public, please **do not** post the ``.cpio.gz`` file on a public mailing list or forum.


### PR DESCRIPTION
The website is long and unwieldy. Users could benefit from a link to the raw data. Inspired by this forum post:

https://forum.qubes-os.org/t/feedback-on-documentation-hcl/42321

More specifically:

> Make it possible to filter away entries based on criterias, e.g. tested Qubes version, release year, brand name

Link to raw data might nudge people to process the data the way they want. Who knows, maybe somebody clobbers together some tools and uploads them.

Advertising raw data also helps with accessibility, see https://github.com/QubesOS/qubes-issues/issues/8190

I've updated note and warning directives while at it.