### PR TITLE
Exclude GNOME from usability & ux documentation

### DIFF
--- a/developer/general/devel-books.rst
+++ b/developer/general/devel-books.rst
@@ -35,7 +35,7 @@ Below is a list of various books that might be useful in learning some basics ne
 
   - `Programming in Python 3 <https://mark-summerfield.github.io/py3book.html>`__, by Mark Summerfield
 
-  - `Rapid GUI Programming with Python and Qt <https://mark-summerfield.github.io/pyqtbook.html>`__, by Mark Summerfield (Although note that :ref:`Qt is being replaced by GTK <developer/general/usability-ux:kde and xfce>` in Qubes code.)
+  - `Rapid GUI Programming with Python and Qt <https://mark-summerfield.github.io/pyqtbook.html>`__, by Mark Summerfield.
 
 
 

--- a/developer/general/devel-books.rst
+++ b/developer/general/devel-books.rst
@@ -35,7 +35,7 @@ Below is a list of various books that might be useful in learning some basics ne
 
   - `Programming in Python 3 <https://mark-summerfield.github.io/py3book.html>`__, by Mark Summerfield
 
-  - `Rapid GUI Programming with Python and Qt <https://mark-summerfield.github.io/pyqtbook.html>`__, by Mark Summerfield (Although note that :ref:`Qt is being replaced by GTK <developer/general/usability-ux:gnome, kde, and xfce>` in Qubes code.)
+  - `Rapid GUI Programming with Python and Qt <https://mark-summerfield.github.io/pyqtbook.html>`__, by Mark Summerfield (Although note that :ref:`Qt is being replaced by GTK <developer/general/usability-ux:kde and xfce>` in Qubes code.)
 
 
 

--- a/developer/general/usability-ux.rst
+++ b/developer/general/usability-ux.rst
@@ -207,16 +207,12 @@ Clearly, cutting out something as simple as navigating through the file system c
 
 ----
 
-GNOME, KDE, and Xfce
---------------------
+KDE and Xfce
+------------
 
-The desktop GUIs that QubesOS versions 1 - 4.1 offer are `KDE <https://kde.org>`__ and `Xfce <https://xfce.org>`__. We are currently migrating towards using `GNOME <https://www.gnome.org>`__. We know some people prefer KDE, but we believe Gnome is easier to use for average non-technical users. Xfce will always be supported, and technical users will always have the choice to use KDE or other desktop environments.
+The desktop GUIs that QubesOS versions 1 - 4.1 offer are `KDE <https://kde.org>`__ and `Xfce <https://xfce.org>`__. Xfce is the default environment on Qubes OS and will always be supported. Technical users will always have the choice to :doc:`install KDE </user/advanced-topics/kde>` or other desktop environments.
 
-This change means you should use `GTK <https://gtk.org/>`__ rather than Qt for new GUIs.
-
-All three of these mentioned desktop environments have their own `human interface guidelines <https://en.wikipedia.org/wiki/Human_interface_guidelines>`__, and we suggest you familiarize yourself with the platform you developing for.
-
-- `GNOME Human Interface Guidelines <https://developer.gnome.org/hig/>`__
+Both of these desktop environments have their own `human interface guidelines <https://en.wikipedia.org/wiki/Human_interface_guidelines>`__, and we suggest you familiarize yourself with the platform you developing for.
 
 - `KDE HIG <https://hig.kde.org/>`__
 


### PR DESCRIPTION
As far as I can tell Qubes OS team in not considering GNOME as a desktop environment anymore, see https://github.com/QubesOS/qubes-issues/issues/1806

p.s. I asked around and it seems like we prefer Qt over GTK for UI too