### PR TITLE
Add a little FAQ to Split GPG-2 (and 1)

### DIFF
--- a/user/security-in-qubes/split-gpg-2.rst
+++ b/user/security-in-qubes/split-gpg-2.rst
@@ -1,3 +1,5 @@
+.. _split-gpg-2:
+
 ===========
 Split GPG-2
 ===========
@@ -8,7 +10,6 @@ This way the compromise of your less trusted qube does not allow the attacker to
 
 How-to split your GPG keys between two qubes
 --------------------------------------------
-
 The following how-to will set up Split GPG-2 with two qubes:
 
 * one qube holding the private keys, called **server-qube**. This qube is offline and should be trusted.
@@ -225,3 +226,15 @@ It is often thought that the use of smart cards for private key storage guarante
 
 With Qubes Split GPG-2 this problem is drastically minimized, because each time the key is to be used the user is asked for consent (with a definable time out, 5 minutes by default), plus is always notified each time the key is used via a tray notification from the domain where GPG backend is running. This way it would be easy to spot unexpected requests to decrypt documents.
 
+Split GPG-2 frequently asked questions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Do I need to install the package ``split-gpg2-dom0``?
+"""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+**Short answer: no.** ``split-gpg2-dom0`` will only install some python tests for development purposes and a policy file with comments only. You can install it, but it will probably be useless.
+
+I'm using Split GPG-1, do I need to upgrade to Split GPG-2?
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+:ref:`split-gpg-1` is a different implementation. You can use it instead of, or along with, Split GPG-2.

--- a/user/security-in-qubes/split-gpg.rst
+++ b/user/security-in-qubes/split-gpg.rst
@@ -1,6 +1,8 @@
-=========
-Split GPG
-=========
+.. _split-gpg-1:
+
+===========
+Split GPG-1
+===========
 
 .. warning::
       
@@ -395,6 +397,13 @@ Current limitations
 
 - The Split GPG client will fail to sign or encrypt if the private key in the GnuPG backend is protected by a passphrase. It will give an ``Inappropriate ioctl for device`` error. Do not set passphrases for the private keys in the GPG backend domain. Doing so won’t provide any extra security anyway, as explained in the introduction and in :ref:`using-split-gpg-with-subkeys`. If you are generating a new key pair, or if you have a private key that already has a passphrase, you can use ``gpg2 --edit-key <key_id>`` then ``passwd`` to set an empty passphrase. Note that ``pinentry`` might show an error when you try to set an empty passphrase, but it will still make the change. (See `this StackExchange answer <https://unix.stackexchange.com/a/379373>`__ for more information.) **Note:** The error shows only if you **do not** have graphical pinentry installed.
 
+Split GPG-1 frequently asked questions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+I'm using Split GPG-1, do I need to upgrade to Split GPG-2?
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+:ref:`split-gpg-2` is a different implementation. You can use it instead of, or along with, Split GPG-1.
 
 .. [1]
    In order to gain access to the ``vault`` VM, the attacker would require the use of, e.g., a general Xen VM escape exploit or a :ref:`signed, compromised package which is already installed in the template <user/templates/templates:trusting your templates>` upon which the ``vault`` VM is based.


### PR DESCRIPTION
There are some questions that are [frequently asked](https://forum.qubes-os.org/t/anyone-setup-sequoia-pgp/42574/5) in the context of Split GPG-2. That seems irrelevant for the general FAQ, so I put it at the end of the dedicated pages:

* there are a lot of outdated posts and guides suggesting to install `split-gpg2-dom0` which is not required.
* there is a confusion about Split GPG-2 being the new version of Split GPG-1. It's not.