### PR TITLE
Update references to qvm-service and qvm-features

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -132,7 +132,7 @@ intersphinx_mapping = {
     'core-admin-client': ('https://dev.qubes-os.org/projects/core-admin-client/en/latest/', None),
     'core-qrexec': ('https://dev.qubes-os.org/projects/qubes-core-qrexec/en/stable/', None),
 }
-intersphinx_disabled_reftypes = ["*"]
+intersphinx_disabled_reftypes = []
 
 # Open Graph image for social media sharing
 ogp_image = "https://www.qubes-os.org/attachment/icons/qubes-logo-icon-name-slogan-fb.png"

--- a/developer/debugging/vm-interface.rst
+++ b/developer/debugging/vm-interface.rst
@@ -79,7 +79,7 @@ Firewall rules in 3.x
 
 QubesDB is also used to configure the firewall in ProxyVMs. Rules are stored in separate keys for each target VM. Entries:
 
-- ``/qubes-iptables`` - control entry - dom0 writing ``reload`` here signals the ``qubes-firewall`` service to reload rules
+- ``/qubes-iptables`` - control entry - dom0 writing ``reload`` here signals the :option:`qubes-firewall <qvm-service qubes-firewall>` service to reload rules
 
 - ``/qubes-iptables-header`` - rules not related to any particular VM, should be applied before domain rules
 
@@ -285,7 +285,7 @@ Currently, Qubes still calls a few tools in VM directly, not using the service a
 
 - ``gpk-update-viewer`` - called by Qubes Manager to display available updates in a TemplateVM
 
-- ``systemctl start qubes-update-check.timer`` (and similarly stop) - called when enabling/disabling update checking in a given VM (``qubes-update-check`` :doc:`qvm-service </user/advanced-topics/qubes-service>`)
+- ``systemctl start qubes-update-check.timer`` (and similarly stop) - called when enabling/disabling update checking in a given VM (:option:`qubes-update-check <qvm-service qubes-update-check>` :doc:`qvm-service </user/advanced-topics/qubes-service>`)
 
 
 

--- a/developer/releases/4_3/release-notes.rst
+++ b/developer/releases/4_3/release-notes.rst
@@ -104,7 +104,7 @@ UI/UX
 - Centralized Tray Notifications
   (`#889 <https://github.com/QubesOS/qubes-issues/issues/889>`__).
 
-- Options to launch root terminal or `console terminal <https://dev.qubes-os.org/projects/core-admin-client/en/latest/manpages/qvm-features.html#expert-mode>`__ from :program:`Qubes Domains widget` (`#9788 <https://github.com/QubesOS/qubes-issues/issues/9788>`__).
+- Options to launch root terminal or :option:`console terminal <qvm-features expert-mode>` from :program:`Qubes Domains widget` (`#9788 <https://github.com/QubesOS/qubes-issues/issues/9788>`__).
 
   Holding the shift key changes the :guilabel:`Run Terminal` command into a :guilabel:`Run Root Terminal` action.
 
@@ -182,14 +182,14 @@ Security features
 - Preventing unsafe practice of 3rd party template installation with rpm/dnf
   (`#9943 <https://github.com/QubesOS/qubes-issues/issues/9943>`__).
 
-- Ability to `prohibit start <https://dev.qubes-os.org/projects/core-admin-client/en/latest/manpages/qvm-features.html#prohibit-start>`__ of specific qubes
+- Ability to :option:`prohibit start <qvm-features prohibit-start>` of specific qubes
   (`#9622 <https://github.com/QubesOS/qubes-issues/issues/9622>`__).
 
 - UUID support for qubes and support for addressing them by UUID in policies
   (`#8862 <https://github.com/QubesOS/qubes-issues/issues/8862>`__ &
   `#8510 <https://github.com/QubesOS/qubes-issues/issues/8510>`__).
 
-- `Custom persist feature <https://dev.qubes-os.org/projects/core-admin-client/en/latest/manpages/qvm-features.html#custom-persist>`__ to avoid unwanted data to persist as much as possible
+- :option:`Custom persist feature <qvm-features custom-persist.*>` to avoid unwanted data to persist as much as possible
   (`#1006 <https://github.com/QubesOS/qubes-issues/issues/1006>`__).
 
 Anonymity improvements
@@ -276,7 +276,7 @@ Other
 - Automatically clean up `QubesIncoming` directory if empty
   (`#8307 <https://github.com/QubesOS/qubes-issues/issues/8307>`__).
 
-- `vm-config.* <https://dev.qubes-os.org/projects/core-admin-client/en/latest/manpages/qvm-features.html#vm-config>`__ features to pass external configuration to inside the qube (`#9837 <https://github.com/QubesOS/qubes-issues/issues/9837>`__).
+- :option:`vm-config.* <qvm-features vm-config.*>` features to pass external configuration to inside the qube (`#9837 <https://github.com/QubesOS/qubes-issues/issues/9837>`__).
 
 - Admin API for reading/writing denied device-interface list
   (`#9674 <https://github.com/QubesOS/qubes-issues/issues/9674>`__).

--- a/developer/releases/4_3/release-notes.rst
+++ b/developer/releases/4_3/release-notes.rst
@@ -33,7 +33,7 @@ Major features and improvements since Qubes 4.2
 - Device “self-identity oriented” assignment (a.k.a New Devices API)
   (`#9325 <https://github.com/QubesOS/qubes-issues/issues/9325>`__).
 
-  **See:** :option:`core-admin-client:qvm-device --assignments`, ``qvm-device assign`` and ``qvm-device unassign``
+  **See:** :option:`qvm-device --assignments`, :doc:`qvm-device assign <manpages/qvm-device>` and :doc:`qvm-device unassign <manpages/qvm-device>`
 
 - :doc:`/user/templates/windows/qubes-windows-tools` reintroduction with improved features
   (`#1861 <https://github.com/QubesOS/qubes-issues/issues/1861>`__).
@@ -219,7 +219,7 @@ Performance optimizations
   (`#9362 <https://github.com/QubesOS/qubes-issues/issues/9362>`__).
 
 - Minimal state qubes to make NetVM and USBVM to consume as little RAM as
-  possible.
+  possible, see: :option:`qvm-service minimal-netvm` and :option:`qvm-service minimal-usbvm`
 
 Updating & upgrading
 --------------------

--- a/user/advanced-topics/bind-dirs.rst
+++ b/user/advanced-topics/bind-dirs.rst
@@ -87,7 +87,7 @@ Other Configuration Folders
 
 - ``/etc/qubes-bind-dirs.d`` (intermediate priority, for template wide configuration)
 
-- ``/rw/config/qubes-bind-dirs.d`` (highest priority, for per VM configuration)
+- ``/rw/config/qubes-bind-dirs.d`` (highest priority, for per qube configuration)
 
 
 
@@ -133,11 +133,13 @@ How to remove binds from bind-dirs.sh?
 
 (Editing ``/usr/lib/qubes-bind-dirs.d/40_qubes-whonix.conf`` directly is strongly discouraged, since such changes get lost when that file is changed in the package on upgrades.)
 
+.. _custom-persist:
+
 Custom persist feature
 ----------------------
 
 
-Custom persist is an optional advanced feature allowing the creation of minimal state AppVM. The purpose of such an AppVM is to avoid unwanted data to persist as much as possible by disabling the ability to configure persistence from the VM itself. When enabled, the following happens:
+Custom persist is an optional advanced feature allowing the creation of minimal state qube. The purpose of such an qube is to avoid unwanted data to persist as much as possible by disabling the ability to configure persistence from the qube itself. When enabled, the following happens:
 
 - ``/rw/config/rc.local`` is no longer executed
 
@@ -151,41 +153,36 @@ Custom persist is an optional advanced feature allowing the creation of minimal 
 
 
 
-Bind dirs are obviously still supported but this must be configured either in the template (``/usr/lib/qubes-bind-dirs.d`` and ``/etc/qubes-bind-dirs.d``) or from dom0 using ``qvm-features``. The bind dirs declaration must be done this way: ``qvm-features <VMNAME> custom-persist.<ARBITRARY NAME> [PRE-CREATION SETTINGS]<PATH>``
+Bind dirs are obviously still supported but this must be configured either in the template (``/usr/lib/qubes-bind-dirs.d`` and ``/etc/qubes-bind-dirs.d``) or from dom0 using :doc:`manpages/qvm-features`. The bind dirs declaration must be done with this kind of feature: :option:`qvm-features custom-persist.{FEATURE_NAME} <qvm-features custom-persist.*>` (where :samp:`FEATURE_NAME` is an arbitrary name). The value should be formatted like this: :samp:`[PRE-CREATION SETTINGS:]<PATH>` (where :samp:`[PRE-CREATION-SETTINGS:]` is optional and :samp:`<PATH>` is an absolute path.
 
-To use this feature, first, enable it:
+To use this feature:
 
-.. code:: console
+1. :doc:`enable the service </user/how-to-guides/how-to-enable-a-service>` called :option:`custom-persist <qvm-service custom-persist>`.
 
-      $ qvm-service -e my-app-vm custom-persist
+2. Then, configure a persistent directory with :doc:`qvm-features <manpages/qvm-features>` in the :term:`admin qube`:
 
+   .. code:: console
 
+         [user@dom0] $ qvm-features QUBE_NAME custom-persist.FEATURE_NAME PATH
 
-Then, configure a persistent directory with ``qvm-features``:
+   Where :samp:`FEATURE_NAME` is an arbitrary name and :samp:`PATH` is an absolute path.
 
-.. code:: console
-
-      $ qvm-features my-app-vm custom-persist.my_persistent_dir /var/my_persistent_dir
-
-
-
-To re-enable ``/home`` and ``/usr/local`` persistence, just add them to the list:
+Nothing will be persistent except :samp:`PATH`. To re-enable ``/home`` and ``/usr/local`` persistence, just add them to the list:
 
 .. code:: console
 
-      $ qvm-features my-app-vm custom-persist.home /home
-      $ qvm-features my-app-vm custom-persist.usrlocal /usr/local
+      [user@dom0] $ qvm-features QUBE_NAME custom-persist.home /home
+      [user@dom0] $ qvm-features QUBE_NAME custom-persist.usrlocal /usr/local
 
-
-
-When starting the VM, declared custom-persist bind dirs are automatically added to the ``binds`` variable described above and are handled in the same way.
+When starting the qube, declared custom-persist bind dirs are automatically added to the ``binds`` variable described above and are handled in the same way.
 
 A user may want their bind-dirs to be automatically pre-created in ``/rw/bind-dirs``. Custom persist can do this for you by providing the type of the resource to create (file or dir), owner, group and mode. For example:
 
 .. code:: console
 
-      $ qvm-features my-app-vm custom-persist.downloads dir:user:user:0755:/home/user/Downloads
-      $ qvm-features my-app-vm custom-persist.my_ssh_known_hosts_file file:user:user:0600:/home/user/.ssh/known_hosts
+      [user@dom0] $ qvm-features QUBE_NAME custom-persist.downloads dir:user:user:0755:/home/user/Downloads
+
+Will automatically create a :file:`/home/user/Downloads` directory owned by `user` with the `0755` mode
 
 
 

--- a/user/advanced-topics/config-files.rst
+++ b/user/advanced-topics/config-files.rst
@@ -35,7 +35,7 @@ These files are placed in ``/rw``, which survives a VM restart. That way, they c
 
 - ``/rw/config/qubes-ip-change-hook`` - script runs in NetVM after every external IP change and on “hardware” link status change.
 
-- In ProxyVMs (or app qubes with ``qubes-firewall`` service enabled), scripts placed in the following directories will be executed in the listed order followed by ``qubes-firewall-user-script`` at start up. Good place to write custom firewall rules.
+- In ProxyVMs (or app qubes with :option:`qubes-firewall <qvm-service qubes-firewall>` service enabled), scripts placed in the following directories will be executed in the listed order followed by ``qubes-firewall-user-script`` at start up. Good place to write custom firewall rules.
 
   .. code:: text
 

--- a/user/advanced-topics/disposable-customization.rst
+++ b/user/advanced-topics/disposable-customization.rst
@@ -104,7 +104,7 @@ For instance, to have Mozilla Thunderbird application open all attachments in a 
 
       qvm-appmenus --get-available --i-understand-format-is-unstable <QUBE> | grep -i thunderbird
 
-In the current case, we identified the application ID to be ``net.thunderbird.Thunderbird`` (in your case it may as well be ``thunderbird``). Finally, enable the ``app-dispvm.net.thunderbird.Thunderbird`` service via the :ref:`qube settings <how-to-enable-a-service-in-the-settings>`.
+In the current case, we identified the application ID to be ``net.thunderbird.Thunderbird`` (in your case it may as well be ``thunderbird``). Finally, enable the :option:`app-dispvm.net.thunderbird.Thunderbird <qvm-features app-dispvm.*>` service via the :ref:`qube settings <how-to-enable-a-service-in-the-settings>`.
 
 .. warning:: This feature is currently somewhat experimental, and only works for Linux qubes. It is known to work with Thunderbird and Wire, but it may fail to work with some applications that do not honor all XDG environment variables. If the feature does not work for you, please file a bug report.
 
@@ -239,7 +239,7 @@ You can also use the command line equivalent:
       user@dom0:~$ qvm-prefs <DISPOSABLE_TEMPLATE> template_for_dispvms True
       user@dom0:~$ qvm-features <DISPOSABLE_TEMPLATE> appmenus-dispvm 1
 
-The ``appmenus-dispvm`` feature is only necessary if you intend to launch disposables derived from this disposable template via graphical applications. When enabled, new entries will be available for each application in |qubes-logo-icon|:menuselection:`Qubes App Menu (Q icon) --> APPS --> <DISPOSABLE_TEMPLATE> --> <APPLICATION> --> New disposable qube from <DISPOSABLE_TEMPLATE>` while disposable qube desktop entries will have ``(dvm)`` string inserted. Clicking on this entry will launch the application in a new disposable based on the disposable template (not in the disposable template itself).
+The :option:`appmenus-dispvm <qvm-features appmenus-dispvm>` feature is only necessary if you intend to launch disposables derived from this disposable template via graphical applications. When enabled, new entries will be available for each application in |qubes-logo-icon|:menuselection:`Qubes App Menu (Q icon) --> APPS --> <DISPOSABLE_TEMPLATE> --> <APPLICATION> --> New disposable qube from <DISPOSABLE_TEMPLATE>` while disposable qube desktop entries will have ``(dvm)`` string inserted. Clicking on this entry will launch the application in a new disposable based on the disposable template (not in the disposable template itself).
 
 .. important:: Application shortcuts that existed before setting this feature will not be updated automatically. Please go to |qubes-logo-icon|:menuselection:`Qubes App Menu (Q icon) --> APPS --> <DISPOSABLE_TEMPLATE> --> Settings`, in the :guilabel:`Applications` tab, unselect all existing shortcuts by clicking :guilabel:`<<`, then click :guilabel:`&OK` and close the dialog. Give it a few seconds and then reopen and re-select all the shortcuts you want to see in the menu. See :doc:`app menu shortcut troubleshooting </user/troubleshooting/app-menu-shortcut-troubleshooting>` for background information.
 

--- a/user/advanced-topics/qubes-service.rst
+++ b/user/advanced-topics/qubes-service.rst
@@ -6,7 +6,7 @@ Qubes service
 
       This page is intended for advanced users.
 
-Usage documentation is in the ``qvm-service`` man page. There are also described predefined services.
+Usage documentation is in the :doc:`qvm-service <manpages/qvm-service>` man page. There are also described predefined services.
 
 Under the hood, an enabled service in a VM is signaled by a file in ``/var/run/qubes-service``. This can be used to implement an almost enable/disable **per-VM** switch controlled by dom0.
 
@@ -19,4 +19,4 @@ Adding support for systemd services is pretty simple. In the VM, create the foll
 
 
 
-This will cause the service to be started only when you enable it with ``qvm-service`` for this VM.
+This will cause the service to be started only when you enable it with :doc:`qvm-service <manpages/qvm-service>` for this VM.

--- a/user/advanced-topics/salt.rst
+++ b/user/advanced-topics/salt.rst
@@ -584,9 +584,9 @@ Additional pillar data is available to ease targeting configurations (for exampl
 
 Features the qube has. Only some values are included:
 
-- ``service.*`` - services enabled or disabled in the qube
+- :option:`service.* <qvm-features service.*>` - services enabled or disabled in the qube
 
-- ``vm-config.*`` - features also exposed to qubesdb
+- :option:`vm-config.* <qvm-features vm-config.*>` - features also exposed to qubesdb
 
 
 

--- a/user/downloading-installing-upgrading/upgrade/4_3.rst
+++ b/user/downloading-installing-upgrading/upgrade/4_3.rst
@@ -112,7 +112,7 @@ The upgrade consists of **six stages** available in two phase:
       - resync applications and features
       - create LVM devices cache
       - update PCI device IDs
-      - enable minimal-netvm / minimal-usbvm services
+      - enable :option:`minimal-netvm <qvm-service minimal-netvm>` / :option:`minimal-usbvm <qvm-service minimal-usbvm>` services
       - cleanup salt states
       - enable preloaded disposables if system has more than 16GB memory
 

--- a/user/how-to-guides/how-to-edit-a-policy.rst
+++ b/user/how-to-guides/how-to-edit-a-policy.rst
@@ -82,4 +82,4 @@ See also
 --------
 
 * :doc:`/developer/services/qrexec`
-* `qubes-core-qrexec's documentation <https://dev.qubes-os.org/projects/qubes-core-qrexec/en/latest/>`__
+* :doc:`core-qrexec:index`

--- a/user/how-to-guides/how-to-enable-a-service.rst
+++ b/user/how-to-guides/how-to-enable-a-service.rst
@@ -5,7 +5,7 @@ How to enable a qube service
 To enable a :doc:`service </user/advanced-topics/qubes-service>` in a qube there are two options:
 
 * Use the :program:`Settings` of the qube
-* Use `qvm-service <https://dev.qubes-os.org/projects/core-admin-client/en/latest/manpages/qvm-service.html>`__
+* Use :doc:`qvm-service <manpages/qvm-service>`
 
 You might have to restart the qube for changes to be reflected.
 

--- a/user/how-to-guides/how-to-install-software.rst
+++ b/user/how-to-guides/how-to-install-software.rst
@@ -255,11 +255,11 @@ Updates proxy is a service which allows access from package managers configured 
 
 The proxy is running in selected VMs (by default all the NetVMs (1)) and intercepts traffic directed to 127.0.0.1:8082. Thanks to such configuration all the VMs can use the same proxy address. If the VM is configured to have access to the updates proxy (2), the startup scripts will automatically configure dnf/apt to really use the proxy (3). Also access to updates proxy is independent of any other firewall settings (VM will have access to updates proxy, even if policy is set to block all the traffic).
 
-There are two services (``qvm-service``, :doc:`service framework </user/advanced-topics/qubes-service>`):
+There are two services (:doc:`core-admin-client:manpages/qvm-service`, :doc:`service framework </user/advanced-topics/qubes-service>`):
 
-1. ``qubes-updates-proxy`` (and its deprecated name: ``qubes-yum-proxy``) - a service providing a proxy for templates - by default enabled in NetVMs (especially: sys-net)
+1. :option:`qubes-updates-proxy <core-admin-client:qvm-service qubes-updates-proxy>` (and its deprecated name: :option:`qubes-yum-proxy <core-admin-client:qvm-service qubes-yum-proxy>`) - a service providing a proxy for templates - by default enabled in NetVMs (especially: sys-net)
 
-2. ``updates-proxy-setup`` (and its deprecated name: ``yum-proxy-setup``) - use a proxy provided by another VM (instead of downloading updates directly), enabled by default in all templates
+2. :option:`updates-proxy-setup <core-admin-client:qvm-service updates-proxy-setup>` (and its deprecated name: :option:`yum-proxy-setup <core-admin-client:qvm-service yum-proxy-setup>`) - use a proxy provided by another VM (instead of downloading updates directly), enabled by default in all templates
 
 Both the old and new names work. The defaults listed above are applied if the service is not explicitly listed in the services tab.
 

--- a/user/reference/glossary.rst
+++ b/user/reference/glossary.rst
@@ -143,7 +143,7 @@ Qube types and properties
       Any :term:`app qube` with the primary purpose of providing services to other qubes. ``sys-net`` and ``sys-firewall`` are examples of service qubes.
 
    internal qube
-      A qube which has the ``internal`` feature set. Those qubes are hidden from GUI tools such as user menu and have many GUI features disabled. They are used for the :term:`management qube` and preloading disposable qubes. In most cases, internal qubes should not be manipulated by the user directly.
+      A qube which has the :option:`internal <qvm-features internal>` feature set. Those qubes are hidden from GUI tools such as user menu and have many GUI features disabled. They are used for the :term:`management qube` and preloading disposable qubes. In most cases, internal qubes should not be manipulated by the user directly.
 
    interface qube
       An interface qube handles display-related tasks and some system management. There can be more than one interface qube present on the system. Each interface qube can have its own set of privileges, permissions, managed qubes, etc. In the initial install, :term:`dom0` is the only interface qube.

--- a/user/security-in-qubes/firewall.rst
+++ b/user/security-in-qubes/firewall.rst
@@ -78,7 +78,7 @@ The firewall rules for each qube are saved in an XML file in that qube’s direc
 
       /var/lib/qubes/appvms/<vm-name>/firewall.xml
 
-Rules are implemented on the :term:`net qube`: If a rule is set for a qube that uses *sys-firewall* as its net qube, *sys-firewall* will implement the rules. This is done by the `qubes-firewall <https://dev.qubes-os.org/projects/core-admin-client/en/latest/manpages/qvm-service.html#supported-services>`_ service. You can verify that the service is running by executing the following command in the net qube:
+Rules are implemented on the :term:`net qube`: If a rule is set for a qube that uses *sys-firewall* as its net qube, *sys-firewall* will implement the rules. This is done by the :option:`qubes-firewall <qvm-service qubes-firewall>` service. You can verify that the service is running by executing the following command in the net qube:
 
 .. code:: console
 


### PR DESCRIPTION
Now that https://github.com/QubesOS/qubes-core-admin-client/pull/479 is merged, I updated some of the references to `qvm-service` and `qvm-features` tools. I also made some edits to the "Custom persist section" of `bind-dirs.rst`


Cherry-picked from #1732: "Allow intersphinx references without prefixes". We only use qubes projects, so it removes the need to prefix cross-references.
