### PR TITLE
Ease the use of intersphinx: use local inventories and remove prefixes

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -140,7 +140,7 @@ if os.environ.get("QUBES_DOC_LOCAL_INTERSPHINX", "").lower() in ("true", "on", "
     for repo, (target, inventory) in intersphinx_mapping.items():
         intersphinx_mapping[repo] = (local_pattern.format(repo), inventory)
 
-intersphinx_disabled_reftypes = ["*"]
+intersphinx_disabled_reftypes = []
 
 # Open Graph image for social media sharing
 ogp_image = "https://www.qubes-os.org/attachment/icons/qubes-logo-icon-name-slogan-fb.png"

--- a/conf.py
+++ b/conf.py
@@ -132,6 +132,14 @@ intersphinx_mapping = {
     'core-admin-client': ('https://dev.qubes-os.org/projects/core-admin-client/en/latest/', None),
     'core-qrexec': ('https://dev.qubes-os.org/projects/qubes-core-qrexec/en/stable/', None),
 }
+
+if os.environ.get("QUBES_DOC_LOCAL_INTERSPHINX", "").lower() in ("true", "on", "1"):
+    local_pattern = os.environ.get(
+        "QUBES_DOC_LOCAL_INTERSPHINX_PATTERN", "../qubes-{}/doc/_build/html"
+    )
+    for repo, (target, inventory) in intersphinx_mapping.items():
+        intersphinx_mapping[repo] = (local_pattern.format(repo), inventory)
+
 intersphinx_disabled_reftypes = ["*"]
 
 # Open Graph image for social media sharing


### PR DESCRIPTION
* **Add a way to look for local intersphinx inventory**
  
  When editing references between qubes-doc and qubes-core-* projects, it's better to use inventory from local builds.

* **Allow intersphinx references without prefixes**
  
  We only use qubes projects, so it removes the need to prefix cross-references.

**TODO:** document environment variables