### PR TITLE
Clarify the name of the doc and current version

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -21,11 +21,11 @@ copyright = f'%Y, {author} and others'
 
 # The major project version, used as the replacement for the |version| default
 # substitution. i.e. '4.3'
-version = 'latest'
+version = 'development'
 
 # The full version, including alpha/beta/rc tags
 # Note: this value is not used in the Qubes OS documentation
-release = version 
+release = version
 
 
 # -- General configuration ---------------------------------------------------
@@ -95,7 +95,7 @@ templates_path = ['_templates']
 
 html_theme = 'sphinx_rtd_theme'
 
-html_title = f'{project} Documentation'
+html_title = f'{project} {release} documentation'
 
 html_theme_options = {
   'style_external_links': True,
@@ -169,13 +169,20 @@ gettext_uuid = True
 # -- -- Options for markup ---------------------------------------------------
 
 # Define a block of reusable reStructuredText (reST) snippets, warnings etc. that Sphinx automatically appends to every source file before it is parsed
-rst_epilog = """
+if os.environ.get('READTHEDOCS_VERSION') == 'development':
+    rst_prolog = """
+.. attention:: This is the documentation of the last **development** version. For most users, the documentation of the `latest supported release <https://doc.qubes-os.org/en/latest/>`__ is more appropriate.
+"""
+
+rst_epilog = f"""
 .. |debian-codename| replace:: trixie
 .. |debian-version| replace:: 13
 .. |qubes-logo-icon| image:: /attachment/icons/128x128/apps/qubes-logo-icon.png
    :height: 1em
    :class: no-scaled-link
    :alt: Qubes logo icon
+
+.. |main-title| replace:: {html_title}
 """
 
 # -- -- Options for the nitpicky mode ----------------------------------------

--- a/index.rst
+++ b/index.rst
@@ -4,9 +4,8 @@
 |main-title|
 ============
 
-=================
 Table of contents
-=================
+-----------------
 
 
 .. _introduction:
@@ -28,9 +27,8 @@ Table of contents
    introduction/privacy
 
 
-==================
 User Documentation
-==================
+^^^^^^^^^^^^^^^^^^
 
 
 Core documentation for Qubes users.
@@ -196,9 +194,8 @@ Core documentation for Qubes users.
    project-security/verifying-signatures
 
 
-=======================
 Developer Documentation
-=======================
+^^^^^^^^^^^^^^^^^^^^^^^
 
 
 Core documentation for Qubes developers and advanced users.
@@ -313,9 +310,8 @@ Core documentation for Qubes developers and advanced users.
    developer/releases/version-scheme
 
 
-======================
 External Documentation
-======================
+^^^^^^^^^^^^^^^^^^^^^^
 
 Unofficial, third-party documentation from the Qubes community and others.
 

--- a/index.rst
+++ b/index.rst
@@ -1,6 +1,8 @@
-=============
-Documentation
-=============
+.. _main-index:
+
+============
+|main-title|
+============
 
 =================
 Table of contents


### PR DESCRIPTION
* Indicate "core documentation" (it's not core-admin or else)
* Use the release name
* Put an admonition on development version if built on Read The Docs
    
Partial fix of: https://github.com/QubesOS/qubes-issues/issues/10263
